### PR TITLE
Suggest struct fields from metadata

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -144,10 +144,11 @@ defmodule ElixirSense do
       behaviours: behaviours,
       module: module,
       scope: scope,
-      protocol: protocol
+      protocol: protocol,
+      structs: structs
     } = Metadata.get_env(buffer_file_metadata, line)
 
-    Suggestion.find(hint, [module|imports], aliases, module, vars, attributes, behaviours, scope, protocol, buffer_file_metadata.mods_funs, text_before)
+    Suggestion.find(hint, [module|imports], aliases, module, vars, attributes, behaviours, scope, protocol, buffer_file_metadata.mods_funs, structs, text_before)
   end
 
   @doc """

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -412,7 +412,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result(ast)
   end
 
-  defp pre({type, [line: line, column: column], fields} = ast, state) when type in [:defstruct, :defexception] do
+  defp pre({type, _, fields} = ast, state) when type in [:defstruct, :defexception] do
     fields = case fields do
       [fields] -> if Keyword.keyword?(fields), do: fields, else: []
       _ -> []

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -412,6 +412,17 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result(ast)
   end
 
+  defp pre({type, [line: line, column: column], fields} = ast, state) when type in [:defstruct, :defexception] do
+    fields = case fields do
+      [fields] -> if Keyword.keyword?(fields), do: fields, else: []
+      _ -> []
+    end
+
+    state
+    |> add_struct(type, fields)
+    |> result(ast)
+  end
+
   defp pre({call, [line: line, column: column], params} = ast, state) when is_call(call, params) do
     state =
       if !String.starts_with?(to_string(call), "__atom_elixir_marker_") do

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -15,7 +15,7 @@ defmodule ElixirSense.Core.Parser do
     end
   end
 
-  def parse_string(source, try_to_fix_parse_error, try_to_fix_line_not_found, cursor_line_number) when is_integer(cursor_line_number) do
+  def parse_string(source, try_to_fix_parse_error, try_to_fix_line_not_found, cursor_line_number) do
     case string_to_ast(source, if(try_to_fix_parse_error, do: 6, else: 0), cursor_line_number) do
       {:ok, ast, modified_source} ->
         acc = MetadataBuilder.build(ast)

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -15,7 +15,7 @@ defmodule ElixirSense.Core.Parser do
     end
   end
 
-  def parse_string(source, try_to_fix_parse_error, try_to_fix_line_not_found, cursor_line_number) do
+  def parse_string(source, try_to_fix_parse_error, try_to_fix_line_not_found, cursor_line_number) when is_integer(cursor_line_number) do
     case string_to_ast(source, if(try_to_fix_parse_error, do: 6, else: 0), cursor_line_number) do
       {:ok, ast, modified_source} ->
         acc = MetadataBuilder.build(ast)
@@ -259,7 +259,7 @@ defmodule ElixirSense.Core.Parser do
     String.length(line) - String.length(trimmed_line)
   end
 
-  defp fix_line_not_found(source, line_number) do
+  defp fix_line_not_found(source, line_number) when is_integer(line_number) do
     source
     |> String.split(["\n", "\r\n"])
     # by replacing a line here we risk introducing a syntax error

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -106,7 +106,11 @@ defmodule ElixirSense.Core.Source do
     end
   end
 
-  defp extract_struct_module({:ok, {:%, _, [{:__aliases__, _, module_list}, {:%{},_, fields}]}}) do
+  defp extract_struct_module({:ok, {:%, _, [{:__aliases__, _, module_list}, {:%{}, _, [{:|, _, [_expr, fields]}] }]}}) do
+    fields_names = Keyword.keys(fields) |> Enum.slice(0..-2)
+    {Module.concat(module_list), fields_names}
+  end
+  defp extract_struct_module({:ok, {:%, _, [{:__aliases__, _, module_list}, {:%{}, _, fields}]}}) do
     fields_names = Keyword.keys(fields) |> Enum.slice(0..-2)
     {Module.concat(module_list), fields_names}
   end

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -182,7 +182,13 @@ defmodule ElixirSense.Core.Source do
       {grapheme, rest} ->
         {new_pos, new_line, new_col} =
           if grapheme in ["\n", "\r\n"] do
-            {pos + 1, current_line + 1, 1}
+            if current_line == line do
+              # this is the line we're lookin for
+              # but it's shorter than expected
+              {pos, current_line, col}
+            else
+              {pos + 1, current_line + 1, 1}
+            end
           else
             {pos + 1, current_line, current_col + 1}
           end

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -498,7 +498,8 @@ defmodule ElixirSense.Core.State do
     |> Enum.max_by(fn
       {env_line, _} when env_line < line -> env_line
       _ -> 0
-    end, fn -> default_env() end)
+    end, fn -> {0, default_env()} end)
+    |> elem(1)
   end
 
   def default_env(), do: %ElixirSense.Core.State.Env{}

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -25,7 +25,8 @@ defmodule ElixirSense.Core.State do
     mods_funs_to_positions: %{},
     mods_funs: %{},
     lines_to_env: %{},
-    calls: %{}
+    calls: %{},
+    structs: %{}
   ]
 
   defmodule Env do
@@ -45,6 +46,7 @@ defmodule ElixirSense.Core.State do
       behaviours: [],
       scope: nil,
       scope_id: nil,
+      structs: %{}
     ]
   end
 
@@ -55,7 +57,7 @@ defmodule ElixirSense.Core.State do
 
   defmodule ModFunInfo do
     @moduledoc false
-    defstruct type: nil
+    defstruct type: nil, fields: nil
   end
 
   def current_aliases(state) do
@@ -91,7 +93,8 @@ defmodule ElixirSense.Core.State do
         [] -> nil
         [head|_] -> head
       end),
-      protocol_variants: current_scope_protocols
+      protocol_variants: current_scope_protocols,
+      structs: state.structs
     }
   end
 
@@ -123,6 +126,15 @@ defmodule ElixirSense.Core.State do
       end)
 
     %{state | calls: calls}
+  end
+
+  def add_struct(state, type, fields) do
+    structs = get_current_module_variants(state)
+    |> Enum.reduce(state.mods_funs, fn variant, acc ->
+      acc |> Map.put(variant, {type, fields})
+    end)
+
+    %{state | structs: structs}
   end
 
   def get_scope_name(state, line) do

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -57,7 +57,7 @@ defmodule ElixirSense.Core.State do
 
   defmodule ModFunInfo do
     @moduledoc false
-    defstruct type: nil, fields: nil
+    defstruct type: nil
   end
 
   def current_aliases(state) do

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -110,7 +110,7 @@ defmodule ElixirSense.Core.State do
     end
   end
 
-  def add_current_env_to_line(state, line) do
+  def add_current_env_to_line(state, line) when is_integer(line) do
     env = get_current_env(state)
     %{state | lines_to_env: Map.put(state.lines_to_env, line, env)}
   end

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -112,11 +112,15 @@ defmodule ElixirSense.Providers.Suggestion do
   @spec find(String.t, [module], [{module, module}], module, [String.t], [String.t], [module], State.scope, any, %{}, %{}, String.t) :: [suggestion]
   def find(hint, imports, aliases, module, vars, attributes, behaviours, scope, protocol, mods_and_funs, structs,  text_before) do
     case find_struct_fields(hint, text_before, imports, aliases, module, structs) do
-      [] ->
+      {[], _} ->
         find_all_except_struct_fields(hint, imports, aliases, vars, attributes, behaviours, scope, module, protocol, mods_and_funs, text_before)
 
-      fields ->
+      {fields, nil} ->
         [%{type: :hint, value: "#{hint}"} | fields]
+      {fields, :maybe_struct_update} ->
+        # TODO refactor hint generation
+        [_hint | rest] = find_mods_funs_vars_attributes(hint, imports, aliases, vars, attributes, module, mods_and_funs)
+        [%{type: :hint, value: "#{hint}"} | fields ++ rest]
     end
   end
 
@@ -141,6 +145,16 @@ defmodule ElixirSense.Providers.Suggestion do
     |> Enum.uniq_by(&(&1))
   end
 
+  defp find_mods_funs_vars_attributes(hint, imports, aliases, vars, attributes, module, mods_and_funs) do
+    vars = Enum.map(vars, fn v -> v.name end)
+    %{hint: hint_suggestion, suggestions: mods_and_funcs} = find_hint_mods_funcs(hint, imports, aliases, module, mods_and_funs)
+
+    [hint_suggestion]
+    |> Kernel.++(find_attributes(attributes, hint))
+    |> Kernel.++(find_vars(vars, hint))
+    |> Kernel.++(mods_and_funcs)
+  end
+
   defp find_struct_fields(hint, text_before, imports, aliases, module, structs) do
     with \
       {mod, fields_so_far} <- Source.which_struct(text_before),
@@ -156,12 +170,13 @@ defmodule ElixirSense.Providers.Suggestion do
         structs[actual_mod] |> elem(1) |> Enum.map(& &1 |> elem(0))
       end
 
-      fields
+      result = fields
       |> Kernel.--(fields_so_far)
       |> Enum.filter(fn field -> String.starts_with?("#{field}", hint)end)
       |> Enum.map(fn field -> %{type: :field, name: field, origin: Introspection.module_to_string(actual_mod)} end)
+      {result, if(fields_so_far == [], do: :maybe_struct_update)}
     else
-      _ -> []
+      _ -> {[], nil}
     end
   end
 

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -43,6 +43,16 @@ defmodule ElixirSense.Providers.Suggestion do
     spec: String.t
   }
 
+  @type protocol_function :: %{
+    type: :protocol_function,
+    name: String.t,
+    arity: non_neg_integer,
+    args: String.t,
+    origin: String.t,
+    summary: String.t,
+    spec: String.t
+  }
+
   @type func :: %{
     type: :function,
     name: String.t,
@@ -89,6 +99,7 @@ defmodule ElixirSense.Providers.Suggestion do
                     | field
                     | return
                     | callback
+                    | protocol_function
                     | func
                     | mod
                     | hint

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -98,9 +98,9 @@ defmodule ElixirSense.Providers.Suggestion do
   @doc """
   Finds all suggestions for a hint based on context information.
   """
-  @spec find(String.t, [module], [{module, module}], module, [String.t], [String.t], [module], State.scope, any, %{}, String.t) :: [suggestion]
-  def find(hint, imports, aliases, module, vars, attributes, behaviours, scope, protocol, mods_and_funs, text_before) do
-    case find_struct_fields(hint, text_before, imports, aliases, module) do
+  @spec find(String.t, [module], [{module, module}], module, [String.t], [String.t], [module], State.scope, any, %{}, %{}, String.t) :: [suggestion]
+  def find(hint, imports, aliases, module, vars, attributes, behaviours, scope, protocol, mods_and_funs, structs,  text_before) do
+    case find_struct_fields(hint, text_before, imports, aliases, module, structs) do
       [] ->
         find_all_except_struct_fields(hint, imports, aliases, vars, attributes, behaviours, scope, module, protocol, mods_and_funs, text_before)
 
@@ -130,16 +130,22 @@ defmodule ElixirSense.Providers.Suggestion do
     |> Enum.uniq_by(&(&1))
   end
 
-  defp find_struct_fields(hint, text_before, imports, aliases, module) do
+  defp find_struct_fields(hint, text_before, imports, aliases, module, structs) do
     with \
       {mod, fields_so_far} <- Source.which_struct(text_before),
       {actual_mod, _}      <- Introspection.actual_mod_fun({mod, nil}, imports, aliases, module),
-      true                 <- Introspection.module_is_struct?(actual_mod)
+      true                 <- Introspection.module_is_struct?(actual_mod) or Map.has_key?(structs, actual_mod)
     do
-      actual_mod
-      |> struct()
-      |> Map.from_struct()
-      |> Map.keys()
+      fields = if Introspection.module_is_struct?(actual_mod) do
+        actual_mod
+        |> struct()
+        |> Map.from_struct()
+        |> Map.keys()
+      else
+        structs[actual_mod] |> elem(1) |> Enum.map(& &1 |> elem(0))
+      end
+
+      fields
       |> Kernel.--(fields_so_far)
       |> Enum.filter(fn field -> String.starts_with?("#{field}", hint)end)
       |> Enum.map(fn field -> %{type: :field, name: field, origin: Introspection.module_to_string(actual_mod)} end)

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1587,7 +1587,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       assert state.structs == %{MyStruct => {:defstruct, [a_field: nil]}}
   end
 
-  test "find struct fields from attr" do
+  test "find struct fields from expression" do
     state = """
       defmodule MyStruct do
         @fields_1 [a: nil]
