### PR TITLE
Extract :elixir_tokenizer and parse based on running version

### DIFF
--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -131,11 +131,7 @@ defmodule ElixirSense.Core.Source do
   end
 
   def which_func(prefix) do
-    tokens =
-      prefix
-      |> String.to_charlist
-      |> :elixir_tokenizer.tokenize(1, [])
-      |> tokenize_prefix()
+    tokens = ElixirSense.Core.Tokenizer.tokenize(prefix)
 
     pattern = %{npar: 0, count: 0, count2: 0, candidate: [], pos: nil, pipe_before: false}
     result = scan(tokens, pattern)
@@ -147,20 +143,6 @@ defmodule ElixirSense.Core.Source do
       pipe_before: pipe_before,
       pos: pos
     }
-  end
-
-  defp tokenize_prefix({:ok, _, _, tokens}) do
-    tokens |> Enum.reverse
-  end
-
-  # Elixir >= 1.7
-  defp tokenize_prefix({:error, {_line, _column, _error_prefix, _token}, _rest, sofar}) do
-    sofar
-  end
-
-  # Elixir < 1.7
-  defp tokenize_prefix({:error, {_line, _error_prefix, _token}, _rest, sofar}) do
-    sofar
   end
 
   defp normalize_candidate(candidate) do

--- a/lib/elixir_sense/core/tokenizer.ex
+++ b/lib/elixir_sense/core/tokenizer.ex
@@ -1,0 +1,56 @@
+defmodule ElixirSense.Core.Tokenizer do
+  @moduledoc """
+  Handles tokenization of Elixir code snippets
+
+  Uses private api :elixir_tokenizer
+  """
+
+  def tokenize(prefix) do
+    prefix
+    |> String.to_charlist
+    |> do_tokenize(System.version())
+  end
+
+  defp do_tokenize(prefix_charlist, elixir_version) do
+    cond do
+      Version.match?(elixir_version, ">= 1.7.0") ->
+        do_tokenize_1_7(prefix_charlist)
+
+      Version.match?(elixir_version, ">= 1.6.0") ->
+        do_tokenize_1_6(prefix_charlist)
+
+      Version.match?(elixir_version, ">= 1.5.0") ->
+        do_tokenize_1_5(prefix_charlist)
+    end
+  end
+
+  defp do_tokenize_1_7(prefix_charlist) do
+    case :elixir_tokenizer.tokenize(prefix_charlist, 1, []) do
+      {:ok, tokens} ->
+        Enum.reverse(tokens)
+
+      {:error, {_line, _column, _error_prefix, _token}, _rest, sofar} ->
+        sofar
+    end
+  end
+
+  defp do_tokenize_1_6(prefix_charlist) do
+    case :elixir_tokenizer.tokenize(prefix_charlist, 1, []) do
+      {:ok, tokens} ->
+        Enum.reverse(tokens)
+
+      {:error, {_line, _error_prefix, _token}, _rest, sofar} ->
+        sofar
+    end
+  end
+
+  defp do_tokenize_1_5(prefix_charlist) do
+    case :elixir_tokenizer.tokenize(prefix_charlist, 1, []) do
+      {:ok, _, _, tokens} ->
+        Enum.reverse(tokens)
+
+      {:error, {_line, _error_prefix, _token}, _rest, sofar} ->
+        sofar
+    end
+  end
+end

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -4,6 +4,10 @@ defmodule ElixirSense.Core.SourceTest do
   import ElixirSense.Core.Source
 
   describe "which_func/1" do
+    test "at the beginning of a defmodule" do
+      assert which_func("defmo") ==
+        %{candidate: :none, npar: 0, pipe_before: false, pos: nil}
+    end
 
     test "functions without namespace" do
       assert which_func("var = func(") == %{

--- a/test/elixir_sense/core/tokenizer_test.exs
+++ b/test/elixir_sense/core/tokenizer_test.exs
@@ -1,0 +1,51 @@
+defmodule ElixirSense.Core.TokenizerTest do
+  use ExUnit.Case
+
+  alias ElixirSense.Core.Tokenizer
+
+  describe "tokenize/1" do
+    test "functions wihtout namespace" do
+      assert Tokenizer.tokenize("var = func(") ==
+               [
+                 {:"(", {1, 11, nil}},
+                 {:paren_identifier, {1, 7, nil}, :func},
+                 {:match_op, {1, 5, nil}, :=},
+                 {:identifier, {1, 1, nil}, :var}
+               ]
+    end
+
+    test "functions with namespace" do
+      assert Tokenizer.tokenize("var = Mod.func(param1, par") == [
+               {:identifier, {1, 24, nil}, :par},
+               {:",", {1, 22, 0}},
+               {:identifier, {1, 16, nil}, :param1},
+               {:"(", {1, 15, nil}},
+               {:paren_identifier, {1, 11, nil}, :func},
+               {:., {1, 10, nil}},
+               {:alias, {1, 7, nil}, :Mod},
+               {:match_op, {1, 5, nil}, :=},
+               {:identifier, {1, 1, nil}, :var}
+             ]
+
+      assert Tokenizer.tokenize("var = Mod.SubMod.func(param1, param2, par") == [
+               {:identifier, {1, 39, nil}, :par},
+               {:",", {1, 37, 0}},
+               {:identifier, {1, 31, nil}, :param2},
+               {:",", {1, 29, 0}},
+               {:identifier, {1, 23, nil}, :param1},
+               {:"(", {1, 22, nil}},
+               {:paren_identifier, {1, 18, nil}, :func},
+               {:., {1, 17, nil}},
+               {:alias, {1, 11, nil}, :SubMod},
+               {:., {1, 10, nil}},
+               {:alias, {1, 7, nil}, :Mod},
+               {:match_op, {1, 5, nil}, :=},
+               {:identifier, {1, 1, nil}, :var}
+             ]
+    end
+
+    test "at the beginning of a defmodule" do
+      assert Tokenizer.tokenize("defmo") == [{:identifier, {1, 1, nil}, :defmo}]
+    end
+  end
+end


### PR DESCRIPTION
The main fix is that Elixir 1.6.x and on returns a two tuple from `:elixir_tokenizer.tokenize/3` whereas before that it returned a four tuple.

Submitted upstream as: https://github.com/msaraiva/elixir_sense/pull/38