### PR TITLE
Update run.exs

### DIFF
--- a/run.exs
+++ b/run.exs
@@ -6,17 +6,28 @@ requires = [
   "elixir_sense/core/metadata.ex",
   "elixir_sense/core/parser.ex",
   "elixir_sense/core/source.ex",
+  "elixir_sense/core/type_ast.ex",
+  "elixir_sense/core/type_info.ex",
+  "elixir_sense/core/builtin_types.ex",
+
+  "elixir_sense/core/normalized/code.ex",
+  "elixir_sense/core/normalized/tokenizer.ex",
+  "elixir_sense/core/normalized/typespec.ex",
+
   "alchemist/helpers/module_info.ex",
   "alchemist/helpers/complete.ex",
+
   "elixir_sense/providers/definition.ex",
   "elixir_sense/providers/docs.ex",
   "elixir_sense/providers/suggestion.ex",
   "elixir_sense/providers/signature.ex",
   "elixir_sense/providers/expand.ex",
   "elixir_sense/providers/eval.ex",
+
   "elixir_sense/server/request_handler.ex",
   "elixir_sense/server/context_loader.ex",
   "elixir_sense/server/tcp_server.ex",
+
   "elixir_sense.ex",
   "elixir_sense/server.ex"
 ]


### PR DESCRIPTION
Incomplete file list causes errors when invoking Elixir_Sense not from within its own directory.

Compare with:
```bash
# cd elixir_sense
find lib -name '*.ex'
```

There may be a better way of solving this, but this change works (tm)