### PR TITLE
Port tests and fixes from iex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+.elixir_ls
+.vscode

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -95,7 +95,7 @@ defmodule Alchemist.Helpers.Complete do
     cond do
       h === ?. and t != [] ->
         expand_dot(reduce(t))
-      h === ?: ->
+      h === ?: and t == [] ->
         expand_erlang_modules()
       identifier?(h) ->
         expand_expr(reduce(expr))

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -370,7 +370,7 @@ defmodule Alchemist.Helpers.Complete do
     if function_exported?(mod, :__info__, 1) do
       if docs = NormalizedCode.get_docs(mod, :docs) do
         specs = TypeInfo.get_module_specs(mod)
-        for {{f, a}, _line, func_kind, _sign, doc} = func_doc <- docs, not hidden_fun?({f, a}, docs) do
+        for {{f, a}, _line, func_kind, _sign, _doc} = func_doc <- docs, not hidden_fun?({f, a}, docs) do
           spec = Map.get(specs, {f, a})
           {f, a, func_kind, func_doc, Introspection.spec_to_string(spec)}
         end
@@ -411,7 +411,7 @@ defmodule Alchemist.Helpers.Complete do
      do: true
 
   defp underscored_fun?({name, _}),
-     do: hd(Atom.to_char_list(name)) == ?_
+     do: hd(Atom.to_charlist(name)) == ?_
 
   defp ensure_loaded(Elixir), do: {:error, :nofile}
   defp ensure_loaded(mod), do: Code.ensure_compiled(mod)

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -147,15 +147,14 @@ defmodule Alchemist.Helpers.Complete do
       hd(:string.tokens(acc, [token]))
     end)
     |> Enum.reverse
-    |> strip_ampersand
-    |> strip_percent
+    |> trim_leading(?&)
+	  |> trim_leading(?%)
   end
 
-  defp strip_percent([?% | t]), do: t
-  defp strip_percent(expr), do: expr
-
-  defp strip_ampersand([?&|t]), do: t
-  defp strip_ampersand(expr), do: expr
+  defp trim_leading([char | rest], char),
+	    do: rest
+  defp trim_leading(expr, _char),
+    do: expr
 
   defp yes(hint, entries) do
     {:yes, String.to_charlist(hint), entries}

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -9,14 +9,17 @@ defmodule Alchemist.Helpers.Complete do
 
   @moduledoc false
 
-  # This Alchemist.Completer holds a codebase copy of the
-  # IEx.Autocomplete because for the use of context specific
-  # aliases.
-  #
-  # With the release of Elixir v1.1 the IEx.Autocomplete will
-  # look for aliases in a certain environment variable
-  # `Application.get_env(:iex, :autocomplete_server)` and until
-  # then we'll use our own autocomplete codebase.
+  # This module is based on Alchemist.Completer which in
+  # turn was originally based on Elixir IEx.Autocomplete taken
+  # from version ~ 1.1
+  # Since then the codebases have diverged as the requirements
+  # put on editor and REPL autocomplete are different.
+  # However some relevant changes have been merged back
+  # from upstream Elixir (1.9).
+
+  # Alchemist.Helpers.Complete will look for aliases in
+  # an environment variable
+  # `Application.get_env(:"alchemist.el", :aliases)`
 
   def run(exp) do
     code = case is_bitstring(exp) do

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -398,7 +398,7 @@ defmodule Alchemist.Helpers.Complete do
   end
 
   defp get_module_funs(mod) do
-    if function_exported?(mod, :__info__, 1) do
+    if Code.ensure_loaded?(mod) and function_exported?(mod, :__info__, 1) do
       if docs = NormalizedCode.get_docs(mod, :docs) do
         specs = TypeInfo.get_module_specs(mod)
         for {{f, a}, _line, func_kind, _sign, _doc} = func_doc <- docs, not hidden_fun?({f, a}, docs) do
@@ -418,7 +418,8 @@ defmodule Alchemist.Helpers.Complete do
       end
     else
       # TODO should we reject underscored funs here?
