### PR TITLE
Use metadata in Introspection.actual_mod_fun

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -52,7 +52,9 @@ defmodule ElixirSense do
       scope: scope
     } = Metadata.get_env(metadata, line)
 
-    {actual_subject, docs} = Docs.all(subject, imports, aliases, module, scope)
+    {actual_subject, docs} =
+      Docs.all(subject, imports, aliases, module, scope, metadata.mods_funs)
+
     %{subject: subject, actual_subject: actual_subject, docs: docs}
   end
 
@@ -95,6 +97,7 @@ defmodule ElixirSense do
       module,
       vars,
       buffer_file_metadata.mods_funs_to_positions,
+      buffer_file_metadata.mods_funs,
       calls
     )
   end
@@ -387,6 +390,15 @@ defmodule ElixirSense do
     vars = buffer_file_metadata.vars_info_per_scope_id[scope_id] |> Map.values()
     arity = Metadata.get_call_arity(buffer_file_metadata, line, col)
 
-    References.find(subject, arity, imports, aliases, module, scope, vars)
+    References.find(
+      subject,
+      arity,
+      imports,
+      aliases,
+      module,
+      scope,
+      vars,
+      buffer_file_metadata.mods_funs
+    )
   end
 end

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -375,32 +375,34 @@ defmodule ElixirSense do
   """
   @spec references(String.t(), pos_integer, pos_integer) :: [References.reference_info()]
   def references(code, line, column) do
-    with {subject, {line, col}} <- Source.subject_with_position(code, line, column) do
-      buffer_file_metadata = Parser.parse_string(code, true, true, line)
+    case Source.subject_with_position(code, line, column) do
+      {subject, {line, col}} ->
+        buffer_file_metadata = Parser.parse_string(code, true, true, line)
 
-      %State.Env{
-        imports: imports,
-        aliases: aliases,
-        module: module,
-        scope: scope,
-        scope_id: scope_id
-      } = Metadata.get_env(buffer_file_metadata, line)
+        %State.Env{
+          imports: imports,
+          aliases: aliases,
+          module: module,
+          scope: scope,
+          scope_id: scope_id
+        } = Metadata.get_env(buffer_file_metadata, line)
 
-      vars = buffer_file_metadata.vars_info_per_scope_id[scope_id] |> Map.values()
-      arity = Metadata.get_call_arity(buffer_file_metadata, line, col)
+        vars = buffer_file_metadata.vars_info_per_scope_id[scope_id] |> Map.values()
+        arity = Metadata.get_call_arity(buffer_file_metadata, line, col)
 
-      References.find(
-        subject,
-        arity,
-        imports,
-        aliases,
-        module,
-        scope,
-        vars,
-        buffer_file_metadata.mods_funs
-      )
-    else
-      _ -> []
+        References.find(
+          subject,
+          arity,
+          imports,
+          aliases,
+          module,
+          scope,
+          vars,
+          buffer_file_metadata.mods_funs
+        )
+
+      _ ->
+        []
     end
   end
 end

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -375,30 +375,32 @@ defmodule ElixirSense do
   """
   @spec references(String.t(), pos_integer, pos_integer) :: [References.reference_info()]
   def references(code, line, column) do
-    {subject, {line, col}} = Source.subject_with_position(code, line, column)
+    with {subject, {line, col}} <- Source.subject_with_position(code, line, column) do
+      buffer_file_metadata = Parser.parse_string(code, true, true, line)
 
-    buffer_file_metadata = Parser.parse_string(code, true, true, line)
+      %State.Env{
+        imports: imports,
+        aliases: aliases,
+        module: module,
+        scope: scope,
+        scope_id: scope_id
+      } = Metadata.get_env(buffer_file_metadata, line)
 
-    %State.Env{
-      imports: imports,
-      aliases: aliases,
-      module: module,
-      scope: scope,
-      scope_id: scope_id
-    } = Metadata.get_env(buffer_file_metadata, line)
+      vars = buffer_file_metadata.vars_info_per_scope_id[scope_id] |> Map.values()
+      arity = Metadata.get_call_arity(buffer_file_metadata, line, col)
 
-    vars = buffer_file_metadata.vars_info_per_scope_id[scope_id] |> Map.values()
-    arity = Metadata.get_call_arity(buffer_file_metadata, line, col)
-
-    References.find(
-      subject,
-      arity,
-      imports,
-      aliases,
-      module,
-      scope,
-      vars,
-      buffer_file_metadata.mods_funs
-    )
+      References.find(
+        subject,
+        arity,
+        imports,
+        aliases,
+        module,
+        scope,
+        vars,
+        buffer_file_metadata.mods_funs
+      )
+    else
+      _ -> []
+    end
   end
 end

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -642,8 +642,8 @@ defmodule ElixirSense.Core.Introspection do
     mods = [current_module | imports]
 
     case Enum.find(mods, fn mod ->
-      find_metadata_function({mod, fun}, current_module, imports, mods_funs) != {nil, nil}
-    end) do
+           find_metadata_function({mod, fun}, current_module, imports, mods_funs) != {nil, nil}
+         end) do
       nil -> {nil, nil}
       mod -> {mod, fun}
     end
