### PR TITLE
Use expansion improvements

### DIFF
--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -373,13 +373,21 @@ defmodule ElixirSense.Core.MetadataBuilder do
   defp pre({:use, [line: line, column: _column], _} = ast, state) do
     # take first variant as we optimistically assume that the result of expanding `use` will be the same for all variants
     current_module = get_current_module(state)
-    %{requires: requires, imports: imports, behaviours: behaviours} = Ast.extract_use_info(ast, current_module, state)
+    %{
+      requires: requires,
+      imports: imports,
+      behaviours: behaviours,
+      aliases: aliases,
+      attributes: attributes
+    } = Ast.extract_use_info(ast, current_module, state) |> IO.inspect
 
     state
-    |> add_current_env_to_line(line)
+    |> add_aliases(aliases)
     |> add_requires(requires)
     |> add_imports(imports)
     |> add_behaviours(behaviours)
+    |> add_attributes(attributes)
+    |> add_current_env_to_line(line)
     |> result(ast)
   end
 

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -365,11 +365,15 @@ defmodule ElixirSense.Core.State do
   end
 
   defp maybe_add_import_alias(state, module) do
-    case module |> Module.split() |> Enum.reverse do
-      [_] -> state
-      [head|_] ->
-        state
-        |> add_alias({Module.concat([head]), module})
+    if ElixirSense.Core.Introspection.elixir_module?(module) do
+      case module |> Module.split() |> Enum.reverse do
+        [_] -> state
+        [head|_] ->
+          state
+          |> add_alias({Module.concat([head]), module})
+      end
+    else
+      state
     end
   end
 
@@ -401,6 +405,10 @@ defmodule ElixirSense.Core.State do
       end
 
     %{state | vars: [vars_from_scope|other_vars], scope_vars: [vars_from_scope|tl(state.scope_vars)]}
+  end
+
+  def add_attributes(state, attributes) do
+    Enum.reduce(attributes, state, fn(attribute, state) -> add_attribute(state, attribute) end)
   end
 
   def add_attribute(state, attribute) do

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -204,7 +204,7 @@ defmodule ElixirSense.Providers.Suggestion do
 
   defp find_protocol_functions(nil, _hint), do: []
   defp find_protocol_functions({protocol, _implementations}, hint) do
-    for {{name, arity}, {type, args, docs, spec}} <- Introspection.module_functions_info(protocol),
+    for {{name, arity}, {_type, args, docs, spec}} <- Introspection.module_functions_info(protocol),
     hint == "" or String.starts_with?("#{name}", hint)
     do
       %{type: :protocol_function, name: name, arity: arity, args: args, origin: Introspection.module_to_string(protocol), summary: docs, spec: spec}

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1496,6 +1496,54 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       } == state.mods_funs
   end
 
+  test "use" do
+    state = """
+      defmodule InheritMod do
+        use ElixirSenseExample.ExampleBehaviour
+
+        IO.puts("")
+      end
+      """
+      |> string_to_state
+      |> IO.inspect
+
+      assert get_line_behaviours(state, 4) == [ElixirSenseExample.ExampleBehaviour]
+      assert get_line_requires(state, 4) == [ElixirSenseExample.ExampleBehaviour]
+  end
+
+  test "use aliased" do
+    state = """
+      defmodule InheritMod do
+        alias ElixirSenseExample.ExampleBehaviour, as: S
+        use S
+
+        IO.puts("")
+      end
+      """
+      |> string_to_state
+
+      ElixirSenseExample.ExampleBehaviourT.a
+
+      assert get_line_behaviours(state, 5) == [ElixirSenseExample.ExampleBehaviour]
+      assert get_line_requires(state, 5) == [MyMacros.Two.Three, MyMacros.One, :ets, MyMacros.Nested, MyMacros, ElixirSenseExample.ExampleBehaviour]
+      assert get_line_imports(state, 5) == [:lists, MyImports.Two.ThreeImports, MyImports.OneImports, MyImports.NestedImports, MyImports]
+      assert get_line_aliases(state, 5) == [
+        {S, ElixirSenseExample.ExampleBehaviour},
+        {Utils, MyModule.Some.Nested},
+        {Nested, MyModule.Other.Nested},
+        {Ets, :ets},
+        {One, MyModule.One},
+        {Three, MyModule.Two.Three},
+        {Four, MyModule.Four},
+        {NestedMacros, MyMacros.Nested},
+        {ErlangMacros, :ets},
+        {NestedImports, MyImports.NestedImports},
+        {OneImports, MyImports.OneImports},
+        {ThreeImports, MyImports.Two.ThreeImports}
+      ]
+      assert get_line_attributes(state, 5) == [:before_compile, :doc, :my_attribute]
+  end
+
   defp string_to_state(string) do
     string
     |> Code.string_to_quoted(columns: true)

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -967,6 +967,43 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_protocol(state, 15)  == nil
   end
 