-      for {f, a} <- mod.module_info(:exports) do
+      funs = mod.module_info(:exports) -- [module_info: 0, module_info: 1]
+      for {f, a} <- funs do
         case f |> Atom.to_string do
           "MACRO-" <> name -> {String.to_atom(name), a, :macro, nil, nil}
           _name            -> {f, a, :function, nil, nil}

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -424,7 +424,7 @@ defmodule Alchemist.Helpers.Complete do
             end
             {func_kind, func_doc} = find_doc({f, new_arity}, docs)
             spec = Map.get(specs, {f, new_arity})
-            {f, a, func_kind, func_doc, spec}
+            {f, a, func_kind, func_doc, Introspection.spec_to_string(spec)}
           end
         else
           macros = for {f, a} <- mod.__info__(:macros), do: {f, a, :defmacro, nil, nil}

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -4,6 +4,7 @@ defmodule Alchemist.Helpers.Complete do
   alias ElixirSense.Core.Introspection
   alias ElixirSense.Core.TypeInfo
   alias ElixirSense.Core.Normalized.Code, as: NormalizedCode
+  alias ElixirSense.Core.Source
 
   @builtin_functions [{:__info__, 1}, {:module_info, 0}, {:module_info, 1}]
 
@@ -266,16 +267,8 @@ defmodule Alchemist.Helpers.Complete do
     |> format_expansion(hint)
   end
 
-  defp expand_alias([name | rest]) when is_atom(name)
-  do
-    case Keyword.fetch(aliases_from_env(), Module.concat(Elixir, name)) do
-      {:ok, name} when rest == [] -> {:ok, name}
-      {:ok, name} -> {:ok, Module.concat([name | rest])}
-      :error -> {:ok, Module.concat([name | rest])}
-    end
-  end
-  defp expand_alias([_ | _]) do
-    :error
+  defp expand_alias(mod_parts) do
+    Source.concat_module_parts(mod_parts, aliases_from_env())
   end
 
   defp aliases_from_env do

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -186,7 +186,7 @@ defmodule Alchemist.Helpers.Complete do
     if prefix in [0, length] do
       yes("", Enum.flat_map(entries, &to_entries/1))
     else
-      yes(:binary.part(first.name, prefix, length - prefix), [])
+      yes(binary_part(first.name, prefix, length - prefix), [])
     end
   end
 
@@ -339,7 +339,8 @@ defmodule Alchemist.Helpers.Complete do
   defp match_modules(hint, root) do
     root
     |> get_modules()
-    |> :lists.usort()
+    |> Enum.sort()
+    |> Enum.dedup()
     |> Enum.drop_while(& not starts_with?(&1, hint))
     |> Enum.take_while(& starts_with?(&1, hint))
   end
@@ -499,7 +500,7 @@ defmodule Alchemist.Helpers.Complete do
 
   defp format_hint(name, hint) do
     hint_size = byte_size(hint)
-    :binary.part(name, hint_size, byte_size(name) - hint_size)
+    binary_part(name, hint_size, byte_size(name) - hint_size)
   end
 
 end

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -457,8 +457,12 @@ defmodule Alchemist.Helpers.Complete do
     to_entries(fun)
   end
 
+  defp to_hint(%{kind: :module, name: name}, hint) when name == hint do
+    format_hint(name, name) <> "."
+  end
+
   defp to_hint(%{kind: :module, name: name}, hint) do
-    format_hint(name, hint) <> "."
+    format_hint(name, hint)
   end
 
   defp to_hint(%{kind: :function, name: name}, hint) do

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -148,7 +148,11 @@ defmodule Alchemist.Helpers.Complete do
     end)
     |> Enum.reverse
     |> strip_ampersand
+    |> strip_percent
   end
+
+  defp strip_percent([?% | t]), do: t
+  defp strip_percent(expr), do: expr
 
   defp strip_ampersand([?&|t]), do: t
   defp strip_ampersand(expr), do: expr

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -143,10 +143,15 @@ defmodule Alchemist.Helpers.Complete do
   end
 
   defp reduce(expr) do
-    Enum.reverse Enum.reduce ' ([{', expr, fn token, acc ->
+    Enum.reduce(' ([{', expr, fn token, acc ->
       hd(:string.tokens(acc, [token]))
-    end
+    end)
+    |> Enum.reverse
+    |> strip_ampersand
   end
