### PR TITLE
Find definitions for functions and modules from metadata

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -83,7 +83,11 @@ defmodule ElixirSense do
       vars: vars
     } = Metadata.get_env(buffer_file_metadata, line) |> IO.inspect(label: "env")
 
-    Definition.find(subject, imports, aliases, module, vars, buffer_file_metadata.mods_funs_to_positions)
+    calls = buffer_file_metadata.calls[line]
+    |> List.wrap()
+    |> Enum.filter(& &1.col <= column)
+
+    Definition.find(subject, imports, aliases, module, vars, buffer_file_metadata.mods_funs_to_positions, calls)
   end
 
   @doc ~S"""

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -73,21 +73,30 @@ defmodule ElixirSense do
   """
   @spec definition(String.t(), pos_integer, pos_integer) :: Definition.location()
   def definition(code, line, column) do
-    subject = Source.subject(code, line, column) |> IO.inspect(label: "subject")
-    buffer_file_metadata = Parser.parse_string(code, true, true, line) |> IO.inspect(label: "buffer_file_metadata")
+    subject = Source.subject(code, line, column)
+    buffer_file_metadata = Parser.parse_string(code, true, true, line)
 
     %State.Env{
       imports: imports,
       aliases: aliases,
       module: module,
       vars: vars
-    } = Metadata.get_env(buffer_file_metadata, line) |> IO.inspect(label: "env")
+    } = Metadata.get_env(buffer_file_metadata, line)
 
-    calls = buffer_file_metadata.calls[line]
-    |> List.wrap()
-    |> Enum.filter(& &1.col <= column)
+    calls =
+      buffer_file_metadata.calls[line]
+      |> List.wrap()
+      |> Enum.filter(&(&1.col <= column))
 
-    Definition.find(subject, imports, aliases, module, vars, buffer_file_metadata.mods_funs_to_positions, calls)
+    Definition.find(
+      subject,
+      imports,
+      aliases,
+      module,
+      vars,
+      buffer_file_metadata.mods_funs_to_positions,
+      calls
+    )
   end
 
   @doc ~S"""

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -73,17 +73,17 @@ defmodule ElixirSense do
   """
   @spec definition(String.t(), pos_integer, pos_integer) :: Definition.location()
   def definition(code, line, column) do
-    subject = Source.subject(code, line, column)
-    buffer_file_metadata = Parser.parse_string(code, true, true, line)
+    subject = Source.subject(code, line, column) |> IO.inspect(label: "subject")
+    buffer_file_metadata = Parser.parse_string(code, true, true, line) |> IO.inspect(label: "buffer_file_metadata")
 
     %State.Env{
       imports: imports,
       aliases: aliases,
       module: module,
       vars: vars
-    } = Metadata.get_env(buffer_file_metadata, line)
+    } = Metadata.get_env(buffer_file_metadata, line) |> IO.inspect(label: "env")
 