@@ -659,12 +659,14 @@ defmodule ElixirSense.Core.Introspection do
 
   defp find_metadata_function({mod, fun}, _current_module, _imports, mods_funs) do
     # TODO types from metadata
-    found_in_metadata = case mods_funs[mod] do
-      nil ->
-        false
-      funs ->
-        Enum.any?(funs, fn {{f, _a}, _} -> f == fun end)
-    end
+    found_in_metadata =
+      case mods_funs[mod] do
+        nil ->
+          false
+
+        funs ->
+          Enum.any?(funs, fn {{f, _a}, _} -> f == fun end)
+      end
 
     if found_in_metadata or ModuleInfo.has_function?(mod, fun) or has_type?(mod, fun) do
       {mod, fun}

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -606,16 +606,79 @@ defmodule ElixirSense.Core.Introspection do
     end
   end
 
-  def actual_mod_fun(mod_fun, imports, aliases, current_module) do
+  defp maybe_expand_alias(nil, _aliases), do: nil
+
+  defp maybe_expand_alias(mod, aliases) do
+    case Enum.find(aliases, fn {a, _m} -> a == mod end) do
+      nil -> mod
+      {_a, m} -> m
+    end
+  end
+
+  def actual_mod_fun({nil, nil}, _, _, _, _), do: {nil, nil}
+
+  def actual_mod_fun(mod_fun = {mod, fun}, imports, aliases, current_module, mods_funs) do
     with {nil, nil} <- find_kernel_function(mod_fun),
-         {nil, nil} <- find_imported_function(mod_fun, imports),
-         {nil, nil} <- find_aliased_function(mod_fun, aliases),
-         {nil, nil} <- find_function_in_module(mod_fun),
-         {nil, nil} <- find_builtin_type(mod_fun),
-         {nil, nil} <- find_function_in_current_module(mod_fun, current_module) do
+         {nil, nil} <-
+           find_metadata_function(
+             {maybe_expand_alias(mod, aliases), fun},
+             current_module,
+             imports,
+             mods_funs
+           ),
+         {nil, nil} <- find_builtin_type(mod_fun) do
       mod_fun
     else
       new_mod_fun -> new_mod_fun
+    end
+  end
+
+  defp has_type?(mod, type) do
+    ElixirSense.Core.Normalized.Typespec.get_types(mod)
+    |> Enum.any?(fn {_kind, {name, _def, _args}} -> name == type end)
+  end
+
+  defp find_metadata_function({nil, fun}, current_module, imports, mods_funs) do
+    mods = [current_module | imports]
+
+    case mods
+         |> Enum.find(fn mod ->
+           find_metadata_function({mod, fun}, current_module, imports, mods_funs) != {nil, nil}
+         end) do
+      nil -> {nil, nil}
+      mod -> {mod, fun}
+    end
+  end
+
+  defp find_metadata_function({mod, nil}, _current_module, _imports, mods_funs) do
+    case Code.ensure_loaded(mod) do
+      {:module, _} ->
+        {mod, nil}
+
+      _ ->
+        case mods_funs[mod] do
+          nil -> {nil, nil}
+          _ -> {mod, nil}
+        end
+    end
+  end
+
+  defp find_metadata_function({mod, fun}, _current_module, _imports, mods_funs) do
+    if ModuleInfo.has_function?(mod, fun) or has_type?(mod, fun) do
+      {mod, fun}
+    else
+      # TODO types from metadata
+      case mods_funs[mod] do
+        nil ->
+          {nil, nil}
+
+        funs ->
+          if funs |> Enum.any?(fn {{f, _a}, _} -> f == fun end) do
+            {mod, fun}
+          else
+            {nil, nil}
+          end
+      end
     end
   end
 
@@ -645,50 +708,6 @@ defmodule ElixirSense.Core.Introspection do
   end
 
   defp find_kernel_function({_mod, _fun}) do