@@ -1596,7 +1596,8 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-      assert state.structs == %{MyStruct => {:defstruct, [a_field: nil]}}
+      # TODO expression is not supported
+      assert state.structs == %{MyStruct => {:defstruct, []}}
   end
 
   test "find exception" do

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1576,6 +1576,40 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       assert get_line_behaviours(state, 5) == [ElixirSenseExample.ExampleBehaviour]
   end
 
+  test "find struct" do
+    state = """
+      defmodule MyStruct do
+        defstruct [a_field: nil]
+      end
+      """
+      |> string_to_state
+
+      assert state.structs == %{MyStruct => {:defstruct, [a_field: nil]}}
+  end
+
+  test "find struct fields from attr" do
+    state = """
+      defmodule MyStruct do
+        @fields_1 [a: nil]
+        defstruct [a_field: nil] ++ @fields_1
+      end
+      """
+      |> string_to_state
+
+      assert state.structs == %{MyStruct => {:defstruct, [a_field: nil]}}
+  end
+
+  test "find exception" do
+    state = """
+      defmodule MyError do
+        defexception [my_field: nil]
+      end
+      """
+      |> string_to_state
+
+      assert state.structs == %{MyError => {:defexception, [my_field: nil]}}
+  end
+
   defp string_to_state(string) do
     string
     |> Code.string_to_quoted(columns: true)

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -479,6 +479,20 @@ defmodule ElixirSense.Core.SourceTest do
       assert which_struct(text_before(code, 7, 8)) == nil
       assert which_struct(text_before(code, 8, 9)) == {Mod, [:field1, :field2, :field3]}
     end