+
+  defp strip_ampersand([?&|t]), do: t
+  defp strip_ampersand(expr), do: expr
 
   defp yes(hint, entries) do
     {:yes, String.to_charlist(hint), entries}

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -301,7 +301,8 @@ defmodule Alchemist.Helpers.Complete do
     parts = String.split(mod, "."),
     depth <= length(parts),
     name = Enum.at(parts, depth - 1),
-    valid_alias_piece?("." <> name) do
+    valid_alias_piece?("." <> name),
+    uniq: true do
       mod_as_atom = mod |> String.to_atom
       desc = Introspection.get_module_docs_summary(mod_as_atom)
       subtype = Introspection.get_module_subtype(mod_as_atom)

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -34,8 +34,11 @@ defmodule Alchemist.Helpers.Complete do
       {:no, _, _}  -> ''
       {:yes, [], _} -> List.insert_at(list, 0, %{type: :hint, value: "#{exp}"})
       {:yes, _, []} -> run(code ++ result)
-      {:yes, _,  _} -> List.insert_at(run(code ++ result), 1, Enum.at(list, 0))
-      #
+      {:yes, _,  r} ->
+        case r do
+          [%{subtype: :struct}] -> List.insert_at(list, 0, %{type: :hint, value: "#{exp}#{result}"})
+          _ -> List.insert_at(run(code ++ result), 1, Enum.at(list, 0))
+        end
     end
   end
 

--- a/lib/elixir_sense/core/normalized/code.ex
+++ b/lib/elixir_sense/core/normalized/code.ex
@@ -53,8 +53,8 @@ defmodule ElixirSense.Core.Normalized.Code do
     docs_en =
       case docs do
         %{"en" => docs_en} -> docs_en
-        false -> false
-        _ -> nil
+        :hidden -> false
+        :none -> nil
       end
 
     case kind do

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -34,7 +34,7 @@ defmodule ElixirSense.Providers.Definition do
         %Location{found: true, type: :variable, file: nil, line: line, column: column}
       _ ->
         subject
-        |> Source.split_module_and_func
+        |> Source.split_module_and_func(aliases)
         |> Introspection.actual_mod_fun(imports, aliases, module)
         |> find_source(module)
     end

--- a/lib/elixir_sense/providers/docs.ex
+++ b/lib/elixir_sense/providers/docs.ex
@@ -10,7 +10,7 @@ defmodule ElixirSense.Providers.Docs do
   def all(subject, imports, aliases, module, scope) do
     mod_fun =
       subject
-      |> Source.split_module_and_func
+      |> Source.split_module_and_func(aliases)
       |> Introspection.actual_mod_fun(imports, aliases, module)
     {mod_fun_to_string(mod_fun), Introspection.get_all_docs(mod_fun, scope)}
   end

--- a/lib/elixir_sense/providers/references.ex
+++ b/lib/elixir_sense/providers/references.ex
@@ -37,7 +37,7 @@ defmodule ElixirSense.Providers.References do
         |> Enum.map(fn pos -> build_var_location(subject, pos) end)
       _ ->
         subject
-        |> Source.split_module_and_func
+        |> Source.split_module_and_func(aliases)
         |> Introspection.actual_mod_fun(imports, aliases, module)
         |> xref_at_cursor(arity, module, scope)
         |> Enum.map(&build_location/1)
@@ -112,7 +112,7 @@ defmodule ElixirSense.Providers.References do
   defp find_actual_mod_fun(code, line, col, imports, aliases, module) do
     code
     |> Source.subject(line, col)
-    |> Source.split_module_and_func
+    |> Source.split_module_and_func(aliases)
     |> Introspection.actual_mod_fun(imports, aliases, module)
   end
 

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -233,7 +233,7 @@ defmodule ElixirSense.Providers.Suggestion do
 
   defp find_typespecs(hint, aliases, module, _scope) do
     hint
-    |> Source.split_module_and_hint()
+    |> Source.split_module_and_hint(aliases)
     |> find_typespecs_for_mod_and_hint(aliases, module)
   end
 