+  test "current module with `Elixir` prefix" do
+
+    state =
+      """
+      IO.puts ""
+      defmodule Elixir.OuterModule do
+        IO.puts ""
+        defmodule InnerModule do
+          def func do
+            if true do
+              IO.puts ""
+            end
+          end
+        end
+        IO.puts ""
+      end
+
+      defmodule Elixir.Some.Nested do
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+      |> IO.inspect
+
+    assert get_line_module(state, 1)  == Elixir
+    assert get_line_protocol(state, 1)  == nil
+    assert get_line_module(state, 3)  == OuterModule
+    assert get_line_protocol(state, 3)  == nil
+    assert get_line_module(state, 7)  == OuterModule.InnerModule
+    assert get_line_protocol(state, 7)  == nil
+    assert get_line_module(state, 11) == OuterModule
+    assert get_line_protocol(state, 11)  == nil
+
+    assert get_line_module(state, 15) == Some.Nested
+    assert get_line_protocol(state, 15)  == nil
+  end
+
 
   test "current module and protocol implementation" do
 

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -975,11 +975,16 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       defmodule Elixir.OuterModule do
         IO.puts ""
         defmodule InnerModule do
-          def func do
-            if true do
-              IO.puts ""
-            end
-          end
+          IO.puts ""
+        end
+
+        defmodule Elixir.ExternalModule do
+          IO.puts ""
+        end
+
+        defprotocol Elixir.Reversible do
+          def reverse(term)
+          IO.puts ""
         end
         IO.puts ""
       end
@@ -989,19 +994,17 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       end
       """
       |> string_to_state
-      |> IO.inspect
 
     assert get_line_module(state, 1)  == Elixir
-    assert get_line_protocol(state, 1)  == nil
     assert get_line_module(state, 3)  == OuterModule
-    assert get_line_protocol(state, 3)  == nil
-    assert get_line_module(state, 7)  == OuterModule.InnerModule
-    assert get_line_protocol(state, 7)  == nil
-    assert get_line_module(state, 11) == OuterModule
-    assert get_line_protocol(state, 11)  == nil
+    assert get_line_module(state, 5)  == OuterModule.InnerModule
+    assert get_line_module(state, 9) == ExternalModule
+    assert get_line_module(state, 14) == Reversible
+    assert get_line_module(state, 16) == OuterModule
+    # external submodule does not create an alias
+    assert get_line_aliases(state, 16) == [{InnerModule, OuterModule.InnerModule}]
 
-    assert get_line_module(state, 15) == Some.Nested
-    assert get_line_protocol(state, 15)  == nil
+    assert get_line_module(state, 20) == Some.Nested
   end
 
 

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -578,56 +578,14 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
           end
           IO.puts ""
         end
+        IO.puts ""
         alias Code, as: MyCode
         IO.puts ""
         defmodule AnotherInnerModule do
           IO.puts ""
         end
         IO.puts ""