-    {nil, nil}
-  end
-
-  defp find_imported_function({nil, fun}, imports) do
-    case imports |> Enum.find(&ModuleInfo.has_function?(&1, fun)) do
-      nil -> {nil, nil}
-      mod -> {mod, fun}
-    end
-  end
-
-  defp find_imported_function({_mod, _fun}, _imports) do
-    {nil, nil}
-  end
-
-  defp find_aliased_function({nil, _fun}, _aliases) do
-    {nil, nil}
-  end
-
-  defp find_aliased_function({mod, fun}, aliases) do
-    if elixir_module?(mod) do
-      module =
-        mod
-        |> Module.split()
-        |> ModuleInfo.expand_alias(aliases)
-
-      {module, fun}
-    else
-      {nil, nil}
-    end
-  end
-
-  defp find_function_in_module({mod, fun}) do
-    if elixir_module?(mod) && ModuleInfo.has_function?(mod, fun) do
-      {mod, fun}
-    else
-      {nil, nil}
-    end
-  end
-
-  defp find_function_in_current_module({nil, fun}, current_module) do
-    {current_module, fun}
-  end
-
-  defp find_function_in_current_module(_, _) do
     {nil, nil}
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -647,7 +647,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
     case concat_module_expression(state, module_expression) do
       {:ok, module} ->
         state
-        |> add_call_to_line({module, call, length(params)}, line, col)
+        |> add_call_to_line({module, call, length(params)}, line, col + 1)
         |> add_current_env_to_line(line)
 
       :error ->
@@ -664,7 +664,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
     module = get_current_module(state)
 
     state
-    |> add_call_to_line({module, call, length(params)}, line, col)
+    |> add_call_to_line({module, call, length(params)}, line, col + 1)
     |> add_current_env_to_line(line)
     |> result(ast)
   end
@@ -675,7 +675,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
        )
        when is_atom(module) and is_call(call, params) do
     state
-    |> add_call_to_line({module, call, length(params)}, line, col)
+    |> add_call_to_line({module, call, length(params)}, line, col + 1)
     |> add_current_env_to_line(line)
     |> result(ast)
   end

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -137,7 +137,7 @@ defmodule ElixirSense.Core.Source do
           |> Enum.at(0)
           |> String.reverse()
 
-        {subject, {line, col - String.length(last_part)}}
+        {subject, {line, col - String.length(last_part) + 1}}
     end
   end
 

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -87,45 +87,6 @@ defmodule ElixirSense.Providers.Definition do
     end
   end
 
-  # defp find_function_or_module({nil, nil}, mods_funs_to_positions, mods_funs, current_module, imports, aliases) do
-  #   {nil, nil}
-  #   |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs)
-  #   |> find_source(current_module)
-  # end
-
-  # defp find_function_or_module({module, function}, mods_funs_to_positions, mods_funs, current_module, imports, aliases)
-  #      when is_atom(function) do
-  #   # TODO arity info would be useful here
-  #   # TODO support local typespecs
-
-  #   fun_module =
-  #     case module do
-  #       nil -> current_module
-  #       mod when is_atom(mod) -> mod
-  #     end
-
-  #   case mods_funs[{fun_module, function, nil}] do
-  #     nil ->
-  #       # module or function not found in buffer metadata, try introspection
-  #       {module, function}
-  #       # TODO
-  #       |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs)
-  #       |> find_source(current_module)
-
-  #     %{positions: positions} ->
-  #       # for simplicity take first position here
-  #       [{line, column} | _] = positions
-
-  #       %Location{
-  #         found: true,
-  #         file: nil,
-  #         type: fun_to_type(function),
-  #         line: line,
-  #         column: column
-  #       }
-  #   end
-  # end
-
   defp find_source({mod, fun}, current_module) do
     with(
       {mod, file} when file not in ["non_existing", nil, ""] <- find_mod_file(mod),

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -25,9 +25,9 @@ defmodule ElixirSense.Providers.Definition do
   @doc """
   Finds out where a module, function, macro or variable was defined.
   """
-  @spec find(String.t(), [module], [{module, module}], module, [%VarInfo{}], map, map) ::
+  @spec find(String.t(), [module], [{module, module}], module, [%VarInfo{}], map, map, map) ::
           %Location{}
-  def find(subject, imports, aliases, module, vars, mods_funs, calls) do
+  def find(subject, imports, aliases, module, vars, mods_funs_to_positions, mods_funs, calls) do
     var_info =
       unless subject_is_call?(subject, calls) do
         vars |> Enum.find(fn %VarInfo{name: name} -> to_string(name) == subject end)
@@ -40,7 +40,7 @@ defmodule ElixirSense.Providers.Definition do
       _ ->
         subject
         |> Source.split_module_and_func(module, aliases)
-        |> find_function_or_module(mods_funs, module, imports, aliases)
+        |> find_function_or_module(mods_funs_to_positions, mods_funs, module, imports, aliases)
     end
   end
 
@@ -54,43 +54,77 @@ defmodule ElixirSense.Providers.Definition do
     end) != nil
   end
 