-    Definition.find(subject, imports, aliases, module, vars)
+    Definition.find(subject, imports, aliases, module, vars, buffer_file_metadata.mods_funs_to_positions)
   end
 
   @doc ~S"""

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -25,25 +25,64 @@ defmodule ElixirSense.Providers.Definition do
   @doc """
   Finds out where a module, function, macro or variable was defined.
   """
-  @spec find(String.t(), [module], [{module, module}], module, [%VarInfo{}]) :: %Location{}
-  def find(subject, imports, aliases, module, vars) do
+  @spec find(String.t(), [module], [{module, module}], module, [%VarInfo{}], map) :: %Location{}
+  def find(subject, imports, aliases, module, vars, mods_funs) do
+    IO.inspect(subject, label: "subject")
     var_info = vars |> Enum.find(fn %VarInfo{name: name} -> to_string(name) == subject end)
 
-    case var_info do
+    case var_info |> IO.inspect(label: "var_info") do
       %VarInfo{positions: [{line, column} | _]} ->
         %Location{found: true, type: :variable, file: nil, line: line, column: column}
 
       _ ->
         subject
         |> Source.split_module_and_func(aliases)
-        |> Introspection.actual_mod_fun(imports, aliases, module)
-        |> find_source(module)
+        |> IO.inspect(label: "split_module_and_func")
+        |> get_buffer_metadata_function(mods_funs, module, imports, aliases)
+        # |> Introspection.actual_mod_fun(imports, aliases, module)
+        # |> find_source(module)
+    end
+  end
+
+  defp get_buffer_metadata_function({nil, nil}, mods_funs, current_module, imports, aliases) do
+    {nil, nil}
+    |> Introspection.actual_mod_fun(imports, aliases, current_module)
+    |> find_source(current_module)
+  end
+  defp get_buffer_metadata_function({module, function}, mods_funs, current_module, imports, aliases) when is_atom(function) do
+    # TODO arity info would be useful here
+    IO.inspect mods_funs
+    IO.inspect {module, function, nil}
+
+    fun_module = case module do
+      mod when mod in [nil, :"__MODULE__"] -> current_module
+      mod when is_atom(mod) ->
+        # TODO expand alias?
+        mod
+    end
+    |> IO.inspect(label: "fun_module")
+
+    case mods_funs[{fun_module, function, nil}] do
+      nil ->
+        {module, function}
+        |> Introspection.actual_mod_fun(imports, aliases, current_module)
+        |> find_source(current_module)
+      %{positions: positions} ->
+        # TODO is it ok to take first position here?
+        [{line, column}| _] = positions
+        %Location{
+          found: true,
+          file: nil,
+          type: fun_to_type(function),
+          line: line,
+          column: column
+        }
     end
   end
 
   defp find_source({mod, fun}, current_module) do
     with(
-      {mod, file} when file not in ["non_existing", nil, ""] <- find_mod_file(mod),
+      {mod, file} when file not in ["non_existing", nil, ""] <- find_mod_file(mod) |> IO.inspect(label: "find_mod_file"),
       nil <- find_fun_position({mod, file}, fun),
       nil <- find_type_position({mod, file}, fun),
       nil <- find_type_position({current_module, file}, fun)
@@ -55,7 +94,7 @@ defmodule ElixirSense.Providers.Definition do
 
       _ ->
         %Location{found: false}
-    end
+    end |> IO.inspect
   end
 
   defp find_mod_file(module) do
@@ -86,11 +125,7 @@ defmodule ElixirSense.Providers.Definition do
   end
 
   defp find_fun_position({mod, file}, fun) do
-    type =
-      case fun do
-        nil -> :module
-        _ -> :function
-      end
+    type = fun_to_type(fun)
 
     position =
       if String.ends_with?(file, ".erl") do
@@ -105,6 +140,9 @@ defmodule ElixirSense.Providers.Definition do
       _ -> nil
     end
   end
+
+  defp fun_to_type(nil), do: :module
+  defp fun_to_type(_), do: :function
 
   defp find_fun_position_in_erl_file(file, fun) do
     fun_name = Atom.to_string(fun)

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -1,5 +1,6 @@
 defmodule ElixirSense.Core.SourceTest do
   use ExUnit.Case
+  doctest ElixirSense.Core.Source
 
   import ElixirSense.Core.Source
 

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -298,6 +298,92 @@ defmodule ElixirSense.Providers.DefinitionTest do
            }
   end
 
+  test "find definition of local functions with __MODULE__" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(), do: :ok
+
+      def a do
+        my_fun1 = 1
+        __MODULE__.my_fun()
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 6, 17) == %Location{
+             found: true,
+             type: :function,
+             file: nil,
+             line: 2,
+             column: 7
+           }
+  end
+
+  test "find definition of local functions with current module" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(), do: :ok
+
+      def a do
+        my_fun1 = 1
+        MyModule.my_fun()
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 6, 14) == %Location{
+             found: true,
+             type: :function,
+             file: nil,
+             line: 2,
+             column: 7
+           }
+  end
+
+  test "find definition of local functions with alias" do
+    buffer = """
+    defmodule MyModule do
+      alias MyModule, as: M
+      def my_fun(), do: :ok
+
+      def a do
+        my_fun1 = 1
+        M.my_fun()
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 7, 7) == %Location{
+             found: true,
+             type: :function,
+             file: nil,
+             line: 3,
+             column: 7
+           }
+  end
+
+  test "find definition of local module" do
+    buffer = """
+    defmodule MyModule do
+      defmodule Submodule do
+        def my_fun(), do: :ok
+      end
+
+      def a do
+        MyModule.Submodule.my_fun()
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 7, 16) == %Location{
+             found: true,
+             type: :module,
+             file: nil,
+             line: 2,
+             column: 13
+           }
+  end
+
   test "find definition of params" do
     buffer = """
     defmodule MyModule do

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -235,6 +235,69 @@ defmodule ElixirSense.Providers.DefinitionTest do
            }
   end
 
+  test "find definition of functions when name not same as variable" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(), do: :ok
+
+      def a do
+        my_fun1 = 1
+        my_fun()
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 6, 6) == %Location{
+             found: true,
+             type: :function,
+             file: nil,
+             line: 2,
+             column: 7
+           }
+  end
+
+  test "find definition of functions when name same as variable" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(), do: :ok
+
+      def a do
+        my_fun = 1
+        my_fun()
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 6, 6) == %Location{
+             found: true,
+             type: :function,
+             file: nil,
+             line: 2,
+             column: 7
+           }
+  end
+
+  test "find definition of variables when name same as function" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(), do: :error
+
+      def a do
+        my_fun = fn -> :ok end
+        my_fun.()
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 6, 6) == %Location{
+             found: true,
+             type: :variable,
+             file: nil,
+             line: 5,
+             column: 5
+           }
+  end
+
   test "find definition of params" do
     buffer = """
     defmodule MyModule do


### PR DESCRIPTION
This PR adds support for finding definitions of functions and modules defined in the current file and not yet compiled. It also fixes an issue when trying to find definition for a local function call when there is a variable with the same name (as long as the call is of the form `my_func()`, there is no ambiguity as to call avariable we need `my_func.()`).
While working on this PR I also found an issue with `Source.split_module_and_func/2` - it failed to properly handle `__MODULE__`. I fixed that and added tests.