+
+    test "nested structs with multiple lines when line shorter than col" do
+      code = """
+      defmodule MyMod do
+        def my_func(par1) do
+          var = %Mod{
+            field1: %InnerMod{},
+
+          }
+        end
+      end
+      """
+      assert which_struct(text_before(code, 5, 7)) == {Mod, [:field1]}
+    end
   end
 
 end

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -493,6 +493,21 @@ defmodule ElixirSense.Core.SourceTest do
       """
       assert which_struct(text_before(code, 5, 7)) == {Mod, [:field1]}
     end
+
+    test "struct update syntax" do
+      code = """
+      defmodule MyMod do
+        def my_func(par1) do
+          var = %Mod{par1 |
+            field1: %InnerMod{},
+
+          }
+        end
+      end
+      """
+      assert which_struct(text_before(code, 3, 23)) == {Mod, []}
+      assert which_struct(text_before(code, 5, 7)) == {Mod, [:field1]}
+    end
   end
 
 end

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -10,7 +10,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "find definition of built-in functions" do
-    result = Suggestion.find("ElixirSenseExample.EmptyModule.", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, "")
+    result = Suggestion.find("ElixirSenseExample.EmptyModule.", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "")
     assert result |> Enum.at(0) == %{type: :hint, value: "ElixirSenseExample.EmptyModule."}
     assert result |> Enum.at(1) == %{
       args: "",
@@ -43,7 +43,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for 'Str'" do
-    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, "") == [
+    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "") == [
       %{type: :hint, value: "Str"},
       %{name: "Stream", subtype: :struct, summary: "Functions for creating and composing streams.", type: :module},
       %{name: "String", subtype: nil, summary: "A String in Elixir is a UTF-8 encoded binary.", type: :module},
@@ -56,7 +56,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
       %{type: :hint, value: "List.delete"},
       %{args: "list," <> _, arity: 2, name: "delete", origin: "List", spec: "@spec delete(" <> _, summary: "Deletes the given" <> _, type: "function"},
       %{args: "list,index", arity: 2, name: "delete_at", origin: "List", spec: "@spec delete_at(list, integer) :: list", summary: "Produces a new list by " <> _, type: "function"}
-    ] = Suggestion.find("List.del", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, "")
+    ] = Suggestion.find("List.del", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "")
   end
 
   test "return completion candidates for module with alias" do
@@ -64,11 +64,11 @@ defmodule ElixirSense.Providers.SuggestionTest do
       %{type: :hint, value: "MyList.delete"},
       %{args: "list," <> _, arity: 2, name: "delete", origin: "List", spec: "@spec delete(" <> _, summary: "Deletes the given " <> _, type: "function"},
       %{args: "list,index", arity: 2, name: "delete_at", origin: "List", spec: "@spec delete_at(list, integer) :: list", summary: "Produces a new list " <> _, type: "function"}
-    ] = Suggestion.find("MyList.del", [], [{MyList, List}], SomeModule, [], [], [], SomeModule, nil, %{}, "")
+    ] = Suggestion.find("MyList.del", [], [{MyList, List}], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "")
   end
 
   test "return completion candidates for functions from import" do
-    assert Suggestion.find("say", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, "") == [
+    assert Suggestion.find("say", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "") == [
       %{type: :hint, value: "say_hi"},
       %{args: "", arity: 0, name: "say_hi", origin: "ElixirSense.Providers.SuggestionTest.MyModule", spec: nil, summary: "", type: "function"}
     ]
@@ -76,14 +76,14 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   test "local calls should not return built-in functions" do
     list =
-      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, "")
+      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "")
       |> Enum.filter(fn item -> item.type in [:hint, "function", "function"] end)
 
     assert list == [%{type: :hint, value: "mo"}]
   end
 
   test "empty hint should not return built-in functions" do
-    suggestions_names = Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, nil,  %{}, "")
+    suggestions_names = Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, nil,  %{}, %{}, "")
       |> Enum.filter(&Map.has_key?(&1, :name))
       |> Enum.map(&(&1.name))
 
@@ -95,19 +95,19 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for struct starting with %" do
-    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
+    assert [%{type: :hint, value: "%ElixirSense.Providers.SuggestionTest.MyStruct"} | _] = Suggestion.find("%ElixirSense.Providers.SuggestionTest.MyStr", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, %{}, "")
   end
 
   test "return completion candidates for &func" do
-    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
+    assert [%{type: :hint, value: "f = &Enum.all?"} | _] = Suggestion.find("f = &Enum.al", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, %{}, "")
   end
 
   test "do not return completion candidates for unknown erlang modules" do
-    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
+    assert [%{type: :hint, value: "Enum:"}] = Suggestion.find("Enum:", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, %{}, "")
   end
 
   test "do not return completion candidates for unknown modules" do
-    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, "")
+    assert [%{type: :hint, value: "x.Foo.get_by"}] = Suggestion.find("x.Foo.get_by", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{}, %{}, "")
   end
 
   test "return completion candidates for metadata modules" do
@@ -115,10 +115,19 @@ defmodule ElixirSense.Providers.SuggestionTest do
       SomeModule => %{
         {:my_func, 1} => %ElixirSense.Core.State.ModFunInfo{type: :defp}
       }
-    }, "")
+    }, %{}, "")
 
     assert [%{type: :hint, value: "SomeModule"} | _] = Suggestion.find("So", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{
       SomeModule => %{}
-    }, "")
+    }, %{}, "")
+  end
+
+  test "return completion candidates for metadata structs" do
+    assert [
+      %{type: :hint, value: "str_"},
+      %{name: :str_field, origin: "SomeModule", type: :field}
+    ] = Suggestion.find("str_", [MyModule], [], SomeModule, [], [], [], {:func, 0}, nil, %{
+      SomeModule => %{}
+    }, %{SomeModule => {:defstruct, [str_field: 1]}}, "%SomeModule{st")
   end
 end

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -851,6 +851,22 @@ defmodule ElixirSense.SuggestionsTest do
     assert Enum.any?(list, fn %{type: type} -> type == :field end) == false
   end
 
+  test "suggestion for exception fields" do
+    buffer = """
+    defmodule MyServer do
+      def func do
+        raise ArgumentError, m
+      end
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 3, 28)
+
+    assert list == [%{type: :hint, value: ""},
+    %{name: :message, origin: "ArgumentError", type: :field}]
+  end
+
   describe "suggestion for param options" do
 
     test "suggest more than one option" do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -839,6 +839,59 @@ defmodule ElixirSense.SuggestionsTest do
     ]
   end
 
