### PR TITLE
Fix tests for Elixir 1.8.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 21.0.8
-elixir ref:v1.7.1
+elixir ref:v1.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ otp_release:
 env:
   EX_HOME: ${TRAVIS_BUILD_DIR}/elixir
   EX_BIN: ${TRAVIS_BUILD_DIR}/elixir/bin
-  EX_VSN: 1.7.1
+  EX_VSN: 1.8.0
 
 before_script:
   - git clone https://github.com/elixir-lang/elixir.git ${EX_HOME}

--- a/test/elixir_sense/core/introspection_test.exs
+++ b/test/elixir_sense/core/introspection_test.exs
@@ -97,15 +97,19 @@ defmodule ElixirSense.Core.IntrospectionTest do
   end
 
   test "get_returns_from_callback (all types in 'when')" do
-    returns = get_returns_from_callback(:gen_server, :handle_call, 3)
-    assert returns == [
-      %{description: "{:reply, reply, new_state}", snippet: "{:reply, \"${1:reply}$\", \"${2:new_state}$\"}", spec: "{:reply, reply, new_state} when reply: term, new_state: term, reason: term"},
-      %{description: "{:reply, reply, new_state, timeout | :hibernate | {:continue, term}}", snippet: "{:reply, \"${1:reply}$\", \"${2:new_state}$\", \"${3:timeout | :hibernate | {:continue, term}}$\"}", spec: "{:reply, reply, new_state, timeout | :hibernate | {:continue, term}} when reply: term, new_state: term, reason: term"},
-      %{description: "{:noreply, new_state}", snippet: "{:noreply, \"${1:new_state}$\"}", spec: "{:noreply, new_state} when reply: term, new_state: term, reason: term"},
-      %{description: "{:noreply, new_state, timeout | :hibernate, {:continue, term}}", snippet: "{:noreply, \"${1:new_state}$\", \"${2:timeout | :hibernate}$\", {:continue, term()}}", spec: "{:noreply, new_state, timeout | :hibernate, {:continue, term}} when reply: term, new_state: term, reason: term"},
-      %{description: "{:stop, reason, reply, new_state}", snippet: "{:stop, \"${1:reason}$\", \"${2:reply}$\", \"${3:new_state}$\"}", spec: "{:stop, reason, reply, new_state} when reply: term, new_state: term, reason: term"},
-      %{description: "{:stop, reason, new_state}", snippet: "{:stop, \"${1:reason}$\", \"${2:new_state}$\"}", spec: "{:stop, reason, new_state} when reply: term, new_state: term, reason: term"}
-    ]
+    returns = get_returns_from_callback(ElixirSenseExample.ExampleBehaviour, :handle_call, 3)
+
+    expected_returns =
+      [
+        %{description: "{:reply, reply, new_state}", snippet: "{:reply, \"${1:reply}$\", \"${2:new_state}$\"}", spec: "{:reply, reply, new_state} when reply: term, new_state: term, reason: term"},
+        %{description: "{:reply, reply, new_state, timeout | :hibernate | {:continue, term}}", snippet: "{:reply, \"${1:reply}$\", \"${2:new_state}$\", \"${3:timeout | :hibernate | {:continue, term}}$\"}", spec: "{:reply, reply, new_state, timeout | :hibernate | {:continue, term}} when reply: term, new_state: term, reason: term"},
+        %{description: "{:noreply, new_state}", snippet: "{:noreply, \"${1:new_state}$\"}", spec: "{:noreply, new_state} when reply: term, new_state: term, reason: term"},
+        %{description: "{:noreply, new_state, timeout | :hibernate | {:continue, term}}", snippet: "{:noreply, \"${1:new_state}$\", \"${2:timeout | :hibernate | {:continue, term}}$\"}", spec: "{:noreply, new_state, timeout | :hibernate | {:continue, term}} when reply: term, new_state: term, reason: term"},
+        %{description: "{:stop, reason, reply, new_state}", snippet: "{:stop, \"${1:reason}$\", \"${2:reply}$\", \"${3:new_state}$\"}", spec: "{:stop, reason, reply, new_state} when reply: term, new_state: term, reason: term"},
+        %{description: "{:stop, reason, new_state}", snippet: "{:stop, \"${1:reason}$\", \"${2:new_state}$\"}", spec: "{:stop, reason, new_state} when reply: term, new_state: term, reason: term"}
+      ]
+
+    assert returns == expected_returns
   end
 
   test "get_returns_from_callback (erlang specs)" do

