### PR TITLE
Add support for atoms as module names

### DIFF
--- a/lib/elixir_sense/core/ast.ex
+++ b/lib/elixir_sense/core/ast.ex
@@ -289,8 +289,12 @@ defmodule ElixirSense.Core.Ast do
   end
 
   defp extract_aliases([mod]) when is_atom(mod) do
-    alias = Module.split(mod) |> Enum.take(-1) |> Module.concat()
-    [{alias, mod}]
+    if Introspection.elixir_module?(mod) do
+      alias = Module.split(mod) |> Enum.take(-1) |> Module.concat()
+      [{alias, mod}]
+    else
+      [{mod, mod}]
+    end
   end
 
   defp extract_aliases([{{:., _, [prefix, :{}]}, _, suffixes}]) when is_list(suffixes) do

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -291,12 +291,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
           [{{:., _, [{:__aliases__, _, prefix_atoms}, :{}]}, _, imports}]} = ast,
          state
        ) do
-    imports_modules =
-      imports
-      |> Enum.map(fn
-        {:__aliases__, _, mods} -> Module.concat(prefix_atoms ++ mods)
-        mod when is_atom(mod) -> Module.concat(prefix_atoms ++ [mod])
-      end)
+    imports_modules = modules_from_12_syntax(imports, prefix_atoms)
 
     pre_import(ast, state, line, imports_modules)
   end
@@ -329,12 +324,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
           [{{:., _, [{:__aliases__, _, prefix_atoms}, :{}]}, _, requires}]} = ast,
          state
        ) do
-    requires_modules =
-      requires
-      |> Enum.map(fn
-        {:__aliases__, _, mods} -> Module.concat(prefix_atoms ++ mods)
-        mod when is_atom(mod) -> Module.concat(prefix_atoms ++ [mod])
-      end)
+    requires_modules = modules_from_12_syntax(requires, prefix_atoms)
 
     pre_require(ast, state, line, requires_modules)
   end
@@ -750,5 +740,13 @@ defmodule ElixirSense.Core.MetadataBuilder do
   defp alias_tuple(module, {:__aliases__, _, alias_atoms = [al | _]})
        when is_atom(module) and is_atom(al) do
     {Module.concat(alias_atoms), module}
+  end
+
+  defp modules_from_12_syntax(expressions, prefix_atoms) do
+    expressions
+    |> Enum.map(fn
+      {:__aliases__, _, mods} -> Module.concat(prefix_atoms ++ mods)
+      mod when is_atom(mod) -> Module.concat(prefix_atoms ++ [mod])
+    end)
   end
 end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -197,6 +197,10 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_module(ast, state, {line, column}, module)
   end
 
+  defp pre({:defmodule, [line: line, column: column], [module, _]} = ast, state) when is_atom(module) do
+    pre_module(ast, state, {line, column}, module)
+  end
+
   defp pre(
          {:defprotocol, _, [{:__aliases__, [line: line, column: column], module}, _]} = ast,
          state
@@ -606,6 +610,10 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   defp post({:defmodule, _, [{:__aliases__, _, module}, _]} = ast, state) do
+    post_module(ast, state, module)
+  end
+
+  defp post({:defmodule, _, [module, _]} = ast, state) when is_atom(module) do
     post_module(ast, state, module)
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -198,7 +198,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_module(ast, state, {line, column}, module)
   end
 
-  defp pre({:defmodule, [line: line, column: column], [module, _]} = ast, state) when is_atom(module) do
+  defp pre({:defmodule, [line: line, column: column], [module, _]} = ast, state)
+       when is_atom(module) do
     pre_module(ast, state, {line, column}, module)
   end
 
@@ -209,7 +210,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_module(ast, state, {line, column}, module)
   end
 
-  defp pre({:defprotocol, [line: line, column: column], [module, _]} = ast, state) when is_atom(module) do
+  defp pre({:defprotocol, [line: line, column: column], [module, _]} = ast, state)
+       when is_atom(module) do
     pre_module(ast, state, {line, column}, module)
   end
 
@@ -223,11 +225,10 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   defp pre(
-         {:defimpl, [line: line, column: column],
-          [protocol, [for: implementations], _]} =
-           ast,
+         {:defimpl, [line: line, column: column], [protocol, [for: implementations], _]} = ast,
          state
-       ) when is_atom(protocol) do
+       )
+       when is_atom(protocol) do
     pre_protocol_implementation(ast, state, {line, column}, protocol, implementations)
   end
 