-      end
-      IO.puts ""
-      """
-      |> string_to_state
-
-    assert get_line_aliases(state, 3)  == [{MyList, List}]
-    assert get_line_aliases(state, 6)  == [{MyList, List}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 9)  == [{MyList, List}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 12) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
-    assert get_line_aliases(state, 14) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}]
-    assert get_line_aliases(state, 16) == [{MyList, List}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 19) == [{MyList, List}, {MyCode, Code}]
-    assert get_line_aliases(state, 21) == [{MyList, List}, {MyCode, Code}]
-    assert get_line_aliases(state, 23) == [{MyList, List}, {MyCode, Code}]
-    assert get_line_aliases(state, 25) == []
-  end
-
-  test "aliases nested" do
-
-    state =
-      """
-      defmodule OuterModule.Nested do
-        alias List, as: MyList
-        IO.puts ""
-        defmodule InnerModule do
-          alias Enum, as: MyEnum
-          IO.puts ""
-          def func do
-            alias String, as: MyString
-            IO.puts ""
-            if true do
-              alias Macro, as: MyMacro
-              IO.puts ""
-            end
-            IO.puts ""
-          end
-          IO.puts ""
-        end
-        alias Code, as: MyCode
-        IO.puts ""
-      end
-      defmodule OuterModule.Nested1 do
-        IO.puts ""
-        defmodule InnerModule.Nested do
+        defmodule SomeInnerModule.Nested do
           IO.puts ""
         end
         IO.puts ""
@@ -642,11 +600,16 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_aliases(state, 12) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}, {MyMacro, Macro}]
     assert get_line_aliases(state, 14) == [{MyList, List}, {MyEnum, Enum}, {MyString, String}]
     assert get_line_aliases(state, 16) == [{MyList, List}, {MyEnum, Enum}]
-    assert get_line_aliases(state, 19) == [{MyList, List}, {MyCode, Code}]
-    assert get_line_aliases(state, 22) == []
-    assert get_line_aliases(state, 24) == []
-    assert get_line_aliases(state, 26) == []
-    assert get_line_aliases(state, 28) == []
+    # submodule defines an alias in parent module
+    assert get_line_aliases(state, 18) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}]
+    assert get_line_aliases(state, 20) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}]
+    assert get_line_aliases(state, 22) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}]
+    assert get_line_aliases(state, 24) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}, {AnotherInnerModule, OuterModule.AnotherInnerModule}]
+    # submodule aliases are inherited to sibling submodules
+    assert get_line_aliases(state, 26) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}, {AnotherInnerModule, OuterModule.AnotherInnerModule}]
+    # submodule Sub0.Sub1.Sub2 is equivalent to alias Sub0
+    assert get_line_aliases(state, 28) == [{MyList, List}, {InnerModule, OuterModule.InnerModule}, {MyCode, Code}, {AnotherInnerModule, OuterModule.AnotherInnerModule}, {SomeInnerModule, OuterModule.SomeInnerModule}]
+    assert get_line_aliases(state, 30) == []
   end
 
   test "aliases with `fn`" do
@@ -1353,6 +1316,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       defmodule MyModule do
         defguard is_even(value) when is_integer(value) and rem(value, 2) == 0
         defguardp is_odd(value) when is_integer(value) and rem(value, 2) == 1
+        defguardp useless when 1 == 1
         IO.puts ""
       end
       """
@@ -1375,6 +1339,13 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
           {MyModule, :is_odd, nil} => %{
             params: [[{:value, [line: 3, column: 20], nil}]],
             positions: [{3, 13}]
+          },
+          {MyModule, :useless, 0} => %{
+            params: [[]], positions: [{4, 13}]
+          },
+          {MyModule, :useless, nil} => %{
+            params: [[]],
+            positions: [{4, 13}]
           }
         }
       } = state
@@ -1505,10 +1476,50 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       end
       """
       |> string_to_state
-      |> IO.inspect
 
       assert get_line_behaviours(state, 4) == [ElixirSenseExample.ExampleBehaviour]
