### PR TITLE
Track pipe and capture calls

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -317,15 +317,15 @@ defmodule ElixirSense do
         %{
           uri: "test/support/modules_with_references.ex",
           range: %{
-            start: %{line: 26, column: 60},
-            end: %{line: 26, column: 64}
+            start: %{line: 36, column: 60},
+            end: %{line: 36, column: 64}
           }
         },
         %{
           uri: "test/support/modules_with_references.ex",
           range: %{
-            start: %{line: 42, column: 16},
-            end: %{line: 42, column: 20}
+            start: %{line: 65, column: 16},
+            end: %{line: 65, column: 20}
           }
         }
       ]

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -352,9 +352,17 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result({:=, meta, [:_, rhs]})
   end
 
-  defp pre({var_or_call, [line: _line, column: _column], context} = ast, state) when is_atom(var_or_call) and context in [nil, Elixir] do
-    state
-    |> add_vars(find_vars(ast), false)
+  defp pre({var_or_call, [line: line, column: column], context} = ast, state) when is_atom(var_or_call) and context in [nil, Elixir] do
+    if Enum.any?(get_current_vars(state), & &1.name == var_or_call) do
+      state
+      |> add_vars(find_vars(ast), false)
+    else
+      # pre Elixir 1.4 local call syntax
+      # TODO remove on Elixir 2.0
+      state
+      |> add_call_to_line({nil, var_or_call, 0}, line, column)
+      |> add_current_env_to_line(line)
+    end
     |> result(ast)
   end
 
@@ -436,8 +444,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result(ast)
   end
 
-  defp pre({{:., _, [{:__aliases__, _, mod_path}, call]}, [line: line, column: col], params} = ast, state)
-       when is_call(call, params) do
+  defp pre({{:., _, [{:__aliases__, _, mod_path}, call]}, [line: line, column: col], params} = ast, state) when is_call(call, params) do
     mod = Module.concat(mod_path)
     state
     |> add_call_to_line({mod, call, length(params)}, line, col)

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1804,6 +1804,33 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       %{arity: 1, col: 27, func: :other, line: 3, mod: nil},
       ]}
   end
+
+  test "registers calls capture operator external" do
+    state = """
+      defmodule NyModule do
+        def func do
+          &MyMod.func/1
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 1, col: 11, func: :func, line: 3, mod: MyMod}]}
+  end
+
+  test "registers calls capture operator local" do
+    state = """
+      defmodule NyModule do
+        def func do
+          &func/1
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 1, col: 6, func: :func, line: 3, mod: nil}]}
+  end
+
   defp string_to_state(string) do
     string
     |> Code.string_to_quoted(columns: true)

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1611,6 +1611,83 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       assert state.structs == %{MyError => {:defexception, [my_field: nil]}}
   end
 