@@ -317,7 +318,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   # atom module
-  defp pre({:import, [line: line, column: _column], [atom | _] = ast}, state) when is_atom(atom) do
+  defp pre({:import, [line: line, column: _column], [atom | _] = ast}, state)
+       when is_atom(atom) do
     pre_import(ast, state, line, atom)
   end
 
@@ -343,7 +345,12 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   # require with `as` option
-  defp pre({:require, [line: line, column: _column], [{_, _, module_atoms = [mod | _]}, [as: alias_expression]]} = ast, state) when is_atom(mod) do
+  defp pre(
+         {:require, [line: line, column: _column],
+          [{_, _, module_atoms = [mod | _]}, [as: alias_expression]]} = ast,
+         state
+       )
+       when is_atom(mod) do
     alias_tuple = alias_tuple(Module.concat(module_atoms), alias_expression)
     module = module_atoms |> Module.concat()
     {_, new_state} = pre_alias(ast, state, line, alias_tuple)
@@ -351,24 +358,35 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   # require erlang module with `as` option
-  defp pre({:require, [line: line, column: _column], [mod, [as: alias_expression]]} = ast, state) when is_atom(mod) do
+  defp pre({:require, [line: line, column: _column], [mod, [as: alias_expression]]} = ast, state)
+       when is_atom(mod) do
     alias_tuple = alias_tuple(mod, alias_expression)
     {_, new_state} = pre_alias(ast, state, line, alias_tuple)
     pre_require(ast, new_state, line, mod)
   end
 
   # require with options
-  defp pre({:require, [line: line, column: _column], [{_, _, module_atoms = [mod | _]}, _opts]} = ast, state) when is_atom(mod) do
+  defp pre(
+         {:require, [line: line, column: _column], [{_, _, module_atoms = [mod | _]}, _opts]} =
+           ast,
+         state
+       )
+       when is_atom(mod) do
     module = module_atoms |> Module.concat()
     pre_require(ast, state, line, module)
   end
 
-  defp pre({:require, [line: line, column: _column], [mod, _opts]} = ast, state) when is_atom(mod) do
+  defp pre({:require, [line: line, column: _column], [mod, _opts]} = ast, state)
+       when is_atom(mod) do
     pre_require(ast, state, line, mod)
   end
 
   # alias with v1.2 notation