-      assert get_line_requires(state, 4) == [ElixirSenseExample.ExampleBehaviour]
+      assert get_line_requires(state, 4) == [MyMacros.Two.Three, MyMacros.One, :ets, MyMacros.Nested, MyMacros, ElixirSenseExample.ExampleBehaviour]
+      assert get_line_imports(state, 4) == [:lists, MyImports.Two.ThreeImports, MyImports.OneImports, MyImports.NestedImports, MyImports]
+      assert get_line_aliases(state, 4) == [
+        {Utils, MyModule.Some.Nested},
+        {Ets, :ets},
+        {One, MyModule.One},
+        {Three, MyModule.Two.Three},
+        {Four, MyModule.Four},
+        {NestedMacros, MyMacros.Nested},
+        {ErlangMacros, :ets},
+        {Nested, InheritMod.Nested},
+        {Deeply, InheritMod.Deeply},
+        {ProtocolEmbedded, InheritMod.ProtocolEmbedded},
+        {NestedImports, MyImports.NestedImports},
+        {OneImports, MyImports.OneImports},
+        {ThreeImports, MyImports.Two.ThreeImports}
+      ]
+      assert get_line_attributes(state, 4) == [:before_compile, :doc, :my_attribute]
+
+      # FIXME `defdelegate` inside `__using__/1` macro is not supported
+
+      assert %{InheritMod => %{
+        {:handle_call, 3} => %ElixirSense.Core.State.ModFunInfo{type: :def},
+        {:private_func, 0} => %ElixirSense.Core.State.ModFunInfo{type: :defp},
+        {:private_func_arg, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defp},
+        {:private_guard, 0} => %ElixirSense.Core.State.ModFunInfo{type: :defguardp},
+        {:private_guard_arg, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defguardp},
+        {:private_macro, 0} => %ElixirSense.Core.State.ModFunInfo{type: :defmacrop},
+        {:private_macro_arg, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defmacrop},
+        {:public_func, 0} => %ElixirSense.Core.State.ModFunInfo{type: :def},
+        {:public_func_arg, 2} => %ElixirSense.Core.State.ModFunInfo{type: :def},
+        {:public_guard, 0} => %ElixirSense.Core.State.ModFunInfo{type: :defguard},
+        {:public_guard_arg, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defguard},
+        {:public_macro, 0} => %ElixirSense.Core.State.ModFunInfo{type: :defmacro},
+        {:public_macro_arg, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defmacro}
+      },
+      # FIXME only submodules defined at top level are supported in `__using__/1`
+      # FIXME submofule func and macro extraction is not supported in `__using__/1`
+      InheritMod.Deeply.Nested => %{},
+      InheritMod.Nested => %{},
+      InheritMod.ProtocolEmbedded => %{}
+      } == state.mods_funs
   end
 
   test "use aliased" do
@@ -1522,26 +1533,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-      ElixirSenseExample.ExampleBehaviourT.a
-
       assert get_line_behaviours(state, 5) == [ElixirSenseExample.ExampleBehaviour]
-      assert get_line_requires(state, 5) == [MyMacros.Two.Three, MyMacros.One, :ets, MyMacros.Nested, MyMacros, ElixirSenseExample.ExampleBehaviour]
-      assert get_line_imports(state, 5) == [:lists, MyImports.Two.ThreeImports, MyImports.OneImports, MyImports.NestedImports, MyImports]
-      assert get_line_aliases(state, 5) == [
-        {S, ElixirSenseExample.ExampleBehaviour},
-        {Utils, MyModule.Some.Nested},
-        {Nested, MyModule.Other.Nested},
-        {Ets, :ets},
-        {One, MyModule.One},
-        {Three, MyModule.Two.Three},
-        {Four, MyModule.Four},
-        {NestedMacros, MyMacros.Nested},
-        {ErlangMacros, :ets},
-        {NestedImports, MyImports.NestedImports},
-        {OneImports, MyImports.OneImports},
-        {ThreeImports, MyImports.Two.ThreeImports}
-      ]
-      assert get_line_attributes(state, 5) == [:before_compile, :doc, :my_attribute]
   end
 
   defp string_to_state(string) do

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -59,6 +59,23 @@ defmodule ElixirSenseExample.ExampleBehaviour do
       end
 
       defoverridable handle_call: 3
