### PR TITLE
Fallback strategy for line env

### DIFF
--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -16,7 +16,7 @@ defmodule ElixirSense.Core.Metadata do
 
   def get_env(%__MODULE__{} = metadata, line) do
     case Map.get(metadata.lines_to_env, line) do
-      nil -> %State.Env{}
+      nil -> State.default_env()
       ctx -> ctx
     end
   end
@@ -96,4 +96,5 @@ defmodule ElixirSense.Core.Metadata do
       {line, 0}
     end |> Enum.at(0)
   end
+
 end

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -30,7 +30,7 @@ defmodule ElixirSense.Core.Parser do
 
           create_metadata(source, {:ok, result})
         end
-      {:error, reason} = error ->
+      {:error, _reason} = error ->
         # IO.puts :stderr, "CAN'T FIX IT"
         # IO.inspect :stderr, reason, []
         create_metadata(source, error)

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -325,4 +325,14 @@ defmodule ElixirSense.Core.State do
       Map.put(acc, var, var_info)
     end)
   end
+
+  def get_closest_previous_env(%__MODULE__{} = metadata, line) do
+    metadata.lines_to_env
+    |> Enum.max_by(fn
+      {env_line, _} when env_line < line -> env_line
+      _ -> 0
+    end, fn -> default_env() end)
+  end
+
+  def default_env(), do: %ElixirSense.Core.State.Env{}
 end

--- a/test/elixir_sense/core/parser_test.exs
+++ b/test/elixir_sense/core/parser_test.exs
@@ -1,7 +1,6 @@
 defmodule ElixirSense.Core.ParserTest do
   use ExUnit.Case
 
-  import ExUnit.CaptureIO
   import ElixirSense.Core.Parser
   alias ElixirSense.Core.{Metadata, State.Env, State.VarInfo}
 

--- a/test/elixir_sense/core/parser_test.exs
+++ b/test/elixir_sense/core/parser_test.exs
@@ -355,6 +355,41 @@ defmodule ElixirSense.Core.ParserTest do
       parse_string(source, true, true, 5)
     end)
     assert output == ""
+
+  test "parse struct" do
+    source = """
+    defmodule MyModule do
+      def func() do
+        %{
+          data: "foo"
+        }
+      end
+    end
+    """
+
+    assert %ElixirSense.Core.Metadata{
+      calls: %{
+        3 => [%{func: :%{}}]
+      }
+    } = parse_string(source, true, true, 4)
+  end
+
+  test "parse struct with missing terminator" do
+    source = """
+    defmodule MyModule do
+      def func() do
+        %{
+          data: "foo"
+
+      end
+    end
+    """
+
+    assert %ElixirSense.Core.Metadata{
+      calls: %{
+        3 => [%{func: :%{}}]
+      }
+    } = parse_string(source, true, true, 4)
   end
 
 end

--- a/test/elixir_sense/core/parser_test.exs
+++ b/test/elixir_sense/core/parser_test.exs
@@ -334,10 +334,13 @@ defmodule ElixirSense.Core.ParserTest do
     end
     '''
 
-    err = capture_io(:stderr, fn ->
-      parse_string(source, true, true, 3)
-    end)
-    assert err == ""
+    assert %ElixirSense.Core.Metadata{
+      lines_to_env: %{
+        6 => %ElixirSense.Core.State.Env{
+          attributes: [:doc],
+        }
+      }
+    } = parse_string(source, true, true, 6)
   end
 
   test "parse_string with literal strings in sigils" do
@@ -351,10 +354,18 @@ defmodule ElixirSense.Core.ParserTest do
       end
     end
     '''
-    output = capture_io(:stderr, fn ->
-      parse_string(source, true, true, 5)
-    end)
-    assert output == ""
+
+    assert %ElixirSense.Core.Metadata{
+      lines_to_env: %{
+        5 => %ElixirSense.Core.State.Env{
+          vars: [
+            %ElixirSense.Core.State.VarInfo{name: :x},
+            %ElixirSense.Core.State.VarInfo{name: :y}
+          ]
+        }
+      }
+    } = parse_string(source, true, true, 5)
+  end
 
   test "parse struct" do
     source = """


### PR DESCRIPTION
If after parsing and metadata extraction we don't have line metadata and by inserting marker we introduce a parse error try to get env from previous lines. It's not certain but likely that it will be a good guess.
Fixes issue mentioned in https://github.com/elixir-lsp/elixir_sense/pull/21