-  defp pre({:alias, [line: line, column: _column], [{{:., _, [{:__aliases__, _, prefix_atoms}, :{}]}, _, aliases}]} = ast, state) do
+  defp pre(
+         {:alias, [line: line, column: _column],
+          [{{:., _, [{:__aliases__, _, prefix_atoms}, :{}]}, _, aliases}]} = ast,
+         state
+       ) do
     aliases_tuples =
       aliases
       |> Enum.map(fn
@@ -380,29 +398,42 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   # alias without options
-  defp pre({:alias, [line: line, column: _column], [{:__aliases__, _, module_atoms = [mod | _]}]} = ast, state) when is_atom(mod) do
+  defp pre(
+         {:alias, [line: line, column: _column], [{:__aliases__, _, module_atoms = [mod | _]}]} =
+           ast,
+         state
+       )
+       when is_atom(mod) do
     alias_tuple = {Module.concat([List.last(module_atoms)]), Module.concat(module_atoms)}
     pre_alias(ast, state, line, alias_tuple)
   end
 
   # alias with `as` option
-  defp pre({:alias, [line: line, column: _column], [{_, _, module_atoms = [mod | _]}, [as: alias_expression]]} = ast, state) when is_atom(mod) do
+  defp pre(
+         {:alias, [line: line, column: _column],
+          [{_, _, module_atoms = [mod | _]}, [as: alias_expression]]} = ast,
+         state
+       )
+       when is_atom(mod) do
     alias_tuple = alias_tuple(Module.concat(module_atoms), alias_expression)
     pre_alias(ast, state, line, alias_tuple)
   end
 
   # alias atom module
   defp pre({:alias, [line: line, column: _column], [mod]} = ast, state) when is_atom(mod) do
-    alias_tuple = if Introspection.elixir_module?(mod) do
-      {Module.concat([List.last(Module.split(mod))]), mod}
-    else
-      {mod, mod}
-    end
+    alias_tuple =
+      if Introspection.elixir_module?(mod) do
+        {Module.concat([List.last(Module.split(mod))]), mod}
+      else
+        {mod, mod}
+      end
+
     pre_alias(ast, state, line, alias_tuple)
   end
 
   # alias atom module with `as` option
-  defp pre({:alias, [line: line, column: _column], [mod, [as: alias_expression]]} = ast, state) when is_atom(mod) do
+  defp pre({:alias, [line: line, column: _column], [mod, [as: alias_expression]]} = ast, state)
+       when is_atom(mod) do
     alias_tuple = alias_tuple(mod, alias_expression)
     pre_alias(ast, state, line, alias_tuple)
   end
@@ -612,7 +643,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
     post_protocol_implementation(ast, state, protocol, implementations)
   end
 
-  defp post({:defimpl, _, [protocol, [for: implementations], _]} = ast, state) when is_atom(protocol) do
+  defp post({:defimpl, _, [protocol, [for: implementations], _]} = ast, state)
+       when is_atom(protocol) do
     post_protocol_implementation(ast, state, protocol, implementations)
   end
 
@@ -686,7 +718,13 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_module(ast, state, position, {protocol, modules})
   end
 
-  defp pre_protocol_implementation(ast, state, position, protocol, {:__aliases__, _, implementation}) do
+  defp pre_protocol_implementation(
+         ast,
+         state,
+         position,
+         protocol,
+         {:__aliases__, _, implementation}
+       ) do
     pre_module(ast, state, position, {protocol, [implementation]})
   end
 
@@ -709,7 +747,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
     {alias_module, module}
   end
 
-  defp alias_tuple(module, {:__aliases__, _, alias_atoms = [al | _]}) when is_atom(module) and is_atom(al) do
+  defp alias_tuple(module, {:__aliases__, _, alias_atoms = [al | _]})
+       when is_atom(module) and is_atom(al) do
     {Module.concat(alias_atoms), module}
   end
 end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -7,6 +7,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
   alias ElixirSense.Core.Ast
   alias ElixirSense.Core.State
   alias ElixirSense.Core.State.VarInfo
+  alias ElixirSense.Core.Introspection
 
   @scope_keywords [:for, :try, :fn]
   @block_keywords [:do, :else, :rescue, :catch, :after]
@@ -414,7 +415,22 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_alias(ast, state, line, alias_tuple)
   end
 
-  # alias erlang module with `as` option
+  # alias atom module
+  defp pre(
+         {:alias, [line: line, column: _column],
+          [mod]} = ast,
+         state
+       )
+       when is_atom(mod) do
+    alias_tuple = if Introspection.elixir_module?(mod) do
+      {Module.concat([List.last(Module.split(mod))]), mod}
+    else
+      {mod, mod}
+    end
+    pre_alias(ast, state, line, alias_tuple)
+  end
+
+  # alias atom module with `as` option
   defp pre(
          {:alias, [line: line, column: _column],
           [mod, [as: {:__aliases__, _, alias_atoms = [al | _]}]]} = ast,

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -292,8 +292,9 @@ defmodule ElixirSense.Core.MetadataBuilder do
        ) do
     imports_modules =
       imports
-      |> Enum.map(fn {:__aliases__, _, mods} ->
-        Module.concat(prefix_atoms ++ mods)
+      |> Enum.map(fn
+        {:__aliases__, _, mods} -> Module.concat(prefix_atoms ++ mods)
+        mod when is_atom(mod) -> Module.concat(prefix_atoms ++ [mod])
       end)
 
     pre_import(ast, state, line, imports_modules)
@@ -315,8 +316,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_import(ast, state, line, module)
   end
 
-  # erlang module
-  defp pre({:import, [line: line, column: _column], [atom] = ast}, state) when is_atom(atom) do
+  # atom module
+  defp pre({:import, [line: line, column: _column], [atom | _] = ast}, state) when is_atom(atom) do
     pre_import(ast, state, line, atom)
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -717,7 +717,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   defp get_implementations_from_for_expression(state, for_expression) do
     for_expression
-    |> List.wrap
+    |> List.wrap()
     |> Enum.map(fn
       {:__aliases__, _, implementation} -> implementation
       module when is_atom(module) -> module

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -56,6 +56,8 @@ defmodule ElixirSense.Core.State do
     defstruct type: nil
   end
 
+  alias ElixirSense.Core.Introspection
+
   def current_aliases(state) do
     state.aliases |> List.flatten() |> Enum.uniq_by(&elem(&1, 0)) |> Enum.reverse()
   end
@@ -202,10 +204,14 @@ defmodule ElixirSense.Core.State do
   def escape_protocol_impementations(module_parts), do: module_parts
 
   def unescape_protocol_impementations(module) when is_atom(module) do
-    Module.split(module)
-    |> Enum.reverse()
-    |> Enum.map(&String.to_atom/1)
-    |> unescape_protocol_impementations
+    if Introspection.elixir_module?(module) do
+      Module.split(module)
+      |> Enum.reverse()
+      |> Enum.map(&String.to_atom/1)
+      |> unescape_protocol_impementations
+    else
+      [module]
+    end
   end
 
   def unescape_protocol_impementations(parts) do
@@ -247,11 +253,14 @@ defmodule ElixirSense.Core.State do
               {namespace, scopes}
           end
 
-        module ->
+        module when is_list(module) ->
           module_reversed = :lists.reverse(module)
           namespace = module_reversed ++ hd(state.namespace)
           scopes = module_reversed ++ hd(state.scopes)
           {namespace, scopes}
+
+        module when is_atom(module) ->
+          {module, [module]}
       end
 
     %{state | namespace: [namespace | state.namespace], scopes: [scopes | state.scopes]}
@@ -265,7 +274,7 @@ defmodule ElixirSense.Core.State do
 
     state = %{state | namespace: outer_mods, scopes: outer_scopes}
 
-    if length(outer_scopes) > 1 and state.protocols |> hd == [] do
+    if length(outer_scopes) > 1 and state.protocols |> hd == [] and is_list(module) do
       # submodule defined, create alias in outer module namespace
 
       # take only outermost submodule part as deeply nested submodules do not create aliases

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -195,6 +195,7 @@ defmodule ElixirSense.Core.State do
           parts
           |> Enum.map(&Atom.to_string/1)
           |> Enum.join(@dot_marker)
+
         module when is_atom(module) ->
           Atom.to_string(module) |> String.replace("Elixir.", "")
       end)
@@ -306,15 +307,17 @@ defmodule ElixirSense.Core.State do
         module when is_list(module) ->
           expanded = expand_alias(state, Module.concat(module))
           unescape_protocol_impementations(expanded)
+
         module when is_atom(module) ->
           unescape_protocol_impementations(module)
       end)
 
-    candidate = if is_list(protocol) do
-      expand_alias(state, Module.concat(protocol))
-    else
-      protocol
-    end
+    candidate =
+      if is_list(protocol) do
+        expand_alias(state, Module.concat(protocol))
+      else
+        protocol
+      end
 
     protocols =
       unescape_protocol_impementations(candidate)

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -190,23 +190,17 @@ defmodule ElixirSense.Core.State do
   def escape_protocol_impementations({protocol, implementations}) do
     joined_implementations =
       implementations
-      |> Enum.map(fn
+      |> Enum.map_join(@or_marker, fn
         parts when is_list(parts) ->
           parts
-          |> Enum.map(&Atom.to_string/1)
-          |> Enum.join(@dot_marker)
+          |> Enum.map_join(@dot_marker, &Atom.to_string/1)
 
         module when is_atom(module) ->
           Atom.to_string(module) |> String.replace("Elixir.", "")
       end)
-      |> Enum.join(@or_marker)
       |> String.to_atom()
 
-    if is_list(protocol) do
-      protocol
-    else
-      [protocol]
-    end ++ [joined_implementations]
+    List.wrap(protocol) ++ [joined_implementations]
   end
 
   def escape_protocol_impementations(module_parts), do: module_parts

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1459,6 +1459,19 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_behaviours(state, 3) == [:gen_server]
   end
 
+  test "behaviour from atom module" do
+    state =
+      """
+      defmodule OuterModule do
+        @behaviour :"Elixir.My.Behavior"
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_behaviours(state, 3) == [My.Behavior]
+  end
+
   test "behaviour duplicated" do
     state =
       """

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -728,6 +728,20 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_aliases(state, 4) == [{Ets, :ets}]
   end
 
+  test "aliases atom module" do
+    state =
+      """
+      defmodule MyModule do
+        alias :"Elixir.A.B"
+        alias :"Elixir.A.C", as: S
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_aliases(state, 4) == [{B, A.B}, {S, A.C}]
+  end
+
   test "aliases defined with v1.2 notation (multiline)" do
     state =
       """

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1193,6 +1193,42 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
            ]
   end
 
+  test "protocol implementation for atom modules" do
+    state =
+      """
+      defprotocol :my_reversible do
+        def reverse(term)
+        IO.puts ""
+      end
+
+      defimpl :my_reversible, for: [String, :my_str, :"Elixir.MyStr"] do
+        def reverse(term), do: String.reverse(term)
+        IO.puts ""
+      end
+
+      defprotocol :"Elixir.My.Reversible" do
+        def reverse(term)
+        IO.puts ""
+      end
+
+      defimpl :"Elixir.My.Reversible", for: [String, :my_str, :"Elixir.MyStr"] do
+        def reverse(term), do: String.reverse(term)
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_module(state, 3) == :my_reversible
+    assert get_line_protocol(state, 3) == nil
+    assert get_line_module(state, 8) == [:"Elixir.my_reversible.String", :"Elixir.my_reversible.my_str", :"Elixir.my_reversible.MyStr"]
+    assert get_line_protocol(state, 8) == {:my_reversible, [String, :my_str, MyStr]}
+
+    assert get_line_module(state, 13) == My.Reversible
+    assert get_line_protocol(state, 13) == nil
+    assert get_line_module(state, 18) == [My.Reversible.String, :"Elixir.My.Reversible.my_str", My.Reversible.MyStr]
+    assert get_line_protocol(state, 18) == {My.Reversible, [String, :my_str, MyStr]}
+  end
+
   test "protocol implementation module naming rules" do
     state =
       """

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1060,6 +1060,72 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_module(state, 20) == Some.Nested
   end
 
+  test "current module atom" do
+    state =
+      """
+      IO.puts ""
+      defmodule :outer_module do
+        IO.puts ""
+        defmodule :inner_module do
+          def func do
+            if true do
+              IO.puts ""
+            end
+          end
+        end
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_module(state, 1) == Elixir
+    assert get_line_protocol(state, 1) == nil
+    assert get_line_module(state, 3) == :outer_module
+    assert get_line_protocol(state, 3) == nil
+    assert get_line_module(state, 7) == :inner_module
+    assert get_line_protocol(state, 7) == nil
+    assert get_line_module(state, 11) == :outer_module
+    assert get_line_protocol(state, 11) == nil
+  end
+
+  test "current module as atom" do
+    state =
+      """
+      IO.puts ""
+      defmodule :"Elixir.OuterModule" do
+        IO.puts ""
+        defmodule :"Elixir.InnerModule" do
+          def func do
+            if true do
+              IO.puts ""
+            end
+          end
+        end
+        IO.puts ""
+
+        defmodule :"Elixir.OuterModule.InnerModule1" do
+          def func do
+            if true do
+              IO.puts ""
+            end
+          end
+        end
+      end
+      """
+      |> string_to_state
+
+    assert get_line_module(state, 1) == Elixir
+    assert get_line_protocol(state, 1) == nil
+    assert get_line_module(state, 3) == OuterModule
+    assert get_line_protocol(state, 3) == nil
+    assert get_line_module(state, 7) == InnerModule
+    assert get_line_protocol(state, 7) == nil
+    assert get_line_module(state, 11) == OuterModule
+    assert get_line_protocol(state, 11) == nil
+    assert get_line_module(state, 16) == OuterModule.InnerModule1
+    assert get_line_protocol(state, 16) == nil
+  end
+
   test "current module and protocol implementation" do
     state =
       """

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1808,6 +1808,20 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_behaviours(state, 5) == [ElixirSenseExample.ExampleBehaviour]
   end
 
+  test "use atom module" do
+    state =
+      """
+      defmodule InheritMod do
+        use :"Elixir.ElixirSenseExample.ExampleBehaviour"
+
+        IO.puts("")
+      end
+      """
+      |> string_to_state
+
+    assert get_line_behaviours(state, 4) == [ElixirSenseExample.ExampleBehaviour]
+  end
+
   test "find struct" do
     state =
       """

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -947,13 +947,13 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     state =
       """
       defmodule MyModule do
-        require Mod.{Mo1, Mod2}
+        require Mod.{Mo1, Mod2, :"Elixir.Mod3"}
         IO.puts ""
       end
       """
       |> string_to_state
 
-    assert get_line_requires(state, 3) == [Mod.Mod2, Mod.Mo1]
+    assert get_line_requires(state, 3) == [Mod.Mod3, Mod.Mod2, Mod.Mo1]
   end
 
   test "requires duplicated" do
@@ -983,6 +983,23 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
     assert get_line_requires(state, 4) == [:ets, Integer]
     assert get_line_aliases(state, 4) == [{I, Integer}, {E, :ets}]
+  end
+
+  test "requires atom module" do
+    state =
+      """
+      defmodule MyModule do
+        require :my_mod
+        require :"Elixir.MyMod.Some"
+        require :"Elixir.MyMod.Other", as: A
+        require :"Elixir.MyMod.Other1", as: :"Elixir.A1"
+        IO.puts ""
+      end
+      """
+      |> string_to_state
+
+    assert get_line_requires(state, 6) == [MyMod.Other1, MyMod.Other, MyMod.Some, :my_mod]
+    assert get_line_aliases(state, 6) == [{A, MyMod.Other}, {A1, MyMod.Other1}]
   end
 
   test "requires aliased module" do

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1330,6 +1330,28 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_protocol(state, 24) == {NiceProto, [Enumerable.Date.Range]}
   end
 
+  test "protocol implementation using __MODULE__" do
+    state =
+      """
+      defprotocol NiceProto do
+        def reverse(term)
+      end
+
+      defmodule MyStruct do
+        defstruct [a: nil]
+
+        defimpl NiceProto, for: __MODULE__ do
+          def reverse(term), do: String.reverse(term)
+        end
+      end
+      """
+      |> string_to_state
+
+    # protocol implementation module name does not inherit enclosing module, only protocol
+    assert get_line_module(state, 8) == NiceProto.MyStruct
+    assert get_line_protocol(state, 8) == {NiceProto, [MyStruct]}
+  end
+
   test "registers positions" do
     state =
       """

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -907,8 +907,17 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    refute get_line_imports(state, 6) == [SomeModule.Inner, List, :erlang_module, SomeModule.NextInner]
-    assert get_line_aliases(state, 6) == [{Inner, SomeModule.Inner}, {NextInner, SomeModule.NextInner}]
+    refute get_line_imports(state, 6) == [
+             SomeModule.Inner,
+             List,
+             :erlang_module,
+             SomeModule.NextInner
+           ]
+
+    assert get_line_aliases(state, 6) == [
+             {Inner, SomeModule.Inner},
+             {NextInner, SomeModule.NextInner}
+           ]
   end
 
   test "requires" do
@@ -1254,12 +1263,24 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
     assert get_line_module(state, 3) == :my_reversible
     assert get_line_protocol(state, 3) == nil
-    assert get_line_module(state, 8) == [:"Elixir.my_reversible.String", :"Elixir.my_reversible.my_str", :"Elixir.my_reversible.MyStr"]
+
+    assert get_line_module(state, 8) == [
+             :"Elixir.my_reversible.String",
+             :"Elixir.my_reversible.my_str",
+             :"Elixir.my_reversible.MyStr"
+           ]
+
     assert get_line_protocol(state, 8) == {:my_reversible, [String, :my_str, MyStr]}
 
     assert get_line_module(state, 13) == My.Reversible
     assert get_line_protocol(state, 13) == nil
-    assert get_line_module(state, 18) == [My.Reversible.String, :"Elixir.My.Reversible.my_str", My.Reversible.MyStr]
+
+    assert get_line_module(state, 18) == [
+             My.Reversible.String,
+             :"Elixir.My.Reversible.my_str",
+             My.Reversible.MyStr
+           ]
+
     assert get_line_protocol(state, 18) == {My.Reversible, [String, :my_str, MyStr]}
   end
 

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -820,13 +820,13 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     state =
       """
       defmodule MyModule do
-        import Foo.Bar.{User, Email}
+        import Foo.Bar.{User, Email, :"Elixir.Other"}
         IO.puts ""
       end
       """
       |> string_to_state
 
-    assert get_line_imports(state, 3) == [Foo.Bar.Email, Foo.Bar.User]
+    assert get_line_imports(state, 3) == [Foo.Bar.Other, Foo.Bar.Email, Foo.Bar.User]
   end
 
   test "imports" do
@@ -900,14 +900,15 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       defmodule OuterModule do
         import List
         import SomeModule.Inner
+        import :"Elixir.SomeModule.NextInner"
         import :erlang_module
         IO.puts ""
       end
       """
       |> string_to_state
 
-    refute get_line_imports(state, 5) == [SomeModule.Inner, List, :erlang_module]
-    assert get_line_aliases(state, 5) == [{Inner, SomeModule.Inner}]
+    refute get_line_imports(state, 6) == [SomeModule.Inner, List, :erlang_module, SomeModule.NextInner]
+    assert get_line_aliases(state, 6) == [{Inner, SomeModule.Inner}, {NextInner, SomeModule.NextInner}]
   end
 
   test "requires" do

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -734,12 +734,13 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       defmodule MyModule do
         alias :"Elixir.A.B"
         alias :"Elixir.A.C", as: S
+        alias :"Elixir.A.D", as: :"Elixir.X"
         IO.puts ""
       end
       """
       |> string_to_state
 
-    assert get_line_aliases(state, 4) == [{B, A.B}, {S, A.C}]
+    assert get_line_aliases(state, 5) == [{B, A.B}, {S, A.C}, {X, A.D}]
   end
 
   test "aliases defined with v1.2 notation (multiline)" do
@@ -760,7 +761,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     state =
       """
       defmodule A do
-        alias Components.{Dialog, Dialog.Footer, Button}
+        alias Components.{Dialog, Dialog.Footer, Button, :"Elixir.Other"}
         IO.puts ""
       end
       """
@@ -769,7 +770,8 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert get_line_aliases(state, 3) == [
              {Dialog, Components.Dialog},
              {Footer, Components.Dialog.Footer},
-             {Button, Components.Button}
+             {Button, Components.Button},
+             {Other, Components.Other}
            ]
   end
 

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -483,6 +483,16 @@ defmodule ElixirSense.Core.SourceTest do
       assert which_struct(code) == {IO.Stream, []}
     end
 
+    test "modules erlang atom" do
+      code = """
+      defmodule MyMod do
+        def my_func(par1) do
+          var = %:my_module{
+      """
+
+      assert which_struct(code) == {:my_module, []}
+    end
+
     test "nested structs" do
       code = """
       defmodule MyMod do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -950,6 +950,26 @@ defmodule ElixirSense.SuggestionsTest do
            ]
   end
 
+  test "suggestion for aliased struct fields atom module" do
+    buffer = """
+    defmodule Mod do
+      alias IO.Stream
+      %:"Elixir.Stream"{
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 3, 21)
+      |> Enum.filter(&(&1.type in [:field, :hint]))
+
+    assert list == [
+             %{type: :hint, value: ""},
+             %{name: :device, origin: "IO.Stream", type: :field},
+             %{name: :line_or_bytes, origin: "IO.Stream", type: :field},
+             %{name: :raw, origin: "IO.Stream", type: :field}
+           ]
+  end
+
   test "suggestion for metadata struct fields" do
     buffer = """
     defmodule MyServer do
@@ -980,6 +1000,39 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{name: :field_1, origin: "MyServer", type: :field}
+           ]
+  end
+
+  test "suggestion for metadata struct fields atom module" do
+    buffer = """
+    defmodule :my_server do
+      defstruct [
+        field_1: nil,
+        field_2: ""
+      ]
+
+      def func do
+        %:my_server{}
+        %:my_server{field_2: "2", }
+      end
+    end
+    """
+
+    list =
+      ElixirSense.suggestions(buffer, 8, 17)
+      |> Enum.filter(&(&1.type in [:field, :hint]))
+
+    assert list == [
+             %{type: :hint, value: ""},
+             %{name: :field_1, origin: ":my_server", type: :field},
+             %{name: :field_2, origin: ":my_server", type: :field}
+           ]
+
+    list = ElixirSense.suggestions(buffer, 9, 30)
+
+    assert list == [
+             %{type: :hint, value: ""},
+             %{name: :field_1, origin: ":my_server", type: :field}
            ]
   end
 

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -101,6 +101,7 @@ defmodule ElixirSenseExample.ExampleBehaviour do
       alias :ets, as: Ets
       alias MyModule.{One, Two.Three}
       alias MyModule.{Four}
+      alias :lists
 
       require MyMacros
       require MyMacros.Nested, as: NestedMacros


### PR DESCRIPTION
Elixir allows defining erlang style modules with
```
defmodule :my_module do
```
as well as aliasing/requiring/importing such modules.

Fixes https://github.com/elixir-lsp/elixir_sense/issues/48