--- a/test/elixir_sense/docs_test.exs
+++ b/test/elixir_sense/docs_test.exs
@@ -179,29 +179,8 @@ defmodule ElixirSense.DocsTest do
       %{subject: subject, docs: %{docs: docs}} = ElixirSense.docs(buffer, 2, 5)
 
       assert subject == "defmacro"
-      assert docs =~ """
-      > Kernel.defmacro(call, expr \\\\\\\\ nil)
-
-      Defines a macro with the given name and body.
-
-      Check `def/2` for rules on naming and default arguments.
-
-      ## Examples
-
-          defmodule MyLogic do
-            defmacro unless(expr, opts) do
-              quote do
-                if !unquote(expr), unquote(opts)
-              end
-            end
-          end
-
-          require MyLogic
-          MyLogic.unless false do
-            IO.puts \"It works\"
-          end
-
-      """
+      assert docs =~ "Kernel.defmacro(call, expr \\\\\\\\ nil)"
+      assert docs =~ "Defines a macro with the given name and body."
     end
 
     test "retrieve documentation from modules" do

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -9,15 +9,42 @@ defmodule ElixirSense.Providers.SuggestionTest do
     def say_hi, do: true
   end
 
-  test "find definition of functions from Kernel" do
-    result = Suggestion.find("List", [], [], SomeModule, [], [], [], SomeModule, "") |> Enum.take(16)
-    assert result |> Enum.at(0) == %{type: :hint, value: "List."}
-    assert result |> Enum.at(1) == %{name: "List", subtype: nil, summary: "Functions that work on (linked) lists.", type: :module}
-    assert result |> Enum.at(3) == %{args: "", arity: 1, name: "__info__", origin: "List", spec: nil, summary: "", type: "function"}
-    assert result |> Enum.at(4) == %{args: "list", arity: 1, name: "first", origin: "List", spec: "@spec first([elem]) :: nil | elem when elem: var", summary: "Returns the first element in `list` or `nil` if `list` is empty.", type: "function"}
-    assert result |> Enum.at(5) == %{args: "list", arity: 1, name: "last", origin: "List", spec: "@spec last([elem]) :: nil | elem when elem: var", summary: "Returns the last element in `list` or `nil` if `list` is empty.", type: "function"}
-    assert result |> Enum.at(13) == %{args: "", arity: 1, name: "module_info", origin: "List", spec: nil, summary: "", type: "function"}
-    assert result |> Enum.at(15) == %{args: "list,counter \\\\ :infinity", name: "ascii_printable?", arity: 2, origin: "List", type: "function", spec: "", summary: "Checks if a list is a charlist made only of printable ASCII characters."}
+  test "find definition of default functions" do
+    result = Suggestion.find("ElixirSenseExample.EmptyModule", [], [], SomeModule, [], [], [], SomeModule, "") |> Enum.take(18)
+    assert result |> Enum.at(0) == %{type: :hint, value: "ElixirSenseExample.EmptyModule."}
+    assert result |> Enum.at(1) == %{
+      name: "EmptyModule",
+      subtype: nil,
+      summary: "Empty module without other functions",
+      type: :module
+    }
+    assert result |> Enum.at(2) == %{
+      args: "",
+      arity: 1,
+      name: "__info__",
+      origin: "ElixirSenseExample.EmptyModule",
+      spec: nil,
+      summary: "",
+      type: "function"
+    }
+    assert result |> Enum.at(3) == %{
+      args: "",
+      arity: 1,
+      name: "module_info",
+      origin: "ElixirSenseExample.EmptyModule",
+      spec: nil,
+      summary: "",
+      type: "function"
+    }
+    assert result |> Enum.at(4) == %{
+      args: "",
+      arity: 0,
+      name: "module_info",
+      origin: "ElixirSenseExample.EmptyModule",
+      spec: nil,
+      summary: "",
+      type: "function"
+    }
   end
 
   test "return completion candidates for 'Str'" do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -126,15 +126,14 @@ defmodule ElixirSense.SuggestionsTest do
     }]
   end
 
-  test "lists returns" do
+  test "lists function return values" do
     buffer = """
     defmodule MyServer do
-      use GenServer
+      use ElixirSenseExample.ExampleBehaviour
 
       def handle_call(request, from, state) do
 
       end
-
     end
     """
 
@@ -155,9 +154,9 @@ defmodule ElixirSense.SuggestionsTest do
         snippet: "{:noreply, \"${1:new_state}$\"}",
         spec: "{:noreply, new_state} when reply: term, new_state: term, reason: term",
         type: :return},