--- a/test/alchemist/helpers/complete_test.ex
+++ b/test/alchemist/helpers/complete_test.ex
@@ -67,6 +67,7 @@ defmodule Alchemist.Helpers.CompleteTest do
 
     File.write!("Elixir.Sample.beam", bytecode)
     assert {:docs_v1, _, _, _, _, _, _} = Code.fetch_docs(Sample)
+    # IEx version asserts expansion on Sample._ but we also include :__info__ and there is more than 1 match
     assert {:yes, 'ar__', [%{name: "__bar__"}]} = expand('Sample.__b')
   after
     File.rm("Elixir.Sample.beam")
@@ -134,10 +135,10 @@ defmodule Alchemist.Helpers.CompleteTest do
   test "imports completion" do
     {:yes, '', list} = expand('')
     assert is_list(list)
-    # IEx.Helpers import
-    # assert list |> Enum.find(& &1.name == "h")
+
     assert list |> Enum.find(& &1.name == "unquote")
-    # IEx.Helpers import
+    # IEX version asserts IEx.Helpers are imported
+    # assert list |> Enum.find(& &1.name == "h")
     # assert list |> Enum.find(& &1.name == "pwd")
   end
 
@@ -164,7 +165,17 @@ defmodule Alchemist.Helpers.CompleteTest do
 
   test "ampersand completion" do
     assert expand('&Enu') == {:yes, 'm', []}
-    assert {:yes, [], [%{name: "all?"}, %{name: "any?"}, %{name: "at"}]} = expand('&Enum.a')
+    # TODO IEx version returns entry per arity here
+    # assert {:yes, [], [
+    #   %{name: "all?", arity: 1}, %{name: "all?", arity: 2},
+    #   %{name: "any?", arity: 1}, %{name: "any?", arity: 2},
+    #   %{name: "at", arity: 2}, %{name: "at", arity: 3},
+    #   ]} = expand('&Enum.a')
+    assert {:yes, [], [
+      %{name: "all?", arity: 2},
+      %{name: "any?", arity: 2},
+      %{name: "at", arity: 3},
+      ]} = expand('&Enum.a')
     assert {:yes, [], [%{name: "all?"}, %{name: "any?"}, %{name: "at"}]} = expand('f = &Enum.a')
   end
 

