### PR TITLE
Add support for protocols

### DIFF
--- a/lib/alchemist/helpers/complete.ex
+++ b/lib/alchemist/helpers/complete.ex
@@ -362,6 +362,7 @@ defmodule Alchemist.Helpers.Complete do
   end
 
   defp get_metadata_module_funs(mod, include_builtin, env) do
+    # TODO add builtin functions for protocols, protocol_implementations, structs, behaviours and exceptions
     case env.mods_and_funs[mod] do
       nil -> []
       funs ->

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -143,10 +143,11 @@ defmodule ElixirSense do
       attributes: attributes,
       behaviours: behaviours,
       module: module,
-      scope: scope
+      scope: scope,
+      protocol: protocol
     } = Metadata.get_env(buffer_file_metadata, line)
 
-    Suggestion.find(hint, [module|imports], aliases, module, vars, attributes, behaviours, scope, buffer_file_metadata.mods_funs, text_before)
+    Suggestion.find(hint, [module|imports], aliases, module, vars, attributes, behaviours, scope, protocol, buffer_file_metadata.mods_funs, text_before)
   end
 
   @doc """

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -621,10 +621,10 @@ defmodule ElixirSense.Core.Introspection do
     {nil, nil}
   end
 
-  defp elixir_module?(module) when is_atom(module) do
+  def elixir_module?(module) when is_atom(module) do
     module == Module.concat(Elixir, module)
   end
-  defp elixir_module?(_) do
+  def elixir_module?(_) do
     false
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -363,7 +363,9 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   defp pre({:use, [line: line, column: _column], _} = ast, state) do
-    %{requires: requires, imports: imports, behaviours: behaviours} = Ast.extract_use_info(ast, get_current_module(state), state)
+    # take first variant as we optimistically assume that the result of expanding `use` will be the same for all variants
+    current_module = get_current_module(state)
+    %{requires: requires, imports: imports, behaviours: behaviours} = Ast.extract_use_info(ast, current_module, state)
 
     state
     |> add_current_env_to_line(line)

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -226,6 +226,12 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_func(ast_without_params, state, %{line: line, col: column}, name, params)
   end
 
+  # protocol function
+  defp pre({def_name, meta, [{name, [line: line, column: column] = meta2, params}]} = ast, state) when def_name in @defs do
+    ast_without_params = {def_name, meta, [{name, add_no_call(meta2), []}, nil]}
+    pre_func(ast_without_params, state, %{line: line, col: column}, name, params)
+  end
+
   defp pre({def_name, _meta, _} = ast, state) when def_name in @defs do
     {ast, state}
   end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -26,6 +26,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   defp pre_module(ast, state, position, module) do
     state
+    |> maybe_add_protocol_implementation(module)
     |> new_namespace(module)
     |> add_current_module_to_index(position)
     |> new_attributes_scope
@@ -45,6 +46,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> remove_import_scope
     |> remove_require_scope
     |> remove_vars_scope
+    |> remove_protocol_implementation
     |> remove_module_from_namespace(module)
     |> result(ast)
   end
@@ -205,7 +207,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
         pre_module(ast, state, {line, column}, {protocol, modules})
 
       {:__aliases__, _, implementation} ->
-        pre_module(ast, state, {line, column}, protocol ++ implementation)
+        pre_module(ast, state, {line, column}, {protocol, [implementation]})
     end
   end
 
@@ -427,7 +429,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
         post_module(ast, state, {protocol, modules})
 
       {:__aliases__, _, implementation} ->
-        post_module(ast, state, protocol ++ implementation)
+        post_module(ast, state, {protocol, [implementation]})
     end
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -227,7 +227,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   # protocol function
-  defp pre({def_name, meta, [{name, [line: line, column: column] = meta2, params}]} = ast, state) when def_name in @defs do
+  defp pre({def_name, meta, [{name, [line: line, column: column] = meta2, params}]}, state) when def_name == :def do
     ast_without_params = {def_name, meta, [{name, add_no_call(meta2), []}, nil]}
     pre_func(ast_without_params, state, %{line: line, col: column}, name, params)
   end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -191,6 +191,10 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_module(ast, state, {line, column}, module)
   end
 
+  defp pre({:defprotocol, _, [{:__aliases__, [line: line, column: column], module}, _]} = ast, state) do
+    pre_module(ast, state, {line, column}, module)
+  end
+
   defp pre({def_name, meta, [{:when, _, [head|_]}, body]}, state) when def_name in @defs do
     pre({def_name, meta, [head, body]}, state)
   end
@@ -390,6 +394,10 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   defp post({:defmodule, _, [{:__aliases__, _, module}, _]} = ast, state) do
+    post_module(ast, state, module)
+  end
+
+  defp post({:defprotocol, _, [{:__aliases__, _, module}, _]} = ast, state) do
     post_module(ast, state, module)
   end
 

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -330,10 +330,10 @@ defmodule ElixirSense.Core.State do
   end
 
   def add_alias(state, {alias, module}) when alias == module, do: state
-  def add_alias(state, alias_tuple = {alias, _}) do
+  def add_alias(state, {alias, aliased}) do
     [aliases_from_scope|inherited_aliases] = state.aliases
     aliases_from_scope = aliases_from_scope |> Enum.reject(& match?({^alias, _}, &1))
-    %{state | aliases: [[alias_tuple|aliases_from_scope]|inherited_aliases]}
+    %{state | aliases: [[{alias, expand_alias(state, aliased)}|aliases_from_scope]|inherited_aliases]}
   end
 
   def add_aliases(state, aliases_tuples) do
@@ -363,6 +363,7 @@ defmodule ElixirSense.Core.State do
   end
 
   def add_import(state, module) do
+    module = expand_alias(state, module)
     [imports_from_scope|inherited_imports] = state.imports
     imports_from_scope = imports_from_scope -- [module]
     %{state | imports: [[module|imports_from_scope]|inherited_imports]}
@@ -383,6 +384,8 @@ defmodule ElixirSense.Core.State do
   end
 
   def add_require(state, module) do
+    module = expand_alias(state, module)
+
     [requires_from_scope|inherited_requires] = state.requires
     requires_from_scope = requires_from_scope -- [module]
     %{state | requires: [[module|requires_from_scope]|inherited_requires]}
@@ -425,6 +428,7 @@ defmodule ElixirSense.Core.State do
   end
 
   def add_behaviour(state, module) do
+    module = expand_alias(state, module)
     [behaviours_from_scope|other_behaviours] = state.behaviours
     behaviours_from_scope = behaviours_from_scope -- [module]
     %{state | behaviours: [[module|behaviours_from_scope]|other_behaviours]}

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -197,6 +197,7 @@ defmodule ElixirSense.Core.State do
   end
 
   def new_namespace(state, module) do
+    # TODO refactor to allow {:implementation, protocol, [implementations]} in scope
     module = escape_protocol_impementations(module)
     module_reversed = :lists.reverse(module)
     namespace = module_reversed ++ state.namespace
@@ -466,6 +467,7 @@ defmodule ElixirSense.Core.State do
     end
   end
 
+  # TODO refactor to use mods_funs
   def get_known_module(state, module) do
     if ElixirSense.Core.Introspection.elixir_module?(module) do
       case state.mods_funs_to_positions[{module, nil, nil}] do

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -131,21 +131,9 @@ defmodule ElixirSense.Core.State do
     end
   end
 
-  defp drop_elixir_prefix(module) do
-    "Elixir." <> rest = module |> Atom.to_string()
-    rest
-  end
-
   def get_current_scope_name(state) do
     case hd(state.scopes) do
       {fun, _} -> fun |> Atom.to_string()
-      {:implementation, protocol, [implementation]} ->
-        "#{protocol |> Atom.to_string}.#{drop_elixir_prefix(implementation)}"
-      {:implementation, protocol, implementations} ->
-        joined = implementations
-        |> Enum.map(&drop_elixir_prefix/1)
-        |> Enum.join(", ")
-        "#{protocol |> Atom.to_string}.{#{joined}}"
       mod -> mod |> Atom.to_string()
     end
   end

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -33,7 +33,7 @@ defmodule ElixirSense.Core.State do
       imports: [],
       requires: [],
       aliases: [],
-      # TODO check usages
+      # NOTE for protocol impementation this will be the first variant
       module: nil,
       module_variants: [],
       vars: [],
@@ -74,7 +74,8 @@ defmodule ElixirSense.Core.State do
       vars: current_vars,
       attributes: current_attributes,
       behaviours: current_behaviours,
-      # TODO this may be broken for protocol implementations
+      # NOTE  for protocol implementations the scope will be
+      # escaped with `escape_protocol_implemntations`
       scope: current_scope,
       scope_id: current_scope_id,
     }

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -37,8 +37,9 @@ defmodule ElixirSense.Core.State do
       # NOTE for protocol impementation this will be the first variant
       module: nil,
       module_variants: [],
+      # NOTE for protocol impementation this will be the first variant
       protocol: nil,
-      protocols: nil,
+      protocol_variants: nil,
       vars: [],
       attributes: [],
       behaviours: [],
@@ -82,7 +83,7 @@ defmodule ElixirSense.Core.State do
       vars: current_vars,
       attributes: current_attributes,
       behaviours: current_behaviours,
-      # NOTE  for protocol implementations the scope will be
+      # NOTE for protocol implementations the scope and namespace will be
       # escaped with `escape_protocol_implemntations`
       scope: current_scope,
       scope_id: current_scope_id,
@@ -90,7 +91,7 @@ defmodule ElixirSense.Core.State do
         [] -> nil
         [head|_] -> head
       end),
-      protocols: current_scope_protocols
+      protocol_variants: current_scope_protocols
     }
   end
 
@@ -101,7 +102,7 @@ defmodule ElixirSense.Core.State do
   def get_current_module_variants(state = %{protocols: [[]|_]}) do
     state.namespace |> unescape_protocol_impementations
   end
-  def get_current_module_variants(state = %{protocols: [protocols|_]}) do
+  def get_current_module_variants(%{protocols: [protocols|_]}) do
     for {protocol, implementations} <- protocols,
     implementation <- implementations
     do

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -207,8 +207,7 @@ defmodule ElixirSense.Providers.Suggestion do
     for {{name, arity}, {type, args, docs, spec}} <- Introspection.module_functions_info(protocol),
     hint == "" or String.starts_with?("#{name}", hint)
     do
-      "Elixir." <> protocol_name = protocol |> Atom.to_string
-      %{type: :protocol_function, name: name, arity: arity, args: args, origin: protocol_name, summary: docs, spec: spec}
+      %{type: :protocol_function, name: name, arity: arity, args: args, origin: Introspection.module_to_string(protocol), summary: docs, spec: spec}
     end
     |> Enum.sort
   end

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -684,6 +684,21 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_aliases(state, 3) == [{User, Foo.User}, {Email, Foo.Email}]
   end
 
+  test "aliases of aliases" do
+
+    state =
+      """
+      defmodule MyModule do
+        alias Foo.Bar, as: Fb
+        alias Fb.Sub, as: S
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_aliases(state, 4) == [{Fb, Foo.Bar}, {S, Foo.Bar.Sub}]
+  end
+
   test "aliases erlang module" do
     state =
       """
@@ -823,6 +838,21 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_imports(state, 4)   == [List]
   end
 
+  test "imports aliased module" do
+
+    state =
+      """
+      defmodule OuterModule do
+        alias Some.Other.Module, as: S
+        import S
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_imports(state, 4) == [Some.Other.Module]
+  end
+
   test "imports nested" do
 
     state =