-  defp find_function_or_module({nil, nil}, _mods_funs, current_module, imports, aliases) do
-    {nil, nil}
-    |> Introspection.actual_mod_fun(imports, aliases, current_module)
-    |> find_source(current_module)
-  end
+  defp find_function_or_module(
+         {module, function},
+         mods_funs_to_positions,
+         mods_funs,
+         current_module,
+         imports,
+         aliases
+       ) do
+    case {module, function}
+         |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs) do
+      {nil, nil} ->
+        %Location{found: false}
 
-  defp find_function_or_module({module, function}, mods_funs, current_module, imports, aliases)
-       when is_atom(function) do
-    # TODO arity info would be useful here
-    # TODO support local typespecs
+      {mod, fun} ->
+        case mods_funs_to_positions[{mod, fun, nil}] do
+          nil ->
+            {mod, fun} |> find_source(current_module)
 
-    fun_module =
-      case module do
-        nil -> current_module
-        mod when is_atom(mod) -> mod
-      end
+          %{positions: positions} ->
+            # for simplicity take first position here
+            [{line, column} | _] = positions
 
-    case mods_funs[{fun_module, function, nil}] do
-      nil ->
-        # module or function not found in buffer metadata, try introspection
-        {module, function}
-        |> Introspection.actual_mod_fun(imports, aliases, current_module)
-        |> find_source(current_module)
-
-      %{positions: positions} ->
-        # for simplicity take first position here
-        [{line, column} | _] = positions
-
-        %Location{
-          found: true,
-          file: nil,
-          type: fun_to_type(function),
-          line: line,
-          column: column
-        }
+            %Location{
+              found: true,
+              file: nil,
+              type: fun_to_type(function),
+              line: line,
+              column: column
+            }
+        end
     end
   end