+  test "suggestion for metadata struct fields" do
+    buffer = """
+    defmodule MyServer do
+      defstruct [
+        field_1: nil,
+        field_2: ""
+      ]
+
+      def func do
+        %MyServer{}
+        %MyServer{field_2: "2",}
+      end
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 8, 15)
+
+    assert list == [%{type: :hint, value: ""},
+    %{name: :field_1, origin: "MyServer", type: :field},
+    %{name: :field_2, origin: "MyServer", type: :field}]
+
+    list =
+      ElixirSense.suggestions(buffer, 9, 28)
+
+    assert list == [%{type: :hint, value: ""},
+    %{name: :field_1, origin: "MyServer", type: :field}]
+  end
+
+  test "suggestion for metadata struct fields multiline" do
+    buffer = """
+    defmodule MyServer do
+      defstruct [
+        field_1: nil,
+        field_2: ""
+      ]
+
+      def func do
+        %MyServer{
+          field_2: "2",
+
+        }
+      end
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 10, 7)
+
+    assert list == [%{type: :hint, value: ""},
+    %{name: :field_1, origin: "MyServer", type: :field}]
+  end
+
   test "no suggestion of fields when the module is not a struct" do
     buffer =
       """


### PR DESCRIPTION
With this PR elixir_sense is able to produce suggestions for struct fields of metadata modules. It also fixes not always working multiline field suggestions and a crash in struct update syntax