@@ -920,6 +950,22 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
     assert get_line_requires(state, 4)  == [:ets, Integer]
     assert get_line_aliases(state, 4)  == [{I, Integer}, {E, :ets}]
+  end
+
+  test "requires aliased module" do
+
+    state =
+      """
+      defmodule MyModule do
+        alias Some.Other.Module, as: S
+        require S
+        require S.Sub
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_requires(state, 5)  == [Some.Other.Module.Sub, Some.Other.Module]
   end
 
   test "current module" do
@@ -1213,6 +1259,20 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       |> string_to_state
 
     assert get_line_behaviours(state, 4)  == [:gen_server]
+  end
+
+  test "behaviour from aliased module" do
+    state =
+      """
+      defmodule OuterModule do
+        alias Some.Module, as: S
+        @behaviour S
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_behaviours(state, 4)  == [Some.Module]
   end
 
   test "current scope" do

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1556,7 +1556,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
   defp get_line_protocol(state, line) do
     if env = state.lines_to_env[line] do
-      case env.protocols do
+      case env.protocol_variants do
         [] -> nil
         [single] -> single
         other -> other

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -938,6 +938,21 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
         end
         IO.puts ""
       end
+
+      defprotocol Reversible do
+        def reverse(term)
+        IO.puts ""
+      end
+
+      defimpl Reversible, for: String do
+        def reverse(term), do: String.reverse(term)
+        IO.puts ""
+      end
+
+      defimpl Reversible, for: [Map, List] do
+        def reverse(term), do: Enum.reverse(term)
+        IO.puts ""
+      end
       """
       |> string_to_state
 
@@ -945,6 +960,10 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_module(state, 3)  == OuterModule
     assert get_line_module(state, 7)  == OuterModule.InnerModule
     assert get_line_module(state, 11) == OuterModule
+
+    assert get_line_module(state, 16) == Reversible
+    assert get_line_module(state, 21) == Reversible.String
+    assert get_line_module(state, 26) == [Reversible.Map, Reversible.List]
   end
 
   test "behaviours" do

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -10,7 +10,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "find definition of built-in functions" do
-    result = Suggestion.find("ElixirSenseExample.EmptyModule.", [], [], SomeModule, [], [], [], SomeModule, %{}, "")
+    result = Suggestion.find("ElixirSenseExample.EmptyModule.", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, "")
     assert result |> Enum.at(0) == %{type: :hint, value: "ElixirSenseExample.EmptyModule."}
     assert result |> Enum.at(1) == %{
       args: "",
@@ -43,7 +43,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for 'Str'" do
-    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, %{}, "") == [
+    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, "") == [
       %{type: :hint, value: "Str"},
       %{name: "Stream", subtype: :struct, summary: "Functions for creating and composing streams.", type: :module},
       %{name: "String", subtype: nil, summary: "A String in Elixir is a UTF-8 encoded binary.", type: :module},
@@ -56,7 +56,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
       %{type: :hint, value: "List.delete"},
       %{args: "list," <> _, arity: 2, name: "delete", origin: "List", spec: "@spec delete(" <> _, summary: "Deletes the given" <> _, type: "function"},
       %{args: "list,index", arity: 2, name: "delete_at", origin: "List", spec: "@spec delete_at(list, integer) :: list", summary: "Produces a new list by " <> _, type: "function"}
-    ] = Suggestion.find("List.del", [], [], SomeModule, [], [], [], SomeModule, %{}, "")
+    ] = Suggestion.find("List.del", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, "")
   end
 
   test "return completion candidates for module with alias" do
@@ -64,11 +64,11 @@ defmodule ElixirSense.Providers.SuggestionTest do
       %{type: :hint, value: "MyList.delete"},
       %{args: "list," <> _, arity: 2, name: "delete", origin: "List", spec: "@spec delete(" <> _, summary: "Deletes the given " <> _, type: "function"},
       %{args: "list,index", arity: 2, name: "delete_at", origin: "List", spec: "@spec delete_at(list, integer) :: list", summary: "Produces a new list " <> _, type: "function"}
-    ] = Suggestion.find("MyList.del", [], [{MyList, List}], SomeModule, [], [], [], SomeModule, %{}, "")
+    ] = Suggestion.find("MyList.del", [], [{MyList, List}], SomeModule, [], [], [], SomeModule, nil, %{}, "")
   end
 
   test "return completion candidates for functions from import" do
-    assert Suggestion.find("say", [MyModule], [], SomeModule, [], [], [], SomeModule, %{}, "") == [
+    assert Suggestion.find("say", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, "") == [
       %{type: :hint, value: "say_hi"},
       %{args: "", arity: 0, name: "say_hi", origin: "ElixirSense.Providers.SuggestionTest.MyModule", spec: nil, summary: "", type: "function"}
     ]
@@ -76,14 +76,14 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   test "local calls should not return built-in functions" do
     list =
-      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, %{}, "")
+      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, "")
       |> Enum.filter(fn item -> item.type in [:hint, "function", "function"] end)
 
     assert list == [%{type: :hint, value: "mo"}]
   end
 
   test "empty hint should not return built-in functions" do
-    suggestions_names = Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, %{}, "")
+    suggestions_names = Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, nil,  %{}, "")
       |> Enum.filter(&Map.has_key?(&1, :name))
       |> Enum.map(&(&1.name))
 
@@ -95,29 +95,29 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for struct starting with %" do
-    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
+    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
   end
 
   test "return completion candidates for &func" do
-    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
+    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
   end
 
   test "do not return completion candidates for unknown erlang modules" do
-    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
+    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
   end
 
   test "do not return completion candidates for unknown modules" do
-    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{}, "")
+    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
   end
 
   test "return completion candidates for metadata modules" do
-    assert [%{type: :hint, value: "my_func"} | _] = Suggestion.find("my_f", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{
+    assert [%{type: :hint, value: "my_func"} | _] = Suggestion.find("my_f", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{
       SomeModule => %{
         {:my_func, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defp}
       }
     }, "")
 
-    assert [%{type: :hint, value: "SomeModule"} | _] = Suggestion.find("So", [MyModule], [], SomeModule, [], [], [], {:func, 0}, %{
+    assert [%{type: :hint, value: "SomeModule"} | _] = Suggestion.find("So", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{
       SomeModule => %{}
     }, "")
   end

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -126,6 +126,26 @@ defmodule ElixirSense.SuggestionsTest do
     }] = list
   end
 
+  test "lists protocol functions" do
+    buffer = """
+    defimpl Enumerable, for: MyStruct do
+
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 2, 3)
+      |> Enum.filter(fn s -> s[:name] == :reduce end)
+
+    assert [%{
+      args: "enumerable,acc,fun", arity: 3, name: :reduce,
+      origin: "Enumerable",
+      spec: "@spec reduce(t, acc, reducer) :: result",
+      summary: "Reduces the `enumerable` into an element.",
+      type: :protocol_function
+    }] = list
+  end
+
   test "lists function return values" do
     buffer = """
     defmodule MyServer do
@@ -227,6 +247,22 @@ defmodule ElixirSense.SuggestionsTest do
 
     assert list == [
       %{name: :arg, type: :variable}
+    ]
+  end
+
+  test "lists params in protocol implementations" do
+    buffer = """
+    defimpl Enum, for: [MyStruct, MyOtherStruct] do
+      def count(term), do:
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 2, 24)
+      |> Enum.filter(fn s -> s.type == :variable end)
+
+    assert list == [
+      %{name: :term, type: :variable}
     ]
   end
 


### PR DESCRIPTION
With this PR metadata builder is extended to extract info about encountered protocols and implementations. Unfortunately, protocols are quite complicated and in some cases are governed by different rules than regular modules, e.g. you can implement a protocol inside a protocol implementation or implement a protocol for more than one data type which. Those cases are equivalent to defining many modules and functions with the same lines of code. I had to do some tricky encoding to get it right in the current model. While doing so I encountered a bug with alias handling - collected aliases were not utilised properly resulting in badly aliased imports, requires and aliases referring to earlier aliases.
With metadata about protocols we can properly suggest protocol modules, functions and vars inside implementing functions.