### PR TITLE
Improve state tracking during metadata build

### DIFF
--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -28,7 +28,6 @@ defmodule ElixirSense.Core.MetadataBuilder do
     state
     |> new_namespace(module)
     |> add_current_module_to_index(position)
-    |> create_alias_for_current_module
     |> new_attributes_scope
     |> new_behaviours_scope
     |> new_alias_scope
@@ -46,7 +45,6 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> remove_import_scope
     |> remove_require_scope
     |> remove_vars_scope
-    |> remove_alias_for_current_module(module)
     |> remove_module_from_namespace(module)
     |> result(ast)
   end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -40,13 +40,14 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   defp post_module(ast, state, module) do
     state
-    |> remove_module_from_namespace(module)
     |> remove_attributes_scope
     |> remove_behaviours_scope
     |> remove_alias_scope
     |> remove_import_scope
     |> remove_require_scope
     |> remove_vars_scope
+    |> remove_alias_for_current_module(module)
+    |> remove_module_from_namespace(module)
     |> result(ast)
   end
 

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -239,7 +239,7 @@ defmodule ElixirSense.Core.State do
     Enum.reduce(aliases_tuples, state, fn(tuple, state) -> add_alias(state, tuple) end)
   end
 
-  def remove_alias(state, alias_tuple = {alias, _}) do
+  def remove_alias(state, _alias_tuple = {alias, _}) do
     [aliases_from_scope|inherited_aliases] = state.aliases
     aliases_from_scope = aliases_from_scope |> Enum.reject(& match?({^alias, _}, &1))
     %{state | aliases: [aliases_from_scope|inherited_aliases]}
@@ -263,6 +263,7 @@ defmodule ElixirSense.Core.State do
 
   def add_import(state, module) do
     [imports_from_scope|inherited_imports] = state.imports
+    imports_from_scope = imports_from_scope -- [module]
     %{state | imports: [[module|imports_from_scope]|inherited_imports]}
   end
 
@@ -272,6 +273,7 @@ defmodule ElixirSense.Core.State do
 
   def add_require(state, module) do
     [requires_from_scope|inherited_requires] = state.requires
+    requires_from_scope = requires_from_scope -- [module]
     %{state | requires: [[module|requires_from_scope]|inherited_requires]}
   end
 
@@ -313,6 +315,7 @@ defmodule ElixirSense.Core.State do
 
   def add_behaviour(state, module) do
     [behaviours_from_scope|other_behaviours] = state.behaviours
+    behaviours_from_scope = behaviours_from_scope -- [module]
     %{state | behaviours: [[module|behaviours_from_scope]|other_behaviours]}
   end
 

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -209,6 +209,7 @@ defmodule ElixirSense.Core.State do
     %{state | behaviours: behaviours, scope_behaviours: behaviours}
   end
 
+  def add_alias(state, {alias, module}) when alias == module, do: state
   def add_alias(state, alias_tuple = {alias, _}) do
     [aliases_from_scope|inherited_aliases] = state.aliases
     aliases_from_scope = aliases_from_scope |> Enum.reject(& match?({^alias, _}, &1))
@@ -253,11 +254,11 @@ defmodule ElixirSense.Core.State do
   end
 
   defp maybe_add_import_alias(state, module) do
-    case module |> Atom.to_string() |> String.split(".") |> Enum.map(& &1 |> String.to_atom()) |> Enum.drop(1) |> Enum.reverse do
+    case module |> Module.split() |> Enum.reverse do
       [_] -> state
-      [head|_] = parts ->
+      [head|_] ->
         state
-        |> add_alias({:"Elixir.#{head}", module})
+        |> add_alias({Module.concat([head]), module})
     end
   end
 

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -408,14 +408,14 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       |> string_to_state
 
     assert get_line_aliases(state, 3)  == [{MyList, List}]
-    assert get_line_aliases(state, 6)  == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 9)  == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 12) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
-    assert get_line_aliases(state, 14) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 16) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 19) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}]
-    assert get_line_aliases(state, 21) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}, {AnotherInnerModule, OuterModule.AnotherInnerModule}]
-    assert get_line_aliases(state, 23) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}, {AnotherInnerModule, OuterModule.AnotherInnerModule}]
+    assert get_line_aliases(state, 6)  == [{MyList, List}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 9)  == [{MyList, List}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 12) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
+    assert get_line_aliases(state, 14) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 16) == [{MyList, List}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 19) == [{MyList, List}, {MyCode, Code}]
+    assert get_line_aliases(state, 21) == [{MyList, List}, {MyCode, Code}]
+    assert get_line_aliases(state, 23) == [{MyList, List}, {MyCode, Code}]
     assert get_line_aliases(state, 25) == []
   end
 
