### PR TITLE
Improve parser error recovery and suggestions in incomplete code

### DIFF
--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -60,22 +60,20 @@ defmodule ElixirSense.Core.Parser do
     }
   end
 
-  defp string_to_ast(source, errors_threshold, cursor_line_number) do
+  defp string_to_ast(source, errors_threshold, cursor_line_number, original_error \\ nil) do
     case Code.string_to_quoted(source, columns: true) do
       {:ok, ast} ->
         {:ok, ast, source}
       error ->
         # IO.puts :stderr, "PARSE ERROR"
         # IO.inspect :stderr, error, []
-        # IO.inspect source
-        # IO.inspect error
 
         if errors_threshold > 0 do
           source
           |> fix_parse_error(cursor_line_number, error)
-          |> string_to_ast(errors_threshold - 1, cursor_line_number)
+          |> string_to_ast(errors_threshold - 1, cursor_line_number, original_error)
         else
-          error
+          original_error || error
         end
     end
   end

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -35,7 +35,13 @@ defmodule ElixirSense.Core.Source do
   end
 
   def prefix(code, line, col) do
-    line = code |> String.split("\n") |> Enum.at(line - 1)
+    line = code |> String.split("\n") |> Enum.at(line - 1, "")
+    line = if String.length(line) < col do
+      line_padding = for _ <- 1..(String.length(line) - col), into: "", do: " "
+      line <> line_padding
+    else
+      line
+    end
     line_str = line |> String.slice(0, col - 1)
     case Regex.run(Regex.recompile!(~r/[\w0-9\._!\?\:@]+$/), line_str) do
       nil -> ""

--- a/test/elixir_sense/core/metadata_test.exs
+++ b/test/elixir_sense/core/metadata_test.exs
@@ -28,7 +28,7 @@ defmodule ElixirSense.Core.MetadataTest do
       """
 
     params =
-      Parser.parse_string(code, true, true, 0)
+      Parser.parse_string(code, true, true, 1)
       |> Metadata.get_function_params(MyModule, :func)
 
     assert params == [
@@ -74,7 +74,7 @@ defmodule ElixirSense.Core.MetadataTest do
       """
 
     signatures =
-      Parser.parse_string(code, true, true, 0)
+      Parser.parse_string(code, true, true, 1)
       |> Metadata.get_function_signatures(MyModule, :func)
 
     assert signatures == [


### PR DESCRIPTION
This PR improves parse error recovery in a few common cases. It should make it more likely that valid suggestions are provided in case of unmatched ', ", [], (), do end.
Unfortunately I'm afraid it's not possible to make it much better in the current design, i.e. calling elixir parser `Code.string_to_quoted` and modifying source.
Elixir parser is not optimised for handling incomplete and invalid source and error messages are often incomplete.