--- a/test/alchemist/helpers/complete_test.ex
+++ b/test/alchemist/helpers/complete_test.ex
@@ -1,0 +1,156 @@
+defmodule Alchemist.Helpers.CompleteTest do
+  use ExUnit.Case, async: true
+
+  def expand(expr) do
+    Alchemist.Helpers.Complete.expand(Enum.reverse expr)
+  end
+
+  test "erlang module completion" do
+    assert expand(':zl') == {:yes, 'ib.', [%{name: "zlib", subtype: nil, summary: "", type: :module}]}
+  end
+
+  test "erlang module no completion" do
+    assert expand(':unknown') == {:no, '', []}
+    assert expand('Enum:') == {:no, '', []}
+  end
+
+  test "erlang module multiple values completion" do
+    {:yes, '', list} = expand(':user')
+    assert list |> Enum.find(& &1.name == "user")
+    assert list |> Enum.find(& &1.name == "user_drv")
+  end
+
+  test "erlang root completion" do
+    {:yes, '', list} = expand(':')
+    assert is_list(list)
+    assert list |> Enum.find(& &1.name == "lists")
+  end
+
+  test "elixir proxy" do
+    {:yes, '', list} = expand('E')
+    assert list |> Enum.find(& &1.name == "Elixir")
+  end
+
+  test "elixir completion" do
+    assert expand('En') == {:yes, 'um', []}
+    assert {:yes, 'ble.', [%{name: "Enumerable", subtype: :protocol, type: :module}]} = expand('Enumera')
+  end
+
+  test "elixir completion with self" do
+    assert {:yes, '.', [%{name: "Enumerable", subtype: :protocol}]} = expand('Enumerable')
+  end
+
+  test "elixir completion on modules from load path" do
+    assert {:yes, [], [
+      %{name: "Stream", subtype: :struct, type: :module},
+      %{name: "String", subtype: nil, type: :module},
+      %{name: "StringIO", subtype: nil, type: :module}]} = expand('Str')
+    assert {:yes, '', [
+      %{name: "Macro"},
+      %{name: "Map"},
+      %{name: "MapSet"},
+      %{name: "MatchError"},
+    ]} = expand('Ma')
+    assert {:yes, 't.', [%{name: "Dict"}]} = expand('Dic')
+    assert {:yes, [], [
+      %{name: "ExUnit"},
+      %{name: "Exception"}]} = expand('Ex')
+  end
+
+  test "elixir no completion" do
+    assert expand('.') == {:no, '', []}
+    assert expand('Xyz') == {:no, '', []}
+    assert expand('x.Foo') == {:no, '', []}
+  end
+
+  test "elixir root submodule completion" do
+    assert {:yes, 'ss.', [%{name: "Access"}]} = expand('Elixir.Acce')
+  end
+
+  test "elixir submodule completion" do
+    assert {:yes, 'rs.', [%{name: "Chars", subtype: :protocol}]} = expand('String.Cha')
+  end
+
+  test "elixir submodule no completion" do
+    assert expand('IEx.Xyz') == {:no, '', []}
+  end
+
+  test "function completion" do
+    assert {:yes, 'rsion', [%{name: "version", origin: "System"}]} = expand('System.ve')
+    assert {:yes, 'ms', [%{name: "fun2ms", origin: ":ets"}]} = expand(':ets.fun2')
+  end
+
+  test "function completion with arity" do
+    assert {:yes, '', [%{name: "printable?", origin: "String"}]} = expand('String.printable?')
+    assert {:yes, '', [%{name: "printable?"}]} = expand('String.printable?/')
+  end
+
+  test "macro completion" do
+    {:yes, '', list} = expand('Kernel.is_')
+    assert is_list(list)
+  end
+
+  test "imports completion" do
+    {:yes, '', list} = expand('')
+    assert is_list(list)
+    # IEx.Helpers import
+    # assert list |> Enum.find(& &1.name == "h")
+    assert list |> Enum.find(& &1.name == "unquote")
+    # IEx.Helpers import
+    # assert list |> Enum.find(& &1.name == "pwd")
+  end
+
+  test "kernel import completion" do
+    assert {:yes, 'ct', [%{args: "fields", arity: 1, name: "defstruct", origin: "Kernel", spec: "", summary: "Defines a struct.", type: "macro"}]} = expand('defstru')
+    assert {:yes, '', [
+      %{arity: 2, name: "put_in"},
+      %{arity: 3, name: "put_in"},
+      %{arity: 3, name: "put_elem"},
+    ]} = expand('put_')
+  end
+
+  test "kernel special form completion" do
+    assert {:yes, 'icing', [%{name: "unquote_splicing", origin: "Kernel.SpecialForms"}]} = expand('unquote_spl')
+  end
+
+  test "completion inside expression" do
+    assert expand('1 En') == {:yes, 'um', []}
+    assert expand('Test(En') == {:yes, 'um', []}
+    assert {:yes, 'ib.', [_]} = expand('Test :zl')
+    assert {:yes, 'ib.', [_]} = expand('[:zl')
+    assert {:yes, 'ib.', [_]} = expand('{:zl')
+  end
+
+  defmodule SublevelTest.LevelA.LevelB do
+  end
+
+  test "elixir completion sublevel" do
+    assert {:yes, 'LevelA.', [%{name: "LevelA"}]} = expand('Alchemist.Helpers.CompleteTest.SublevelTest.')
+  end
+
+  defmodule MyServer do
+    def current_env do
+      %Macro.Env{aliases: [{MyList, List}, {EList, :lists}]}
+    end
+  end
+
+  test "complete aliases of elixir modules" do
+    Application.put_env(:"alchemist.el", :aliases, [{MyList, List}])
+
+    assert {:yes, 'ist.', [%{name: "MyList"}]} = expand('MyL')
+    assert {:yes, '.', [%{name: "MyList"}]} = expand('MyList')
+    assert {:yes, [], [%{arity: 2, name: "to_integer"}, %{arity: 1, name: "to_integer"}]} = expand('MyList.to_integer')
+  end
+
+  test "complete aliases of erlang modules" do
+    Application.put_env(:"alchemist.el", :aliases, [{EList, :lists}])
+
+    assert {:yes, 'ist.', [%{name: "EList"}]} = expand('EL')
+    assert {:yes, '.', [%{name: "EList"}]} = expand('EList')
+    assert {:yes, [], [
+      %{arity: 2, name: "map"},
+      %{arity: 3, name: "mapfoldl"},
+      %{arity: 3, name: "mapfoldr"}]} = expand('EList.map')
+  end
+
+end