@@ -454,16 +454,16 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert get_line_aliases(state, 3)  == [{Nested, OuterModule.Nested}, {MyList, List}]
-    assert get_line_aliases(state, 6)  == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 9)  == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 12) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
-    assert get_line_aliases(state, 14) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 16) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 19) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyCode, Code}]
-    assert get_line_aliases(state, 22) == [{Nested1, OuterModule.Nested1}]
-    assert get_line_aliases(state, 24) == [{Nested1, OuterModule.Nested1}, {Nested, OuterModule.Nested1.InnerModule.Nested}]
-    assert get_line_aliases(state, 26) == [{Nested1, OuterModule.Nested1}]
+    assert get_line_aliases(state, 3)  == [{MyList, List}]
+    assert get_line_aliases(state, 6)  == [{MyList, List}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 9)  == [{MyList, List}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 12) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
+    assert get_line_aliases(state, 14) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 16) == [{MyList, List}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 19) == [{MyList, List}, {MyCode, Code}]
+    assert get_line_aliases(state, 22) == []
+    assert get_line_aliases(state, 24) == []
+    assert get_line_aliases(state, 26) == []
     assert get_line_aliases(state, 28) == []
   end
 
@@ -611,6 +611,22 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       |> string_to_state
 
     assert get_line_imports(state, 4)   == [List]
+  end
+
+  test "imports nested" do
+
+    state =
+      """
+      defmodule OuterModule do
+        import List
+        import SomeModule.Inner
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_imports(state, 4) == [SomeModule.Inner, List]
+    assert get_line_aliases(state, 4) == [{Inner, SomeModule.Inner}]
   end
 
   test "requires" do

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -385,17 +385,73 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
         end
         alias Code, as: MyCode
         IO.puts ""
+        defmodule AnotherInnerModule do
+          IO.puts ""
+        end
+        IO.puts ""
       end
+      IO.puts ""
       """
       |> string_to_state
 
     assert get_line_aliases(state, 3)  == [{MyList, List}]
-    assert get_line_aliases(state, 6)  == [{InnerModule, OuterModule.InnerModule}, {MyList, List}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 9)  == [{InnerModule, OuterModule.InnerModule}, {MyList, List}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 12) == [{InnerModule, OuterModule.InnerModule}, {MyList, List}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
-    assert get_line_aliases(state, 14) == [{InnerModule, OuterModule.InnerModule}, {MyList, List}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 16) == [{InnerModule, OuterModule.InnerModule}, {MyList, List}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 19) == [{MyCode, Code}, {InnerModule, OuterModule.InnerModule}, {MyList, List}]
+    assert get_line_aliases(state, 6)  == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 9)  == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 12) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
+    assert get_line_aliases(state, 14) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 16) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 19) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}]
+    assert get_line_aliases(state, 21) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}, {AnotherInnerModule, OuterModule.AnotherInnerModule}]
+    assert get_line_aliases(state, 23) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}, {AnotherInnerModule, OuterModule.AnotherInnerModule}]
+    assert get_line_aliases(state, 25) == []
+  end
+
+  test "aliases 1" do
+
+    state =
+      """
+      defmodule OuterModule.Nested do
+        alias List, as: MyList
+        IO.puts ""
+        defmodule InnerModule do
+          alias Enum, as: MyEnum
+          IO.puts ""
+          def func do
+            alias String, as: MyString
+            IO.puts ""
+            if true do
+              alias Macro, as: MyMacro
+              IO.puts ""
+            end
+            IO.puts ""
+          end
+          IO.puts ""
+        end
+        alias Code, as: MyCode
+        IO.puts ""
+      end
+      defmodule OuterModule.Nested1 do
+        IO.puts ""
+        defmodule InnerModule.Nested do
+          IO.puts ""
+        end
+        IO.puts ""
+      end
+      IO.puts ""
+      """
+      |> string_to_state
+
+    assert get_line_aliases(state, 3)  == [{Nested, OuterModule.Nested}, {MyList, List}]
+    assert get_line_aliases(state, 6)  == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 9)  == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 12) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
+    assert get_line_aliases(state, 14) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}, {MyString, String}]
+    assert get_line_aliases(state, 16) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyEnum, Enum}]
+    assert get_line_aliases(state, 19) == [{Nested, OuterModule.Nested}, {MyList, List}, {InnerModule, OuterModule.Nested.InnerModule}, {MyCode, Code}]
+    assert get_line_aliases(state, 22) == [{Nested1, OuterModule.Nested1}]
+    assert get_line_aliases(state, 24) == [{Nested1, OuterModule.Nested1}, {Nested, OuterModule.Nested1.InnerModule.Nested}]
+    assert get_line_aliases(state, 26) == [{Nested1, OuterModule.Nested1}]
+    assert get_line_aliases(state, 28) == []
   end
 
   test "aliases with `fn`" do
