### PR TITLE
Improve var suggestions when used on the same line

### DIFF
--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -52,13 +52,13 @@ defmodule ElixirSense.Core.MetadataBuilder do
   defp pre_func(ast, state, %{line: line, col: col}, name, params) do
     state
     |> new_named_func(name, length(params || []))
-    |> add_current_env_to_line(line)
     |> add_func_to_index(name, params || [], {line, col})
     |> new_alias_scope
     |> new_import_scope
     |> new_require_scope
     |> new_func_vars_scope
     |> add_vars(find_vars(params), true)
+    |> add_current_env_to_line(line)
     |> result(ast)
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -103,13 +103,14 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result(ast)
   end
 
-  defp pre_clause(ast, state, lhs) do
+  defp pre_clause(ast = {_, [line: line, column: _column], _}, state, lhs) do
     state
     |> new_alias_scope
     |> new_import_scope
     |> new_require_scope
     |> new_vars_scope
     |> add_vars(find_vars(lhs), true)
+    |> add_current_env_to_line(line)
     |> result(ast)
   end
 

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -507,12 +507,13 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       defmodule MyModule do
         alias :ets, as: Ets
+        alias :erlang_module
         IO.puts ""
       end
       """
       |> string_to_state
 
-    assert get_line_aliases(state, 3) == [{Ets, :ets}]
+    assert get_line_aliases(state, 4) == [{Ets, :ets}]
   end
 
   test "aliases defined with v1.2 notation (multiline)" do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -214,6 +214,22 @@ defmodule ElixirSense.SuggestionsTest do
     ]
   end
 
+  test "lists params in fn's" do
+    buffer = """
+    defmodule MyServer do
+      my = fn arg -> arg + 1 end
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 2, 19)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :arg, type: :variable}
+    ]
+  end
+
   test "lists params and vars in case clauses" do
     buffer = """
     defmodule MyServer do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -193,74 +193,86 @@ defmodule ElixirSense.SuggestionsTest do
     ]
   end
 
-  test "lists params and vars in case expression" do
+  test "lists params and vars in case clauses" do
     buffer = """
     defmodule MyServer do
-      use GenServer
-
-      def handle_call(request, _from, state) do
+      def fun(request) do
         case request do
-          {:atom, var} -> :ok
+          {:atom1, vara} ->
+            :ok
+          {:atom2, varb} -> :ok
         end
 
       end
-
     end
     """
 
     list =
-      ElixirSense.suggestions(buffer, 6, 22)
+      ElixirSense.suggestions(buffer, 5, 9)
       |> Enum.filter(fn s -> s.type == :variable end)
 
     assert list == [
       %{name: :request, type: :variable},
-      %{name: :state, type: :variable},
-      %{name: :var, type: :variable}
+      %{name: :vara, type: :variable}
     ]
 
     list =
-      ElixirSense.suggestions(buffer, 8, 7)
+      ElixirSense.suggestions(buffer, 6, 25)
       |> Enum.filter(fn s -> s.type == :variable end)
 
     assert list == [
       %{name: :request, type: :variable},
-      %{name: :state, type: :variable}
+      %{name: :varb, type: :variable}
+    ]
+
+    list =
+      ElixirSense.suggestions(buffer, 8, 4)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :request, type: :variable}
     ]
   end
 
-  test "lists params and vars in case expression 1" do
+  test "lists params and vars in cond clauses" do
     buffer = """
     defmodule MyServer do
-      use GenServer
-
-      def handle_call(request, _from, state) do
-        case request do
-          {:atom, var} ->
+      def fun(request) do
+        cond do
+          vara = Enum.find(request, 4) ->
             :ok
+          varb = Enum.find(request, 5) -> :ok
+          true -> :error
         end
 
       end
-
     end
     """
 
     list =
-      ElixirSense.suggestions(buffer, 7, 8)
+      ElixirSense.suggestions(buffer, 5, 9)
       |> Enum.filter(fn s -> s.type == :variable end)
 
     assert list == [
       %{name: :request, type: :variable},
-      %{name: :state, type: :variable},
-      %{name: :var, type: :variable}
+      %{name: :vara, type: :variable}
     ]
 
     list =
-      ElixirSense.suggestions(buffer, 9, 7)
+      ElixirSense.suggestions(buffer, 6, 39)
       |> Enum.filter(fn s -> s.type == :variable end)
 
     assert list == [
       %{name: :request, type: :variable},
-      %{name: :state, type: :variable}
+      %{name: :varb, type: :variable}
+    ]
+
+    list =
+      ElixirSense.suggestions(buffer, 9, 4)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :request, type: :variable}
     ]
   end
 

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -179,6 +179,11 @@ defmodule ElixirSense.SuggestionsTest do
 
       end
 
+      def init(arg), do: arg
+
+      def handle_cast(arg, _state) when is_atom(arg) do
+        :ok
+      end
     end
     """
 
@@ -190,6 +195,22 @@ defmodule ElixirSense.SuggestionsTest do
       %{name: :request, type: :variable},
       %{name: :state, type: :variable},
       %{name: :var1, type: :variable}
+    ]
+
+    list =
+      ElixirSense.suggestions(buffer, 9, 22)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :arg, type: :variable}
+    ]
+
+    list =
+      ElixirSense.suggestions(buffer, 11, 45)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :arg, type: :variable}
     ]
   end
 

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -174,7 +174,7 @@ defmodule ElixirSense.SuggestionsTest do
     defmodule MyServer do
       use GenServer
 
-      def handle_call(request, from, state) do
+      def handle_call(request, _from, state) do
         var1 = true
 
       end
@@ -187,10 +187,80 @@ defmodule ElixirSense.SuggestionsTest do
       |> Enum.filter(fn s -> s.type == :variable end)
 
     assert list == [
-      %{name: :from, type: :variable},
       %{name: :request, type: :variable},
       %{name: :state, type: :variable},
       %{name: :var1, type: :variable}
+    ]
+  end
+
+  test "lists params and vars in case expression" do
+    buffer = """
+    defmodule MyServer do
+      use GenServer
+
+      def handle_call(request, _from, state) do
+        case request do
+          {:atom, var} -> :ok
+        end
+
+      end
+
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 6, 22)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :request, type: :variable},
+      %{name: :state, type: :variable},
+      %{name: :var, type: :variable}
+    ]
+
+    list =
+      ElixirSense.suggestions(buffer, 8, 7)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :request, type: :variable},
+      %{name: :state, type: :variable}
+    ]
+  end
+
+  test "lists params and vars in case expression 1" do
+    buffer = """
+    defmodule MyServer do
+      use GenServer
+
+      def handle_call(request, _from, state) do
+        case request do
+          {:atom, var} ->
+            :ok
+        end
+
+      end
+
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 7, 8)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :request, type: :variable},
+      %{name: :state, type: :variable},
+      %{name: :var, type: :variable}
+    ]
+
+    list =
+      ElixirSense.suggestions(buffer, 9, 7)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :request, type: :variable},
+      %{name: :state, type: :variable}
     ]
   end
 


### PR DESCRIPTION
This PR adds support for variable suggestions in
```
def my(arg), do: arg
```
and
```
case x do
  var -> var
```
It also extends variable tracking test suite in metadata builder and fixes a few commented out assertions.