+
+  # defp find_function_or_module({nil, nil}, mods_funs_to_positions, mods_funs, current_module, imports, aliases) do
+  #   {nil, nil}
+  #   |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs)
+  #   |> find_source(current_module)
+  # end
+
+  # defp find_function_or_module({module, function}, mods_funs_to_positions, mods_funs, current_module, imports, aliases)
+  #      when is_atom(function) do
+  #   # TODO arity info would be useful here
+  #   # TODO support local typespecs
+
+  #   fun_module =
+  #     case module do
+  #       nil -> current_module
+  #       mod when is_atom(mod) -> mod
+  #     end
+
+  #   case mods_funs[{fun_module, function, nil}] do
+  #     nil ->
+  #       # module or function not found in buffer metadata, try introspection
+  #       {module, function}
+  #       # TODO
+  #       |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs)
+  #       |> find_source(current_module)
+
+  #     %{positions: positions} ->
+  #       # for simplicity take first position here
+  #       [{line, column} | _] = positions
+
+  #       %Location{
+  #         found: true,
+  #         file: nil,
+  #         type: fun_to_type(function),
+  #         line: line,
+  #         column: column
+  #       }
+  #   end
+  # end
 
   defp find_source({mod, fun}, current_module) do
     with(

--- a/lib/elixir_sense/providers/docs.ex
+++ b/lib/elixir_sense/providers/docs.ex
@@ -6,13 +6,13 @@ defmodule ElixirSense.Providers.Docs do
   alias ElixirSense.Core.State
   alias ElixirSense.Core.Source
 
-  @spec all(String.t(), [module], [{module, module}], module, State.scope()) ::
+  @spec all(String.t(), [module], [{module, module}], module, State.scope(), map) ::
           {actual_mod_fun :: String.t(), docs :: Introspection.docs()}
-  def all(subject, imports, aliases, module, scope) do
+  def all(subject, imports, aliases, module, scope, mods_funs) do
     mod_fun =
       subject
       |> Source.split_module_and_func(module, aliases)
-      |> Introspection.actual_mod_fun(imports, aliases, module)
+      |> Introspection.actual_mod_fun(imports, aliases, module, mods_funs)
 
     {mod_fun_to_string(mod_fun), Introspection.get_all_docs(mod_fun, scope)}
   end

--- a/lib/elixir_sense/providers/references.ex
+++ b/lib/elixir_sense/providers/references.ex
@@ -198,9 +198,9 @@ defmodule ElixirSense.Providers.References do
           call
 
         %{line: line, col: col} ->
-          text_after = Source.text_after(code, line, col + 1)
+          text_after = Source.text_after(code, line, col)
           {_rest, line_offset, col_offset} = Source.find_next_word(text_after)
-          col_offset = if line_offset == 0, do: col + 1, else: col_offset
+          col_offset = if line_offset == 0, do: col, else: col_offset
 
           %{call | line: line + line_offset, col: col_offset}
       end

--- a/lib/elixir_sense/providers/signature.ex
+++ b/lib/elixir_sense/providers/signature.ex
@@ -18,7 +18,9 @@ defmodule ElixirSense.Providers.Signature do
   def find(prefix, imports, aliases, module, metadata) do
     case Source.which_func(prefix, module) do
       %{candidate: {mod, fun}, npar: npar, pipe_before: pipe_before} ->
-        {mod, fun} = Introspection.actual_mod_fun({mod, fun}, imports, aliases, module)
+        {mod, fun} =
+          Introspection.actual_mod_fun({mod, fun}, imports, aliases, module, metadata.mods_funs)
+
         signatures = find_signatures({mod, fun}, metadata)
         %{active_param: npar, pipe_before: pipe_before, signatures: signatures}
 

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -218,7 +218,7 @@ defmodule ElixirSense.Providers.Suggestion do
     |> Kernel.++(mods_and_funcs)
     |> Kernel.++(find_param_options(text_before, hint, imports, aliases, module, mods_and_funs))
     |> Kernel.++(find_typespecs(hint, aliases, module, scope))
-    |> Enum.uniq_by(& &1)
+    |> Enum.uniq()
   end
 
   defp find_mods_funs_vars_attributes(

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -137,7 +137,7 @@ defmodule ElixirSense.Providers.Suggestion do
         structs,
         text_before
       ) do
-    case find_struct_fields(hint, text_before, imports, aliases, module, structs) do
+    case find_struct_fields(hint, text_before, imports, aliases, module, structs, mods_and_funs) do
       {[], _} ->
         find_all_except_struct_fields(
           hint,
@@ -216,7 +216,7 @@ defmodule ElixirSense.Providers.Suggestion do
     |> Kernel.++(find_attributes(attributes, hint))
     |> Kernel.++(find_vars(vars, hint))
     |> Kernel.++(mods_and_funcs)
-    |> Kernel.++(find_param_options(text_before, hint, imports, aliases, module))
+    |> Kernel.++(find_param_options(text_before, hint, imports, aliases, module, mods_and_funs))
     |> Kernel.++(find_typespecs(hint, aliases, module, scope))
     |> Enum.uniq_by(& &1)
   end
@@ -245,14 +245,15 @@ defmodule ElixirSense.Providers.Suggestion do
   defp expand_current_module(:__MODULE__, current_module), do: current_module
   defp expand_current_module(module, _current_module), do: module
 
-  defp find_struct_fields(hint, text_before, imports, aliases, module, structs) do
+  defp find_struct_fields(hint, text_before, imports, aliases, module, structs, mods_funs) do
     with {mod, fields_so_far} <- Source.which_struct(text_before),
          {actual_mod, _} <-
            Introspection.actual_mod_fun(
              {expand_current_module(mod, module), nil},
              imports,
              aliases,
-             module
+             module,
+             mods_funs
            ),
          true <- Introspection.module_is_struct?(actual_mod) or Map.has_key?(structs, actual_mod) do
       fields =
@@ -423,13 +424,13 @@ defmodule ElixirSense.Providers.Suggestion do
     |> Enum.sort()
   end
 
-  @spec find_param_options(String.t(), String.t(), [module], [{module, module}], module) :: [
+  @spec find_param_options(String.t(), String.t(), [module], [{module, module}], module, map) :: [
           param_option
         ]
-  defp find_param_options(prefix, hint, imports, aliases, module) do
+  defp find_param_options(prefix, hint, imports, aliases, module, mods_funs) do
     case Source.which_func(prefix, module) do
       %{candidate: {mod, fun}, npar: npar, pipe_before: _pipe_before} ->
-        {mod, fun} = Introspection.actual_mod_fun({mod, fun}, imports, aliases, module)
+        {mod, fun} = Introspection.actual_mod_fun({mod, fun}, imports, aliases, module, mods_funs)
 
         TypeInfo.extract_param_options(mod, fun, npar)
         |> options_to_suggestions(mod)

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -2165,10 +2165,10 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       |> string_to_state
 
     assert state.calls == %{
-             5 => [%{arity: 0, col: 15, func: :func1, line: 5, mod: NyModule}],
-             6 => [%{arity: 0, col: 15, func: :func1, line: 6, mod: NyModule}],
-             7 => [%{arity: 1, col: 15, func: :func2, line: 7, mod: NyModule}],
-             8 => [%{arity: 1, col: 19, func: :func2, line: 8, mod: NyModule.Sub}]
+             5 => [%{arity: 0, col: 16, func: :func1, line: 5, mod: NyModule}],
+             6 => [%{arity: 0, col: 16, func: :func1, line: 6, mod: NyModule}],
+             7 => [%{arity: 1, col: 16, func: :func2, line: 7, mod: NyModule}],
+             8 => [%{arity: 1, col: 20, func: :func2, line: 8, mod: NyModule.Sub}]
            }
   end
 
@@ -2186,9 +2186,9 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       |> string_to_state
 
     assert state.calls == %{
-             3 => [%{arity: 0, col: 13, func: :func1, line: 3, mod: :erl_mod}],
-             4 => [%{arity: 0, col: 13, func: :func1, line: 4, mod: :erl_mod}],
-             5 => [%{arity: 1, col: 13, func: :func2, line: 5, mod: :erl_mod}]
+             3 => [%{arity: 0, col: 14, func: :func1, line: 3, mod: :erl_mod}],
+             4 => [%{arity: 0, col: 14, func: :func1, line: 4, mod: :erl_mod}],
+             5 => [%{arity: 1, col: 14, func: :func2, line: 5, mod: :erl_mod}]
            }
   end
 
@@ -2206,9 +2206,9 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       |> string_to_state
 
     assert state.calls == %{
-             3 => [%{arity: 0, col: 20, func: :func1, line: 3, mod: MyMod}],
-             4 => [%{arity: 0, col: 20, func: :func1, line: 4, mod: MyMod}],
-             5 => [%{arity: 1, col: 20, func: :func2, line: 5, mod: MyMod}]
+             3 => [%{arity: 0, col: 21, func: :func1, line: 3, mod: MyMod}],
+             4 => [%{arity: 0, col: 21, func: :func1, line: 4, mod: MyMod}],
+             5 => [%{arity: 1, col: 21, func: :func2, line: 5, mod: MyMod}]
            }
   end
 
@@ -2223,7 +2223,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 0, col: 10, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 0, col: 11, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls no arg" do
@@ -2237,7 +2237,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 0, col: 10, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 0, col: 11, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls local no arg no parens" do
@@ -2293,7 +2293,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 1, col: 10, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 1, col: 11, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls pipe with __MODULE__ operator no parens" do
@@ -2307,7 +2307,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 1, col: 25, func: :func, line: 3, mod: NyModule}]}
+    assert state.calls == %{3 => [%{arity: 1, col: 26, func: :func, line: 3, mod: NyModule}]}
   end
 
   test "registers calls pipe operator no parens" do