--- a/test/alchemist/helpers/complete_test.ex
+++ b/test/alchemist/helpers/complete_test.ex
@@ -121,6 +121,12 @@ defmodule Alchemist.Helpers.CompleteTest do
     assert {:yes, 'ib.', [_]} = expand('{:zl')
   end
 
+  test "ampersand completion" do
+    assert expand('&Enu') == {:yes, 'm', []}
+    assert {:yes, [], [%{name: "all?"}, %{name: "any?"}, %{name: "at"}]} = expand('&Enum.a')
+    assert {:yes, [], [%{name: "all?"}, %{name: "any?"}, %{name: "at"}]} = expand('f = &Enum.a')
+  end
+
   defmodule SublevelTest.LevelA.LevelB do
   end
 

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -103,6 +103,7 @@ defmodule Alchemist.Helpers.CompleteTest do
     assert expand('.') == {:no, '', []}
     assert expand('Xyz') == {:no, '', []}
     assert expand('x.Foo') == {:no, '', []}
+    assert expand('x.Foo.get_by') == {:no, '', []}
   end
 
   test "elixir root submodule completion" do

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -6,7 +6,7 @@ defmodule Alchemist.Helpers.CompleteTest do
   end
 
   test "erlang module completion" do
-    assert expand(':zl') == {:yes, 'ib.', [%{name: "zlib", subtype: nil, summary: "", type: :module}]}
+    assert expand(':zl') == {:yes, 'ib', [%{name: "zlib", subtype: nil, summary: "", type: :module}]}
   end
 
   test "erlang module no completion" do
@@ -33,7 +33,7 @@ defmodule Alchemist.Helpers.CompleteTest do
 
   test "elixir completion" do
     assert expand('En') == {:yes, 'um', []}
-    assert {:yes, 'ble.', [%{name: "Enumerable", subtype: :protocol, type: :module}]} = expand('Enumera')
+    assert {:yes, 'ble', [%{name: "Enumerable", subtype: :protocol, type: :module}]} = expand('Enumera')
   end
 
   test "elixir completion with self" do
@@ -51,7 +51,7 @@ defmodule Alchemist.Helpers.CompleteTest do
       %{name: "MapSet"},
       %{name: "MatchError"},
     ]} = expand('Ma')
-    assert {:yes, 't.', [%{name: "Dict"}]} = expand('Dic')
+    assert {:yes, 't', [%{name: "Dict"}]} = expand('Dic')
     assert {:yes, [], [
       %{name: "ExUnit"},
       %{name: "Exception"}]} = expand('Ex')
@@ -106,11 +106,11 @@ defmodule Alchemist.Helpers.CompleteTest do
   end
 
   test "elixir root submodule completion" do
-    assert {:yes, 'ss.', [%{name: "Access"}]} = expand('Elixir.Acce')
+    assert {:yes, 'ss', [%{name: "Access"}]} = expand('Elixir.Acce')
   end
 
   test "elixir submodule completion" do
-    assert {:yes, 'rs.', [%{name: "Chars", subtype: :protocol}]} = expand('String.Cha')
+    assert {:yes, 'rs', [%{name: "Chars", subtype: :protocol}]} = expand('String.Cha')
   end
 
   test "elixir submodule no completion" do
@@ -158,9 +158,9 @@ defmodule Alchemist.Helpers.CompleteTest do
   test "completion inside expression" do
     assert expand('1 En') == {:yes, 'um', []}
     assert expand('Test(En') == {:yes, 'um', []}
