### PR TITLE
Fix travis build reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,19 @@ otp_release:
 
 env:
   EX_HOME: ${TRAVIS_BUILD_DIR}/elixir
-  EX_BIN: ${EX_HOME}/bin
-  ELIXIR: ${EX_BIN}/elixir
-  MIX: ${EX_BIN}/mix
+  EX_BIN: ${TRAVIS_BUILD_DIR}/elixir/bin
   EX_VSN: 1.7.1
 
 before_script:
-  - env
-  - echo ${EX_HOME}
-  - echo ${TRAVIS_BUILD_DIR}
-  - echo $ELIXIR
   - git clone https://github.com/elixir-lang/elixir.git ${EX_HOME}
   - pushd ${EX_HOME}
   - git checkout v${EX_VSN}
   - make
   - popd
-  - ${ELIXIR} ${MIX} local.hex --force
-  - ${ELIXIR} ${MIX} local.rebar --force
+  - ${EX_BIN}/elixir ${EX_BIN}/mix local.hex --force
+  - ${EX_BIN}/elixir ${EX_BIN}/mix local.rebar --force
 
 script:
-  - ${ELIXIR} ${MIX} deps.get
-  - MIX_ENV=test ${ELIXIR} ${MIX} deps.compile
-  - ${ELIXIR} ${MIX} test
+  - ${EX_BIN}/elixir ${EX_BIN}/mix deps.get
+  - MIX_ENV=test ${EX_BIN}/elixir ${EX_BIN}/mix deps.compile
+  - ${EX_BIN}/elixir ${EX_BIN}/mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
   EX_VSN: 1.7.1
 
 before_script:
+  - env
+  - echo ${EX_HOME}
+  - echo ${TRAVIS_BUILD_DIR}
+  - echo $ELIXIR
   - git clone https://github.com/elixir-lang/elixir.git ${EX_HOME}
   - pushd ${EX_HOME}
   - git checkout v${EX_VSN}


### PR DESCRIPTION
Apparently Travis will export the variables in `env` in a random order. Therefore we can't rely on the order and each environment variable needs to stand on its own.

Here's an example run where the environment variables were export "out of order":
https://travis-ci.com/elixir-lsp/elixir_sense/jobs/171597380

```
$ export MIX=${EX_BIN}/mix
$ export ELIXIR=${EX_BIN}/elixir
$ export EX_BIN=${EX_HOME}/bin
$ export EX_VSN=1.7.1
$ export EX_HOME=${TRAVIS_BUILD_DIR}/elixir
```

So because `EX_BIN` was exported after `ELIXIR`, `ELIXIR` was defined as simply `/elixir` which is incorrect. I fixed this by making each environment variable not depend on another.