@@ -2321,7 +2321,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 1, col: 20, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 1, col: 21, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls pipe operator" do
@@ -2335,7 +2335,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 1, col: 20, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 1, col: 21, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls pipe operator with arg" do
@@ -2349,7 +2349,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 2, col: 20, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 2, col: 21, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls pipe operator erlang module" do
@@ -2363,7 +2363,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 2, col: 22, func: :func, line: 3, mod: :my_mod}]}
+    assert state.calls == %{3 => [%{arity: 2, col: 23, func: :func, line: 3, mod: :my_mod}]}
   end
 
   test "registers calls pipe operator atom module" do
@@ -2377,7 +2377,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 2, col: 30, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 2, col: 31, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls pipe operator local" do
@@ -2407,7 +2407,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
     assert state.calls == %{
              3 => [
-               %{arity: 1, col: 20, func: :func, line: 3, mod: MyMod},
+               %{arity: 1, col: 21, func: :func, line: 3, mod: MyMod},
                %{arity: 1, col: 31, func: :other, line: 3, mod: nil}
              ]
            }
@@ -2426,8 +2426,8 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
     assert state.calls == %{
              3 => [
-               %{arity: 1, col: 20, func: :func, line: 3, mod: MyMod},
-               %{arity: 1, col: 36, func: :other, line: 3, mod: Other}
+               %{arity: 1, col: 21, func: :func, line: 3, mod: MyMod},
+               %{arity: 1, col: 37, func: :other, line: 3, mod: Other}
              ]
            }
   end
@@ -2446,7 +2446,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert state.calls == %{
              3 => [
                %{arity: 1, col: 15, func: :func_1, line: 3, mod: nil},
-               %{arity: 1, col: 31, func: :other, line: 3, mod: Some}
+               %{arity: 1, col: 32, func: :other, line: 3, mod: Some}
              ]
            }
   end
@@ -2483,8 +2483,8 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       |> string_to_state
 
     assert state.calls == %{
-             3 => [%{arity: 1, col: 16, func: :func, line: 3, mod: NyModule}],
-             4 => [%{arity: 1, col: 20, func: :func, line: 4, mod: NyModule.Sub}]
+             3 => [%{arity: 1, col: 17, func: :func, line: 3, mod: NyModule}],
+             4 => [%{arity: 1, col: 21, func: :func, line: 4, mod: NyModule.Sub}]
            }
   end
 