+
+      alias MyModule.Some.Nested, as: Utils
+      alias MyModule.Other.Nested
+      alias :ets, as: Ets
+      alias MyModule.{One, Two.Three}
+      alias MyModule.{Four}
+
+      require MyMacros
+      require MyMacros.Nested, as: NestedMacros
+      require :ets, as: ErlangMacros
+      require MyMacros.{One, Two.Three}
+
+      import MyImports
+      import MyImports.NestedImports
+      import MyImports.{OneImports, Two.ThreeImports}
+      import :lists
+      @my_attribute "my_attr"
     end
   end
 

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -1,3 +1,35 @@
+defmodule MyMacros do
+  defmodule Nested do
+  end
+  defmodule One do
+  end
+  defmodule Two.Three do
+  end
+end
+
+defmodule MyImports do
+  defmodule NestedImports do
+  end
+  defmodule OneImports do
+  end
+  defmodule Two.ThreeImports do
+  end
+end
+
+defmodule UseWithCallbacks do
+  defmacro __before_compile__(_env) do
+    quote do: :ok
+  end
+end
+
+defmodule ElixirSenseExample.Delegates do
+  def delegated_func(_a), do: :ok
+end
+
+defprotocol ProtocolOutside do
+  def reverse(term)
+end
+
 defmodule ElixirSenseExample.ExampleBehaviour do
   @moduledoc """
   Example of a module that has a __using__ that defines callbacks. Patterned directly off of GenServer from Elixir 1.8.0
@@ -76,6 +108,49 @@ defmodule ElixirSenseExample.ExampleBehaviour do
       import MyImports.{OneImports, Two.ThreeImports}
       import :lists
       @my_attribute "my_attr"
+
+      defp private_func, do: :ok
+      def public_func, do: :ok
+
+      defp private_func_arg(a), do: :ok
+      def public_func_arg(b, a \\ "def"), do: :ok
+
+      defmacrop private_macro, do: :ok
+      defmacro public_macro, do: :ok
+
+      defmacrop private_macro_arg(a), do: :ok
+      defmacro public_macro_arg(a), do: :ok
+
+      defguardp private_guard when 1 == 1
+      defguard public_guard when 1 == 1
+
+      defguardp private_guard_arg(a) when is_integer(a)
+      defguard public_guard_arg(a) when is_integer(a)
+
+      defmodule Nested do
+        def public_func_nested_arg(a), do: :ok
+        defmodule Nested.Child do
+          def public_func_nested_child_arg(a), do: :ok
+        end
+      end
+
+      defmodule Deeply.Nested do
+        def public_func_deeply_nested_arg(a), do: :ok
+      end
+
+      defprotocol ProtocolEmbedded do
+        def reverse(term)
+      end
+
+      defimpl ProtocolEmbedded, for: String do
+        def reverse(a), do: :ok
+      end
+
+      defimpl ProtocolOutside, for: String do
+        def reverse(a), do: :ok
+      end
+
+      # defdelegate delegated_func, to: ElixirSenseExample.Delegates
     end
   end
 

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -134,6 +134,10 @@ defmodule ElixirSenseExample.ExampleBehaviour do
         end
       end
 
+      defmodule Elixir.Outside do
+        def public_func_nested_arg(a), do: :ok
+      end
+
       defmodule Deeply.Nested do
         def public_func_deeply_nested_arg(a), do: :ok
       end


### PR DESCRIPTION
This PR extends metadata builder `use` directive comprehension. This allows for extraction of aliases, module attributes, submodules and functions defined in `__using__/1` (with some limitations, notably `defdelegate`, nested submodules and functions defined in submodules, as expanded macro results in different AST that directly calls into internal compiler APIs).