-    assert {:yes, 'ib.', [_]} = expand('Test :zl')
-    assert {:yes, 'ib.', [_]} = expand('[:zl')
-    assert {:yes, 'ib.', [_]} = expand('{:zl')
+    assert {:yes, 'ib', [_]} = expand('Test :zl')
+    assert {:yes, 'ib', [_]} = expand('[:zl')
+    assert {:yes, 'ib', [_]} = expand('{:zl')
   end
 
   test "ampersand completion" do
@@ -183,7 +183,7 @@ defmodule Alchemist.Helpers.CompleteTest do
   end
 
   test "elixir completion sublevel" do
-    assert {:yes, 'LevelA.', [%{name: "LevelA"}]} = expand('Alchemist.Helpers.CompleteTest.SublevelTest.')
+    assert {:yes, 'LevelA', [%{name: "LevelA"}]} = expand('Alchemist.Helpers.CompleteTest.SublevelTest.')
   end
 
   defmodule MyServer do
@@ -195,7 +195,7 @@ defmodule Alchemist.Helpers.CompleteTest do
   test "complete aliases of elixir modules" do
     Application.put_env(:"alchemist.el", :aliases, [{MyList, List}])
 
-    assert {:yes, 'ist.', [%{name: "MyList"}]} = expand('MyL')
+    assert {:yes, 'ist', [%{name: "MyList"}]} = expand('MyL')
     assert {:yes, '.', [%{name: "MyList"}]} = expand('MyList')
     assert {:yes, [], [%{arity: 2, name: "to_integer"}, %{arity: 1, name: "to_integer"}]} = expand('MyList.to_integer')
   end
@@ -203,7 +203,7 @@ defmodule Alchemist.Helpers.CompleteTest do
   test "complete aliases of erlang modules" do
     Application.put_env(:"alchemist.el", :aliases, [{EList, :lists}])
 
-    assert {:yes, 'ist.', [%{name: "EList"}]} = expand('EL')
+    assert {:yes, 'ist', [%{name: "EList"}]} = expand('EL')
     assert {:yes, '.', [%{name: "EList"}]} = expand('EList')
     assert {:yes, [], [
       %{arity: 2, name: "map"},
@@ -216,7 +216,6 @@ defmodule Alchemist.Helpers.CompleteTest do
   end
 
    test "completion for structs" do
-    # TODO IEx returns uct here
-    assert {:yes, 'uct.', [%{name: "MyStruct"}]} = expand('%Alchemist.Helpers.CompleteTest.MyStr')
+    assert {:yes, 'uct', [%{name: "MyStruct"}]} = expand('%Alchemist.Helpers.CompleteTest.MyStr')
   end
 end

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -211,4 +211,12 @@ defmodule Alchemist.Helpers.CompleteTest do
       %{arity: 3, name: "mapfoldr"}]} = expand('EList.map')
   end
 
+  defmodule MyStruct do
+    defstruct my_val: "val"
+  end
+
+   test "completion for structs" do
+    # TODO IEx returns uct here
+    assert {:yes, 'uct.', [%{name: "MyStruct"}]} = expand('%Alchemist.Helpers.CompleteTest.MyStr')
+  end
 end

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -219,4 +219,12 @@ defmodule Alchemist.Helpers.CompleteTest do
    test "completion for structs" do
     assert {:yes, 'uct', [%{name: "MyStruct"}]} = expand('%Alchemist.Helpers.CompleteTest.MyStr')
   end
+
+  test "ignore invalid Elixir module literals" do
+    defmodule :"Alchemist.Helpers.CompleteTest.Unicodé", do: nil
+    assert expand('Alchemist.Helpers.CompleteTest.Unicod') == {:no, '', []}
+  after
+    :code.purge(:"Alchemist.Helpers.CompleteTest.Unicodé")
+    :code.delete(:"Alchemist.Helpers.CompleteTest.Unicodé")
+  end
 end

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -212,7 +212,7 @@ defmodule Alchemist.Helpers.CompleteTest do
   end
 
   defmodule MyStruct do