@@ -2499,7 +2499,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 1, col: 11, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 1, col: 12, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls capture operator external erlang module" do
@@ -2513,7 +2513,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 1, col: 14, func: :func, line: 3, mod: :erl_mod}]}
+    assert state.calls == %{3 => [%{arity: 1, col: 15, func: :func, line: 3, mod: :erl_mod}]}
   end
 
   test "registers calls capture operator external atom module" do
@@ -2527,7 +2527,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       """
       |> string_to_state
 
-    assert state.calls == %{3 => [%{arity: 1, col: 21, func: :func, line: 3, mod: MyMod}]}
+    assert state.calls == %{3 => [%{arity: 1, col: 22, func: :func, line: 3, mod: MyMod}]}
   end
 
   test "registers calls capture operator local" do

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -84,6 +84,38 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert read_line(file, {line, column}) =~ "function_arity_one"
   end
 
+  test "find definition of functions piped from aliased modules" do
+    buffer = """
+    defmodule MyModule do
+      alias ElixirSenseExample.ModuleWithFunctions, as: MyMod
+      42 |> MyMod.function_arity_one()
+      #              ^
+    end
+    """
+
+    %{found: true, type: :function, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 3, 17)
+
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "function_arity_one"
+  end
+
+  test "find definition of functions captured from aliased modules" do
+    buffer = """
+    defmodule MyModule do
+      alias ElixirSenseExample.ModuleWithFunctions, as: MyMod
+      &MyMod.function_arity_one/1
+      #              ^
+    end
+    """
+
+    %{found: true, type: :function, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 3, 17)
+
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "function_arity_one"
+  end
+
   test "find definition of delegated functions" do
     buffer = """
     defmodule MyModule do

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -7,7 +7,7 @@ defmodule ElixirSense.Providers.ReferencesTest do
     buffer = """
     defmodule B.Callee do
       def fun() do
-           ^
+        #  ^
         :ok
       end
       def my_fun() do
@@ -453,7 +453,7 @@ defmodule ElixirSense.Providers.ReferencesTest do
     defmodule Caller do
       def func() do
         :ets.new(:s, [])
-        #                                               ^
+        # ^                                              ^
       end
     end
     """
@@ -473,7 +473,7 @@ defmodule ElixirSense.Providers.ReferencesTest do
     defmodule Caller do
       def func() do
         :ets.new(:s, [])
-        #                                               ^
+        #     ^                                            ^
       end
     end
     """

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -207,7 +207,7 @@ defmodule ElixirSense.Providers.ReferencesTest do
   test "find references with cursor over a function call from an aliased module" do
     buffer = """
     defmodule Caller do
-      def func() do
+      def my() do
         alias ElixirSense.Providers.ReferencesTest.Modules.Callee1, as: C
         C.func()
         #  ^
@@ -216,6 +216,89 @@ defmodule ElixirSense.Providers.ReferencesTest do
     """
 
     references = ElixirSense.references(buffer, 4, 8)
+
+    assert references == [
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+             },
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+             },
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+             }
+           ]
+  end
+
+  test "find references with cursor over a function call from an imported module" do
+    buffer = """
+    defmodule Caller do
+      def my() do
+        import ElixirSense.Providers.ReferencesTest.Modules.Callee1
+        func()
+        #^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 4, 6)
+
+    assert references == [
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+             },
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+             },
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+             }
+           ]
+  end
+
+  test "find references with cursor over a function call pipe from an imported module" do
+    buffer = """
+    defmodule Caller do
+      def my() do
+        import ElixirSense.Providers.ReferencesTest.Modules.Callee1
+        "" |> func
+        #      ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 4, 12)
+
+    assert references == [
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+             },
+             %{
+               uri: "test/support/modules_with_references.ex",
+               range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+             }
+           ]
+  end
+
+  test "find references with cursor over a function capture from an imported module" do
+    buffer = """
+    defmodule Caller do
+      def my() do
+        import ElixirSense.Providers.ReferencesTest.Modules.Callee1
+        &func/0
+        # ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 4, 7)
 
     assert references == [
              %{
@@ -361,6 +444,46 @@ defmodule ElixirSense.Providers.ReferencesTest do
              %{
                uri: "test/support/modules_with_references.ex",
                range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+             }
+           ]
+  end
+
+  test "find references with cursor over an erlang module" do
+    buffer = """
+    defmodule Caller do
+      def func() do
+        :ets.new(:s, [])
+        #                                               ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 3, 7)
+
+    assert references == [
+             %{
+               range: %{start: %{column: 12, line: 73}, end: %{column: 15, line: 73}},
+               uri: "test/support/modules_with_references.ex"
+             }
+           ]
+  end
+
+  test "find references with cursor over an erlang function call" do
+    buffer = """
+    defmodule Caller do
+      def func() do
+        :ets.new(:s, [])
+        #                                               ^
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 3, 11)
+
+    assert references == [
+             %{
+               range: %{start: %{column: 12, line: 73}, end: %{column: 15, line: 73}},
+               uri: "test/support/modules_with_references.ex"
              }
            ]
   end

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -3,6 +3,29 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
   # doctest References
 