@@ -430,7 +486,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert get_line_aliases(state, 3) == [{Email, Foo.Email}, {User, Foo.User}]
+    assert get_line_aliases(state, 3) == [{User, Foo.User}, {Email, Foo.Email}]
   end
 
   test "aliases defined with v1.2 notation (multiline)" do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -669,6 +669,11 @@ defmodule ElixirSense.SuggestionsTest do
 
   defmodule ElixirSenseExample.SameModule do
     def test_fun(), do: :ok
+    defmacro some_test_macro() do
+      quote do
+        @attr "val"
+      end
+    end
   end
 
   test "suggestion understands alias shadowing" do
@@ -694,6 +699,15 @@ defmodule ElixirSense.SuggestionsTest do
     end
     """
     assert [%{type: :hint, value: "SameModule.test_fun"}, %{origin: "ElixirSense.SuggestionsTest.ElixirSenseExample.SameModule"}] = ElixirSense.suggestions(buffer, 5, 17)
+
+    buffer = """
+    defmodule ElixirSenseExample.SameModule do
+      require Logger, as: ModuleB
+      require ElixirSense.SuggestionsTest.ElixirSenseExample.SameModule, as: SameModule
+      SameModule.so
+    end
+    """
+    assert [%{type: :hint, value: "SameModule.some_test_macro"}, %{origin: "ElixirSense.SuggestionsTest.ElixirSenseExample.SameModule"}] = ElixirSense.suggestions(buffer, 4, 15)
   end
 
   defp suggestions_by_type(type, buffer) do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -667,6 +667,35 @@ defmodule ElixirSense.SuggestionsTest do
     end
   end
 
+  defmodule ElixirSenseExample.SameModule do
+    def test_fun(), do: :ok
+  end
+
+  test "suggestion understands alias shadowing" do
+    # ordinary alias
+    buffer = """
+    defmodule ElixirSenseExample.OtherModule do
+      alias ElixirSense.SuggestionsTest.ElixirSenseExample.SameModule
+      def some_fun() do
+        SameModule.te
+      end
+    end
+    """
+    assert [%{type: :hint, value: "SameModule.test_fun"}, %{origin: "ElixirSense.SuggestionsTest.ElixirSenseExample.SameModule"}] = ElixirSense.suggestions(buffer, 4, 17)
+
+    # alias shadowing scope/inherited aliases
+    buffer = """
+    defmodule ElixirSenseExample.SameModule do
+      alias List, as: SameModule
+      alias ElixirSense.SuggestionsTest.ElixirSenseExample.SameModule
+      def some_fun() do
+        SameModule.te
+      end
+    end
+    """
+    assert [%{type: :hint, value: "SameModule.test_fun"}, %{origin: "ElixirSense.SuggestionsTest.ElixirSenseExample.SameModule"}] = ElixirSense.suggestions(buffer, 5, 17)
+  end
+
   defp suggestions_by_type(type, buffer) do
     {line, column} = get_last_line_and_column(buffer)
     suggestions_by_type(type, buffer, line, column)


### PR DESCRIPTION
This PR:
- adds support for alias shadowing (https://github.com/JakeBecker/elixir-ls/issues/172)
- fixes submodule aliases leaking into parent module scope
- fixes submodules incorrectly getting parent module alias
- creates alias for imported modules
- fixes handing of duplicated aliases, requires, imports and behaviors