-    defstruct my_val: "val"
+    defstruct [:my_val]
   end
 
    test "completion for structs" do

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -140,19 +140,6 @@ defmodule Alchemist.Helpers.CompleteTest do
 
     assert {:yes, '', [
       %{name: "bar", arity: 0},
-      # IEx version does not have those 3 hints
-      %{
-        arity: 0,
-        name: "module_info",
-      },
-      %{
-        arity: 1,
-        name: "module_info",
-      },
-      %{
-        arity: 1,
-        name: "__info__",
-      },
       %{name: "foo", arity: 1},
       %{name: "foo", arity: 2},
       %{name: "foo", arity: 3},
@@ -307,13 +294,6 @@ defmodule Alchemist.Helpers.CompleteTest do
   after
     :code.purge(:"Alchemist.Helpers.CompleteTest.Unicodé")
     :code.delete(:"Alchemist.Helpers.CompleteTest.Unicodé")
-  end
-
-  test "complete builtin functions" do
-    assert {:yes, 'fo__', [%{name: "__info__"}]} = expand('Enumerable.__in')
-    assert {:yes, 'fo', [%{name: "module_info", arity: 0}, %{name: "module_info", arity: 1}]} = expand('Enumerable.module_in')
-    assert {:yes, 'otocol__', [%{name: "__protocol__", arity: 1}]} = expand('Enumerable.__pr')
-    assert {:yes, 'r', []} = expand('Enumerable.impl_fo')
   end
 
   defmodule MyMacro do

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -99,15 +99,15 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for &func" do
-    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
   end
 
   test "do not return completion candidates for unknown erlang modules" do
-    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
   end
 
   test "do not return completion candidates for unknown modules" do
-    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
   end
 
 end

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -89,4 +89,25 @@ defmodule ElixirSense.Providers.SuggestionTest do
     refute "module_info" in suggestions_names
   end
 
+  defmodule MyStruct do
+    defstruct [:my_val]
+  end
+
+  # TODO
+  test "return completion candidates for struct starting with %" do
+    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct."} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+  end
+
+  test "return completion candidates for &func" do
+    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+  end
+
+  test "do not return completion candidates for unknown erlang modules" do
+    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+  end
+
+  test "do not return completion candidates for unknown modules" do
+    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+  end
+
 end

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -95,7 +95,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   # TODO
   test "return completion candidates for struct starting with %" do
-    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct."} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
   end
 
   test "return completion candidates for &func" do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -71,13 +71,13 @@ defmodule ElixirSense.SuggestionsTest do
 
     assert list  == [
       %{type: :hint, value: "MyList.flatten"},
-      %{args: "list,tail", arity: 2, name: "flatten", origin: "List",
-       spec: "@spec flatten(deep_list, [elem]) :: [elem] when deep_list: [elem | deep_list], elem: var",
-       summary: "Flattens the given `list` of nested lists.\nThe list `tail` will be added at the end of\nthe flattened list.",
-       type: "function"},
       %{args: "list", arity: 1, name: "flatten", origin: "List",
        spec: "@spec flatten(deep_list) :: list when deep_list: [any | deep_list]",
        summary: "Flattens the given `list` of nested lists.",
+       type: "function"},
+      %{args: "list,tail", arity: 2, name: "flatten", origin: "List",
+       spec: "@spec flatten(deep_list, [elem]) :: [elem] when deep_list: [elem | deep_list], elem: var",
+       summary: "Flattens the given `list` of nested lists.\nThe list `tail` will be added at the end of\nthe flattened list.",
        type: "function"}
     ]
   end


### PR DESCRIPTION
`Alchemist.Completer` was based on `IEx.Autocomplete` from Elixir v~1.1. This PR:
- ports relevant changes and fixes from upstream Elixir until v1.9:
  - improved struct handling
  - improved completion for erlang modules
  - fixed crash when completing deep not existing module
  - do not hint invalid module names
  - saner appending `.` after completion
  - hidden functions are not suggested (`@doc false`, underscored with no docs)
  - default argument functions with `@doc false` are not suggested
  - fixed type for macros when docs are not available
  - properly return suggestions for multi-arity functions
- ports tests from `IEx.Autocomplete`
- adds integration tests
- fixes an issue in `Introspection.get_docs` shim uncovered when porting changes