+  test "finds reference tu local function shadowing builtin type" do
+    buffer = """
+    defmodule B.Callee do
+      def fun() do
+           ^
+        :ok
+      end
+      def my_fun() do
+        :ok
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 2, 8)
+
+    assert references == [
+             %{
+               range: %{start: %{column: 14, line: 3}, end: %{column: 17, line: 3}},
+               uri: "test/support/module_with_builtin_type_shadowing.ex"
+             }
+           ]
+  end
+
   test "find references with cursor over a function call" do
     buffer = """
     defmodule Caller do

--- a/test/elixir_sense/signature_test.exs
+++ b/test/elixir_sense/signature_test.exs
@@ -35,6 +35,36 @@ defmodule ElixirSense.SignatureTest do
              }
     end
 
+    test "find signatures from imported modules" do
+      code = """
+      defmodule MyModule do
+        import List
+        flatten(par1,
+      end
+      """
+
+      assert ElixirSense.signature(code, 3, 16) == %{
+               active_param: 1,
+               pipe_before: false,
+               signatures: [
+                 %{
+                   name: "flatten",
+                   params: ["list"],
+                   documentation: "Flattens the given `list` of nested lists.",
+                   spec: "@spec flatten(deep_list) :: list when deep_list: [any | deep_list]"
+                 },
+                 %{
+                   name: "flatten",
+                   params: ["list", "tail"],
+                   documentation:
+                     "Flattens the given `list` of nested lists.\nThe list `tail` will be added at the end of\nthe flattened list.",
+                   spec:
+                     "@spec flatten(deep_list, [elem]) :: [elem] when deep_list: [elem | deep_list], elem: var"
+                 }
+               ]
+             }
+    end
+
     test "find signatures from atom modules" do
       code = """
       defmodule MyModule do
@@ -134,6 +164,45 @@ defmodule ElixirSense.SignatureTest do
       """
 
       assert ElixirSense.signature(code, 4, 12) == %{
+               active_param: 1,
+               pipe_before: false,
+               signatures: [
+                 %{
+                   name: "sum",
+                   params: ["a", "b"],
+                   documentation: "",
+                   spec: ""
+                 },
+                 %{
+                   name: "sum",
+                   params: ["tuple"],
+                   documentation: "",
+                   spec: ""
+                 }
+               ]
+             }
+    end
+
+    test "finds signatures from metadata module functions" do
+      code = """
+      defmodule MyModule do
+        defp sum(a, b) do
+          a + b
+        end
+
+        defp sum({a, b}) do
+          a + b
+        end
+      end
+
+      defmodule Other do
+        def run do
+          MyModule.sum(a,
+        end
+      end
+      """
+
+      assert ElixirSense.signature(code, 13, 21) == %{
                active_param: 1,
                pipe_before: false,
                signatures: [

--- a/test/support/module_with_builtin_type_shadowing.ex
+++ b/test/support/module_with_builtin_type_shadowing.ex
@@ -1,0 +1,5 @@
+defmodule ElixirSenseExample.ModuleWithBuiltinTypeShadowing do
+  def plain_fun do
+    B.Callee.fun()
+  end
+end

--- a/test/support/modules_with_references.ex
+++ b/test/support/modules_with_references.ex
@@ -68,5 +68,9 @@ defmodule ElixirSense.Providers.ReferencesTest.Modules do
     def call_on_different_line() do
       Callee3.func()
     end
+
+    def call_erlang() do
+      :ets.new(:a, [])
+    end
   end
 end


### PR DESCRIPTION
This PR changes order of returned funs - now builtin types are tried after local functions. Previous implementation returned `{mod, fun}` regardless if the function existed or not. Now metadata is used to verify that.
While working on this i added a few tests and noticed that finding references for imported functions was not working. It turned out that `Source.subject_and_pos returned` wrong column for the call and there was some inconsistency in how call positions were stored in metadata.
I also had to fix `ModuleInfo.get_module_funs` as it was crashing when called for erlang modules
Fixes https://github.com/elixir-lsp/elixir_sense/issues/42
Resolves https://github.com/elixir-lsp/elixir_sense/pull/43
