### PR TITLE
Use nesting in documentation to handle the long module names

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,10 @@ defmodule ElixirSense.Mixfile do
   end
 
   defp docs do
-    [main: "ElixirSense"]
+    [
+      main: "ElixirSense",
+      nest_modules_by_prefix: [ElixirSense.Core, ElixirSense.Providers, ElixirSense.Server]
+    ]
   end
 
   defp description do


### PR DESCRIPTION
Before:
![elixir_sense_docs_before](https://user-images.githubusercontent.com/9973/63330874-48178d80-c2d0-11e9-88df-4b9ec986f0ee.png)

After:
![elixir_sense_docs_after](https://user-images.githubusercontent.com/9973/63330882-4c43ab00-c2d0-11e9-86b5-161f9652de02.png)
