### PR TITLE
Suggest funs and modules from metadata

### DIFF
--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -40,13 +40,15 @@ defmodule Alchemist.Helpers.Complete do
     {status, result, list} = expand(code |> Enum.reverse, env)
 
     case {status, result, list} do
-      {:no, _, _}  -> ''
-      {:yes, [], _} -> List.insert_at(list, 0, %{type: :hint, value: "#{exp}"})
+      {:no, _, _}  -> {%{type: :hint, value: "#{exp}"}, []}
+      {:yes, [], _} -> {%{type: :hint, value: "#{exp}"}, list}
       {:yes, _, []} -> run(code ++ result, env)
       {:yes, _,  r} ->
         case r do
-          [%{subtype: :struct}] -> List.insert_at(list, 0, %{type: :hint, value: "#{exp}#{result}"})
-          _ -> List.insert_at(run(code ++ result, env), 1, Enum.at(list, 0))
+          [%{subtype: :struct}] -> {%{type: :hint, value: "#{exp}#{result}"}, list}
+          # TODO maybe eval in some cases
+          [_] -> {%{type: :hint, value: "#{exp}#{result}"}, list}
+          [_ | _] -> run(code ++ result, env)
         end
     end
   end

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -18,10 +18,14 @@ defmodule Alchemist.Helpers.Complete do
   # put on editor and REPL autocomplete are different.
   # However some relevant changes have been merged back
   # from upstream Elixir (1.9).
-
-  # Alchemist.Helpers.Complete will look for aliases in
-  # an environment variable
-  # `Application.get_env(:"alchemist.el", :aliases)
+  # Changes made to the original version include:
+  # - different result format with added docs and spec
+  # - built in funcss are not excluded
+  # - recursive evalutor `run/2` added on top of `expand/2`
+  # - added expansion basing on metadata besides introspection
+  # - uses custom docs extraction function
+  # - gets metadata by argument instead of environment variables
+  # (original Elixir 1.1) and later GenServer
 
   defmodule Env do
     defstruct [

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -46,63 +46,11 @@ defmodule Alchemist.Helpers.Complete do
       {:yes, _,  r} ->
         case r do
           [%{subtype: :struct}] -> {%{type: :hint, value: "#{exp}#{result}"}, list}
-          # TODO maybe eval in some cases
+          # TODO maybe run recursively in some cases
           [_] -> {%{type: :hint, value: "#{exp}#{result}"}, list}
           [_ | _] -> run(code ++ result, env)
         end
     end
-  end
-
-  def run(hint, modules) do
-    context_module = modules |> Enum.at(0)
-
-    exported? = fn mod, f, a ->
-      (function_exported?(mod, f, a) or macro_exported?(mod, f, a))
-    end
-    accept_function = fn
-      (mod, mod, _, _, _)          -> true
-      (_  , _  , _, _, :undefined) -> false
-      (_  , mod, f, a, _)          -> exported?.(mod, f, a)
-    end
-
-    for module <- modules, module != Elixir do
-      funs = ModuleInfo.get_functions(module, hint)
-      funs_info = Introspection.module_functions_info(module)
-
-      for {f, a} <- funs,
-          {func_kind, fun_args, desc, spec} = Map.get(funs_info, {f, a}, {:undefined, "", "", ""}),
-          accept_function.(context_module, module, f, a, func_kind)
-      do
-        kind = case {context_module, module, func_kind} do
-          {m, m, :defmacro}  -> "public_macro"
-          {_, _, :defmacro}  -> "macro"
-          {m, m, :def}       -> "public_function"
-          {_, _, :def}       -> "function"
-          {m, m, :undefined} -> if exported?.(module, f, a), do: "public_function", else: "private_function"
-          _                  -> "unknown"
-        end
-
-        func_name = Atom.to_string(f)
-        mod_name = module |> Introspection.module_to_string
-        %{type: kind, name: func_name, arity: a, args: fun_args, origin: mod_name, summary: desc, spec: spec}
-      end
-    end |> List.flatten |> add_builtin_functions(hint)
-  end
-
-  defp add_builtin_functions(list, hint) do
-    builtin_list =
-      if String.contains?(hint, ".") do
-        local_hint = String.split(hint, ".") |> List.last()
-        for {f, a} <- @builtin_functions,
-            f_name = to_string(f),
-            String.starts_with?(f_name, local_hint)
-            do
-          %{name: f_name, arity: a, args: "", origin: "", summary: "Built-in function", spec: nil, type: "function"}
-        end
-      else
-        []
-      end
-    list ++ builtin_list
   end
 
   def expand('', env) do

--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -537,7 +537,7 @@ defmodule Alchemist.Helpers.Complete do
     for {a, {doc, spec}} <- arities_docs_specs do
       {fun_args, desc} = Introspection.extract_fun_args_and_desc(doc)
       kind = case func_kind do
-        :defmacro -> "macro"
+        k when k in [:defmacro, :defmacrop, :defguard, :defguardp] -> "macro"
         _         -> "function"
       end
       mod_name = mod

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -146,7 +146,7 @@ defmodule ElixirSense do
       scope: scope
     } = Metadata.get_env(buffer_file_metadata, line)
 