-      %{description: "{:noreply, new_state, timeout | :hibernate, {:continue, term}}",
-        snippet: "{:noreply, \"${1:new_state}$\", \"${2:timeout | :hibernate}$\", {:continue, term()}}",
-        spec: "{:noreply, new_state, timeout | :hibernate, {:continue, term}} when reply: term, new_state: term, reason: term",
+      %{description: "{:noreply, new_state, timeout | :hibernate | {:continue, term}}",
+        snippet: "{:noreply, \"${1:new_state}$\", \"${2:timeout | :hibernate | {:continue, term}}$\"}",
+        spec: "{:noreply, new_state, timeout | :hibernate | {:continue, term}} when reply: term, new_state: term, reason: term",
         type: :return},
       %{description: "{:stop, reason, reply, new_state}",
         snippet: "{:stop, \"${1:reason}$\", \"${2:reply}$\", \"${3:new_state}$\"}",

--- a/test/support/empty_module.ex
+++ b/test/support/empty_module.ex
@@ -1,0 +1,7 @@
+defmodule ElixirSenseExample.EmptyModule do
+  @moduledoc """
+  Empty module without other functions
+
+  More moduledoc
+  """
+end

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -1,0 +1,100 @@
+defmodule ElixirSenseExample.ExampleBehaviour do
+  @moduledoc """
+  Example of a module that has a __using__ that defines callbacks. Patterned directly off of GenServer from Elixir 1.8.0
+  """
+
+  @type name :: any
+
+  @typedoc "The server reference"
+  @type server :: pid | name | {atom, node}
+
+  @typedoc """
+  Tuple describing the client of a call request.
+  `pid` is the PID of the caller and `tag` is a unique term used to identify the
+  call.
+  """
+  @type from :: {pid, tag :: term}
+
+  @callback handle_call(request :: term, from, state :: term) ::
+              {:reply, reply, new_state}
+              | {:reply, reply, new_state, timeout | :hibernate | {:continue, term}}
+              | {:noreply, new_state}
+              | {:noreply, new_state, timeout | :hibernate | {:continue, term}}
+              | {:stop, reason, reply, new_state}
+              | {:stop, reason, new_state}
+            when reply: term, new_state: term, reason: term
+
+  alias ElixirSenseExample.ExampleBehaviour
+
+  defmacro __using__(opts) do
+    quote location: :keep, bind_quoted: [opts: opts] do
+      @behaviour ExampleBehaviour
+
+      if Module.get_attribute(__MODULE__, :doc) == nil do
+        @doc """
+        Returns a specification to start this module under a supervisor.
+        See `Supervisor`.
+        """
+      end
+
+      # TODO: Remove this on Elixir v2.0
+      @before_compile UseWithCallbacks
+
+      @doc false
+      def handle_call(msg, _from, state) do
+        proc =
+          case Process.info(self(), :registered_name) do
+            {_, []} -> self()
+            {_, name} -> name
+          end
+
+        # We do this to trick Dialyzer to not complain about non-local returns.
+        case :erlang.phash2(1, 1) do
+          0 ->
+            raise "attempted to call ExampleBehaviour #{inspect(proc)} but no handle_call/3 clause was provided"
+
+          1 ->
+            {:stop, {:bad_call, msg}, state}
+        end
+      end
+
+      defoverridable handle_call: 3
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    IO.puts("BEFORE COMPILE!")
+
+    unless Module.defines?(env.module, {:init, 1}) do
+      message = """
+      function init/1 required by behaviour GenServer is not implemented \
+      (in module #{inspect(env.module)}).
+      We will inject a default implementation for now:
+      def init(args) do
+      {:ok, args}
+      end
+      You can copy the implementation above or define your own that converts \
+      the arguments given to GenServer.start_link/3 to the server state.
+      """
+
+      :elixir_errors.warn(env.line, env.file, message)
+
+      quote do
+        @doc false
+        def init(args) do
+          {:ok, args}
+        end
+
+        defoverridable init: 1
+      end
+    end
+  end
+
+  @spec reply(from, term) :: :ok
+  def reply(client, reply)
+
+  def reply({to, tag}, reply) when is_pid(to) do
+    send(to, {tag, reply})
+    :ok
+  end
+end


### PR DESCRIPTION
The good news is that none of the tests appear to have any real breakage on 1.8.0, it was just a matter of fixing the tests to not inspect Elixir's code/docs.