+  test "registers calls no arg no parens" do
+    state = """
+      defmodule NyModule do
+        def func do
+          MyMod.func
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 0, col: 10, func: :func, line: 3, mod: MyMod}]}
+  end
+
+  test "registers calls no arg" do
+    state = """
+      defmodule NyModule do
+        def func do
+          MyMod.func()
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 0, col: 10, func: :func, line: 3, mod: MyMod}]}
+  end
+
+  test "registers calls local no arg no parens" do
+    state = """
+      defmodule NyModule do
+        def func do
+          func_1
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 0, col: 5, func: :func_1, line: 3, mod: nil}]}
+  end
+
+  test "registers calls local no arg" do
+    state = """
+      defmodule NyModule do
+        def func do
+          func_1()
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 0, col: 5, func: :func_1, line: 3, mod: nil}]}
+  end
+
+  test "registers calls local arg" do
+    state = """
+      defmodule NyModule do
+        def func do
+          func_1("a")
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 1, col: 5, func: :func_1, line: 3, mod: nil}]}
+  end
+
+  test "registers calls arg" do
+    state = """
+      defmodule NyModule do
+        def func do
+          MyMod.func("test")
+        end
+      end
+      """
+      |> string_to_state
+
+    assert state.calls == %{3 => [%{arity: 1, col: 10, func: :func, line: 3, mod: MyMod}]}
+  end
   defp string_to_state(string) do
     string
     |> Code.string_to_quoted(columns: true)

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -18,15 +18,15 @@ defmodule ElixirSense.Providers.ReferencesTest do
     assert references == [
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 26, column: 60}, end: %{line: 26, column: 64}}
+        range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 16}, end: %{line: 42, column: 20}}
+        range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 63}, end: %{line: 42, column: 67}}
+        range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
       }
     ]
   end
@@ -48,15 +48,15 @@ defmodule ElixirSense.Providers.ReferencesTest do
     assert references == [
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 26, column: 60}, end: %{line: 26, column: 64}}
+        range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 16}, end: %{line: 42, column: 20}}
+        range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 63}, end: %{line: 42, column: 67}}
+        range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
       }
     ]
 
@@ -64,11 +64,11 @@ defmodule ElixirSense.Providers.ReferencesTest do
     assert references == [
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 32, column: 60}, end: %{line: 32, column: 64}}
+        range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 79}, end: %{line: 42, column: 83}}
+        range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
       }
     ]
   end
@@ -87,11 +87,88 @@ defmodule ElixirSense.Providers.ReferencesTest do
     assert references == [
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 32, column: 60}, end: %{line: 32, column: 64}}
+        range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 79}, end: %{line: 42, column: 83}}
+        range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+      }
+    ]
+  end
+
+  test "find references with cursor over a function with arity 1 called via pipe operator" do
+    buffer = """
+    defmodule Caller do
+      def func() do
+        "test"
+        |> ElixirSense.Providers.ReferencesTest.Modules.Callee4.func_arg()
+        #                                                        ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 4, 62)
+    assert references == [
+      %{
+        uri: "test/support/modules_with_references.ex",
+        range: %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+      },
+    ]
+  end
+
+  test "find references with cursor over a function with arity 1 captured" do
+    buffer = """
+    defmodule Caller do
+      def func() do
+        Task.start(&ElixirSense.Providers.ReferencesTest.Modules.Callee4.func_arg/1)
+        #                                                                  ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 3, 72)
+    assert references == [
+      %{
+        uri: "test/support/modules_with_references.ex",
+        range: %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+      },
+    ]
+  end
+
+  test "find references with cursor over a function when caller uses pipe operator" do
+    buffer = """
+    defmodule Caller do
+      def func() do
+        ElixirSense.Providers.ReferencesTest.Modules.Callee4.func_arg("test")
+        #                                                     ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 3, 59)
+    assert references == [
+      %{
+        uri: "test/support/modules_with_references.ex",
+        range: %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+      },
+    ]
+  end
+
+  test "find references with cursor over a function when caller uses capture operator" do
+    buffer = """
+    defmodule Caller do
+      def func() do
+        ElixirSense.Providers.ReferencesTest.Modules.Callee4.func_no_arg()
+        #                                                     ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 3, 59)
+    assert references == [
+      %{
+        uri: "test/support/modules_with_references.ex",
+        range: %{start: %{line: 55, column: 72}, end: %{line: 55, column: 83}}
       }
     ]
   end
@@ -111,15 +188,15 @@ defmodule ElixirSense.Providers.ReferencesTest do
     assert references == [
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 26, column: 60}, end: %{line: 26, column: 64}}
+        range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 16}, end: %{line: 42, column: 20}}
+        range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 63}, end: %{line: 42, column: 67}}
+        range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
       }
     ]
   end
@@ -137,7 +214,7 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     assert reference == %{
       uri: "test/support/modules_with_references.ex",
-      range: %{start: %{line: 42, column: 47}, end: %{line: 42, column: 51}}
+      range: %{start: %{line: 65, column: 47}, end: %{line: 65, column: 51}}
     }
   end
 
@@ -154,7 +231,7 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     assert reference == %{
       uri: "test/support/modules_with_references.ex",
-      range: %{start: %{line: 47, column: 8}, end: %{line: 47, column: 12}}
+      range: %{start: %{line: 70, column: 8}, end: %{line: 70, column: 12}}
     }
   end
 
@@ -195,23 +272,23 @@ defmodule ElixirSense.Providers.ReferencesTest do
     assert references == [
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 26, column: 60}, end: %{line: 26, column: 64}}
+        range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 32, column: 60}, end: %{line: 32, column: 64}}
+        range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 16}, end: %{line: 42, column: 20}}
+        range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 63}, end: %{line: 42, column: 67}}
+        range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
       },
       %{
         uri: "test/support/modules_with_references.ex",
-        range: %{start: %{line: 42, column: 79}, end: %{line: 42, column: 83}}
+        range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
       }
     ]
   end

--- a/test/support/modules_with_references.ex
+++ b/test/support/modules_with_references.ex
@@ -21,6 +21,16 @@ defmodule ElixirSense.Providers.ReferencesTest.Modules do
     end
   end
 
+  defmodule Callee4 do
+    def func_no_arg() do
+      IO.puts ""
+    end
+
+    def func_arg(arg) do
+      IO.puts "" <> arg
+    end
+  end
+
   defmodule Caller1 do
     def func() do
       ElixirSense.Providers.ReferencesTest.Modules.Callee1.func()
@@ -30,6 +40,19 @@ defmodule ElixirSense.Providers.ReferencesTest.Modules do
   defmodule Caller2 do
     def func() do
       ElixirSense.Providers.ReferencesTest.Modules.Callee1.func("test")
+    end
+  end
+
+  defmodule Caller3 do
+    def func() do
+      "test"
+      |> ElixirSense.Providers.ReferencesTest.Modules.Callee4.func_arg()
+    end
+  end
+
+  defmodule Caller4 do
+    def func() do
+      Task.start(&ElixirSense.Providers.ReferencesTest.Modules.Callee4.func_no_arg/0)
     end
   end
 


### PR DESCRIPTION
With this PR elixir_sense will track function calls by `|>` operator and function captures by `&Mod.fun/arity`