-    Suggestion.find(hint, [module|imports], aliases, module, vars, attributes, behaviours, scope, text_before)
+    Suggestion.find(hint, [module|imports], aliases, module, vars, attributes, behaviours, scope, buffer_file_metadata.mods_funs, text_before)
   end
 
   @doc """

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -12,6 +12,7 @@ defmodule ElixirSense.Core.Metadata do
             lines_to_env: %{},
             calls: %{},
             vars_info_per_scope_id: %{},
+            mods_funs: %{},
             error: nil
 
   def get_env(%__MODULE__{} = metadata, line) do

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -49,9 +49,9 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result(ast)
   end
 
-  defp pre_func(ast, state, %{line: line, col: col}, name, params) do
+  defp pre_func(ast = {type, _, _}, state, %{line: line, col: col}, name, params) do
     state
-    |> new_named_func(name, length(params || []))
+    |> new_named_func(name, length(params || []), type)
     |> add_func_to_index(name, params || [], {line, col})
     |> new_alias_scope
     |> new_import_scope

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -72,6 +72,7 @@ defmodule ElixirSense.Core.Parser do
   defp create_metadata(source, {:ok, acc}) do
     %Metadata{
       source: source,
+      mods_funs: acc.mods_funs,
       mods_funs_to_positions: acc.mods_funs_to_positions,
       lines_to_env: acc.lines_to_env,
       vars_info_per_scope_id: acc.vars_info_per_scope_id,

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -293,6 +293,11 @@ defmodule Alchemist.Helpers.CompleteTest do
         MyModule => %{
           {:my_fun_priv, 1} => %{type: :defp},
           {:my_fun_pub, 1} => %{type: :def},
+          {:my_macro_priv, 1} => %{type: :defmacrop},
+          {:my_macro_pub, 1} => %{type: :defmacro},
+          {:my_guard_priv, 1} => %{type: :defguardp},
+          {:my_guard_pub, 1} => %{type: :defguard},
+          {:my_delegated, 1} => %{type: :defdelegate},
         },
         OtherModule => %{
           {:my_fun_pub_other, 1} => %{type: :def},
@@ -301,12 +306,31 @@ defmodule Alchemist.Helpers.CompleteTest do
     }
 
     assert {:yes, 'un_p', []} = expand('my_f', env)
+
     assert {:yes, 'iv', [
-      %{name: "my_fun_priv", origin: "MyModule"}
+      %{name: "my_fun_priv", origin: "MyModule", type: "function"}
     ]} = expand('my_fun_pr', env)
     assert {:yes, 'b', [
-      %{name: "my_fun_pub", origin: "MyModule"}
+      %{name: "my_fun_pub", origin: "MyModule", type: "function"}
     ]} = expand('my_fun_pu', env)
+
+    assert {:yes, 'iv', [
+      %{name: "my_macro_priv", origin: "MyModule", type: "macro"}
+    ]} = expand('my_macro_pr', env)
+    assert {:yes, 'b', [
+      %{name: "my_macro_pub", origin: "MyModule", type: "macro"}
+    ]} = expand('my_macro_pu', env)
+
+    assert {:yes, 'iv', [
+      %{name: "my_guard_priv", origin: "MyModule", type: "macro"}
+    ]} = expand('my_guard_pr', env)
+    assert {:yes, 'b', [
+      %{name: "my_guard_pub", origin: "MyModule", type: "macro"}
+    ]} = expand('my_guard_pu', env)
+
+    assert {:yes, 'legated', [
+      %{name: "my_delegated", origin: "MyModule", type: "function"}
+    ]} = expand('my_de', env)
   end
 
   test "complete remote funs from imported module" do
@@ -394,10 +418,14 @@ defmodule Alchemist.Helpers.CompleteTest do
       expr
     end
     def fun, do: :ok
+    defguard guard(value) when is_integer(value) and rem(value, 2) == 0
+    defdelegate delegated(par), to: OtherModule
   end
 
   test "complete macros and functions from not loaded modules" do
     assert {:yes, 'st', [%{name: "test", type: "macro"}]} = expand('Alchemist.Helpers.CompleteTest.MyMacro.te')
     assert {:yes, 'un', [%{name: "fun", type: "function"}]} = expand('Alchemist.Helpers.CompleteTest.MyMacro.f')
+    assert {:yes, 'uard', [%{name: "guard", type: "macro"}]} = expand('Alchemist.Helpers.CompleteTest.MyMacro.g')
+    assert {:yes, 'legated', [%{name: "delegated", type: "function"}]} = expand('Alchemist.Helpers.CompleteTest.MyMacro.de')
   end
 end

--- a/test/alchemist/helpers/complete_test.exs
+++ b/test/alchemist/helpers/complete_test.exs
@@ -359,6 +359,20 @@ defmodule Alchemist.Helpers.CompleteTest do
     ]} = expand('S.my_f', env)
   end
 
+  test "complete modules" do
+    env = %Env{
+      scope_module: MyModule,
+      aliases: [{MyAlias, Some.OtherModule.Nested}],
+      mods_and_funs: %{
+        Some.OtherModule => %{}
+      }
+    }
+
+    assert {:yes, 'me', [%{name: "Some", type: :module}]} = expand('So', env)
+    assert {:yes, 'OtherModule', [%{name: "OtherModule", type: :module}]} = expand('Some.', env)
+    assert {:yes, 'lias', [%{name: "MyAlias", type: :module}]} = expand('MyA', env)
+  end
+
   defmodule MyStruct do
     defstruct [:my_val]
   end

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -93,7 +93,6 @@ defmodule ElixirSense.Providers.SuggestionTest do
     defstruct [:my_val]
   end
 
-  # TODO
   test "return completion candidates for struct starting with %" do
     assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
   end

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -14,18 +14,18 @@ defmodule ElixirSense.Providers.SuggestionTest do
     assert result |> Enum.at(0) == %{type: :hint, value: "ElixirSenseExample.EmptyModule."}
     assert result |> Enum.at(1) == %{
       args: "",
-      arity: 1,
-      name: "__info__",
-      origin: "",
+      arity: 0,
+      name: "module_info",
+      origin: "ElixirSenseExample.EmptyModule",
       spec: nil,
       summary: "Built-in function",
       type: "function"
     }
     assert result |> Enum.at(2) == %{
       args: "",
-      arity: 0,
+      arity: 1,
       name: "module_info",
-      origin: "",
+      origin: "ElixirSenseExample.EmptyModule",
       spec: nil,
       summary: "Built-in function",
       type: "function"
@@ -33,12 +33,13 @@ defmodule ElixirSense.Providers.SuggestionTest do
     assert result |> Enum.at(3) == %{
       args: "",
       arity: 1,
-      name: "module_info",
-      origin: "",
+      name: "__info__",
+      origin: "ElixirSenseExample.EmptyModule",
       spec: nil,
       summary: "Built-in function",
       type: "function"
     }
+
   end
 
   test "return completion candidates for 'Str'" do
@@ -76,7 +77,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   test "local calls should not return built-in functions" do
     list =
       Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, %{}, "")
-      |> Enum.filter(fn item -> item.type in [:hint, "function", "public_function"] end)
+      |> Enum.filter(fn item -> item.type in [:hint, "function", "function"] end)
 
     assert list == [%{type: :hint, value: "mo"}]
   end

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -10,7 +10,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "find definition of built-in functions" do
-    result = Suggestion.find("ElixirSenseExample.EmptyModule.", [], [], SomeModule, [], [], [], SomeModule, "")
+    result = Suggestion.find("ElixirSenseExample.EmptyModule.", [], [], SomeModule, [], [], [], SomeModule, %{}, "")
     assert result |> Enum.at(0) == %{type: :hint, value: "ElixirSenseExample.EmptyModule."}
     assert result |> Enum.at(1) == %{
       args: "",
@@ -42,7 +42,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for 'Str'" do
-    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, "") == [
+    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, %{}, "") == [
       %{type: :hint, value: "Str"},
       %{name: "Stream", subtype: :struct, summary: "Functions for creating and composing streams.", type: :module},
       %{name: "String", subtype: nil, summary: "A String in Elixir is a UTF-8 encoded binary.", type: :module},
@@ -55,7 +55,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
       %{type: :hint, value: "List.delete"},
       %{args: "list," <> _, arity: 2, name: "delete", origin: "List", spec: "@spec delete(" <> _, summary: "Deletes the given" <> _, type: "function"},
       %{args: "list,index", arity: 2, name: "delete_at", origin: "List", spec: "@spec delete_at(list, integer) :: list", summary: "Produces a new list by " <> _, type: "function"}
-    ] = Suggestion.find("List.del", [], [], SomeModule, [], [], [], SomeModule, "")
+    ] = Suggestion.find("List.del", [], [], SomeModule, [], [], [], SomeModule, %{}, "")
   end
 
   test "return completion candidates for module with alias" do
@@ -63,26 +63,26 @@ defmodule ElixirSense.Providers.SuggestionTest do
       %{type: :hint, value: "MyList.delete"},
       %{args: "list," <> _, arity: 2, name: "delete", origin: "List", spec: "@spec delete(" <> _, summary: "Deletes the given " <> _, type: "function"},
       %{args: "list,index", arity: 2, name: "delete_at", origin: "List", spec: "@spec delete_at(list, integer) :: list", summary: "Produces a new list " <> _, type: "function"}
-    ] = Suggestion.find("MyList.del", [], [{MyList, List}], SomeModule, [], [], [], SomeModule, "")
+    ] = Suggestion.find("MyList.del", [], [{MyList, List}], SomeModule, [], [], [], SomeModule, %{}, "")
   end
 
   test "return completion candidates for functions from import" do
-    assert Suggestion.find("say", [MyModule], [], SomeModule, [], [], [], SomeModule, "") == [
-      %{type: :hint, value: "say"},
-      %{args: "", arity: 0, name: "say_hi", origin: "ElixirSense.Providers.SuggestionTest.MyModule", spec: "", summary: "", type: "public_function"}
+    assert Suggestion.find("say", [MyModule], [], SomeModule, [], [], [], SomeModule, %{}, "") == [
+      %{type: :hint, value: "say_hi"},
+      %{args: "", arity: 0, name: "say_hi", origin: "ElixirSense.Providers.SuggestionTest.MyModule", spec: nil, summary: "", type: "function"}
     ]
   end
 
   test "local calls should not return built-in functions" do
     list =
-      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, %{}, "")
       |> Enum.filter(fn item -> item.type in [:hint, "function", "public_function"] end)
 
     assert list == [%{type: :hint, value: "mo"}]
   end
 
   test "empty hint should not return built-in functions" do
-    suggestions_names = Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, "")
+    suggestions_names = Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, %{}, "")
       |> Enum.filter(&Map.has_key?(&1, :name))
       |> Enum.map(&(&1.name))
 
@@ -94,19 +94,30 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for struct starting with %" do
-    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
+    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
   end
 
   test "return completion candidates for &func" do
-    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
+    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
   end
 
   test "do not return completion candidates for unknown erlang modules" do
-    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
+    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
   end
 
   test "do not return completion candidates for unknown modules" do
-    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], {:func, 0}, "")
+    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
   end
 
+  test "return completion candidates for metadata modules" do
+    assert [%{type: :hint, value: "my_func"} | _] = Suggestion.find("my_f", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{
+      SomeModule => %{
+        {:my_func, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defp}
+      }
+    }, "")
+
+    assert [%{type: :hint, value: "SomeModule"} | _] = Suggestion.find("So", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{
+      SomeModule => %{}
+    }, "")
+  end
 end


### PR DESCRIPTION
I noticed that module, function and macro suggestions only work for compiled modules. This is irritating when working on unfinished code. With the changes from this PR we are able to make suggestions basing on metadata from currently evaluated piece of code as a fallback if the module is not compiled.
I also did some refactoring in Complete module, most noticeably the aliases are no longer passed through application env