### PR TITLE
Provide suggestions and definitions for typespecs from metadata

### DIFF
--- a/lib/alchemist/helpers/module_info.ex
+++ b/lib/alchemist/helpers/module_info.ex
@@ -115,5 +115,4 @@ defmodule Alchemist.Helpers.ModuleInfo do
     # for performance.
     :ets.match(:ac_tab, {{:loaded, :"$1"}, :_})
   end
-
 end

--- a/lib/alchemist/helpers/module_info.ex
+++ b/lib/alchemist/helpers/module_info.ex
@@ -17,24 +17,6 @@ defmodule Alchemist.Helpers.ModuleInfo do
     do_docs?(docs, function)
   end
 
-  def expand_alias([name | rest] = list, aliases) do
-    module = Module.concat(Elixir, name)
-
-    aliases
-    |> Enum.find_value(list, fn {alias, mod} ->
-      if alias === module do
-        case Atom.to_string(mod) do
-          "Elixir." <> mod ->
-            Module.concat([mod | rest])
-
-          _ ->
-            mod
-        end
-      end
-    end)
-    |> normalize_module
-  end
-
   def get_functions(module, hint) do
     hint = to_string(hint)
     {module, _} = Code.eval_string(module)
@@ -134,11 +116,4 @@ defmodule Alchemist.Helpers.ModuleInfo do
     :ets.match(:ac_tab, {{:loaded, :"$1"}, :_})
   end
 
-  defp normalize_module(mod) do
-    if is_list(mod) do
-      Module.concat(mod)
-    else
-      mod
-    end
-  end
 end

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -53,7 +53,7 @@ defmodule ElixirSense do
     } = Metadata.get_env(metadata, line)
 
     {actual_subject, docs} =
-      Docs.all(subject, imports, aliases, module, scope, metadata.mods_funs)
+      Docs.all(subject, imports, aliases, module, scope, metadata.mods_funs, metadata.types)
 
     %{subject: subject, actual_subject: actual_subject, docs: docs}
   end
@@ -98,7 +98,8 @@ defmodule ElixirSense do
       vars,
       buffer_file_metadata.mods_funs_to_positions,
       buffer_file_metadata.mods_funs,
-      calls
+      calls,
+      buffer_file_metadata.types
     )
   end
 
@@ -188,6 +189,7 @@ defmodule ElixirSense do
       protocol,
       buffer_file_metadata.mods_funs,
       structs,
+      buffer_file_metadata.types,
       text_before
     )
   end
@@ -398,7 +400,8 @@ defmodule ElixirSense do
           module,
           scope,
           vars,
-          buffer_file_metadata.mods_funs
+          buffer_file_metadata.mods_funs,
+          buffer_file_metadata.types
         )
 
       _ ->

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -13,6 +13,7 @@ defmodule ElixirSense.Core.Metadata do
             calls: %{},
             vars_info_per_scope_id: %{},
             mods_funs: %{},
+            types: %{},
             error: nil
 
   def get_env(%__MODULE__{} = metadata, line) do

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -281,13 +281,12 @@ defmodule ElixirSense.Core.MetadataBuilder do
   end
 
   defp pre(
-         {:@, [line: line, column: column] = meta_attr,
-          [{kind, _, [{:"::", meta, params = [{name, _, type_args}, _type_def]}]}]} = ast,
+         {:@, [line: line, column: column] = _meta_attr,
+          [{kind, _, [{:"::", _meta, _params = [{name, _, type_args}, _type_def]}]}]} = ast,
          state
        )
        when kind in [:type, :typep, :opaque] and is_atom(name) and
               (is_nil(type_args) or is_list(type_args)) do
-    new_ast = {:@, meta_attr, [{:"::", add_no_call(meta), params}]}
     pre_type(ast, state, %{line: line, col: column}, name, List.wrap(type_args), kind)
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -170,6 +170,13 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result(ast)
   end
 
+  defp pre_type(ast, state, %{line: line, col: col}, type_name, type_args, kind) do
+    state
+    |> add_current_env_to_line(line)
+    |> add_type(type_name, type_args, kind, %{line: line, col: col})
+    |> result(ast)
+  end
+
   defp post_string_literal(ast, state, line, str) do
     str
     |> String.split(["\n", "\r\n"])
@@ -271,6 +278,17 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   defp pre({:@, [line: line, column: _column], [{:behaviour, _, [erlang_module]}]} = ast, state) do
     pre_behaviour(ast, state, line, erlang_module)
+  end
+
+  defp pre(
+         {:@, [line: line, column: column] = meta_attr,
+          [{kind, _, [{:"::", meta, params = [{name, _, type_args}, _type_def]}]}]} = ast,
+         state
+       )
+       when kind in [:type, :typep, :opaque] and is_atom(name) and
+              (is_nil(type_args) or is_list(type_args)) do
+    new_ast = {:@, meta_attr, [{:"::", add_no_call(meta), params}]}
+    pre_type(ast, state, %{line: line, col: column}, name, List.wrap(type_args), kind)
   end
 
   defp pre({:@, [line: line, column: _column] = meta_attr, [{name, meta, params}]}, state) do

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -87,6 +87,7 @@ defmodule ElixirSense.Core.Parser do
     %Metadata{
       source: source,
       mods_funs: acc.mods_funs,
+      types: acc.types,
       mods_funs_to_positions: acc.mods_funs_to_positions,
       lines_to_env: acc.lines_to_env,
       vars_info_per_scope_id: acc.vars_info_per_scope_id,

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -630,23 +630,7 @@ defmodule ElixirSense.Core.State do
   def default_env(), do: %ElixirSense.Core.State.Env{}
 
   def expand_alias(state, module) do
-    if ElixirSense.Core.Introspection.elixir_module?(module) do
-      current_aliases = current_aliases(state)
-      module_parts = Module.split(module)
-
-      case current_aliases
-           |> Enum.find(fn {alias, _} ->
-             [alis_split] = Module.split(alias)
-             alis_split == hd(module_parts)
-           end) do
-        nil ->
-          module
-
-        {_alias, alias_expanded} ->
-          Module.concat(Module.split(alias_expanded) ++ tl(module_parts))
-      end
-    else
-      module
-    end
+    current_aliases = current_aliases(state)
+    ElixirSense.Core.Introspection.expand_alias(module, current_aliases)
   end
 end

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -27,7 +27,17 @@ defmodule ElixirSense.Providers.Definition do
   """
   @spec find(String.t(), [module], [{module, module}], module, [%VarInfo{}], map, map, map, map) ::
           %Location{}
-  def find(subject, imports, aliases, module, vars, mods_funs_to_positions, mods_funs, calls, metadata_types) do
+  def find(
+        subject,
+        imports,
+        aliases,
+        module,
+        vars,
+        mods_funs_to_positions,
+        mods_funs,
+        calls,
+        metadata_types
+      ) do
     var_info =
       unless subject_is_call?(subject, calls) do
         vars |> Enum.find(fn %VarInfo{name: name} -> to_string(name) == subject end)
@@ -40,7 +50,14 @@ defmodule ElixirSense.Providers.Definition do
       _ ->
         subject
         |> Source.split_module_and_func(module, aliases)
-        |> find_function_or_module(mods_funs_to_positions, mods_funs, module, imports, aliases, metadata_types)
+        |> find_function_or_module(
+          mods_funs_to_positions,
+          mods_funs,
+          module,
+          imports,
+          aliases,
+          metadata_types
+        )
     end
   end
 
@@ -64,7 +81,13 @@ defmodule ElixirSense.Providers.Definition do
          metadata_types
        ) do
     case {module, function}
-         |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs, metadata_types) do
+         |> Introspection.actual_mod_fun(
+           imports,
+           aliases,
+           current_module,
+           mods_funs,
+           metadata_types
+         ) do
       {nil, nil} ->
         %Location{found: false}
 

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -69,9 +69,18 @@ defmodule ElixirSense.Providers.Definition do
         %Location{found: false}
 
       {mod, fun} ->
-        case mods_funs_to_positions[{mod, fun, nil}] do
+        case mods_funs_to_positions[{mod, fun, nil}] || metadata_types[{mod, fun, nil}] do
           nil ->
             {mod, fun} |> find_source(current_module)
+
+          %ElixirSense.Core.State.TypeInfo{position: %{col: col, line: line}} ->
+            %Location{
+              found: true,
+              file: nil,
+              type: :typespec,
+              line: line,
+              column: col
+            }
 
           %{positions: positions} ->
             # for simplicity take first position here

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -14,7 +14,7 @@ defmodule ElixirSense.Providers.Definition do
   defmodule Location do
     @type t :: %Location{
             found: boolean,
-            type: :module | :function | :variable,
+            type: :module | :function | :variable | :typespec,
             file: String.t() | nil,
             line: pos_integer | nil,
             column: pos_integer | nil

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -25,9 +25,9 @@ defmodule ElixirSense.Providers.Definition do
   @doc """
   Finds out where a module, function, macro or variable was defined.
   """
-  @spec find(String.t(), [module], [{module, module}], module, [%VarInfo{}], map, map, map) ::
+  @spec find(String.t(), [module], [{module, module}], module, [%VarInfo{}], map, map, map, map) ::
           %Location{}
-  def find(subject, imports, aliases, module, vars, mods_funs_to_positions, mods_funs, calls) do
+  def find(subject, imports, aliases, module, vars, mods_funs_to_positions, mods_funs, calls, metadata_types) do
     var_info =
       unless subject_is_call?(subject, calls) do
         vars |> Enum.find(fn %VarInfo{name: name} -> to_string(name) == subject end)
@@ -40,7 +40,7 @@ defmodule ElixirSense.Providers.Definition do
       _ ->
         subject
         |> Source.split_module_and_func(module, aliases)
-        |> find_function_or_module(mods_funs_to_positions, mods_funs, module, imports, aliases)
+        |> find_function_or_module(mods_funs_to_positions, mods_funs, module, imports, aliases, metadata_types)
     end
   end
 
@@ -60,10 +60,11 @@ defmodule ElixirSense.Providers.Definition do
          mods_funs,
          current_module,
          imports,
-         aliases
+         aliases,
+         metadata_types
        ) do
     case {module, function}
-         |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs) do
+         |> Introspection.actual_mod_fun(imports, aliases, current_module, mods_funs, metadata_types) do
       {nil, nil} ->
         %Location{found: false}
 

--- a/lib/elixir_sense/providers/docs.ex
+++ b/lib/elixir_sense/providers/docs.ex
@@ -6,13 +6,13 @@ defmodule ElixirSense.Providers.Docs do
   alias ElixirSense.Core.State
   alias ElixirSense.Core.Source
 
-  @spec all(String.t(), [module], [{module, module}], module, State.scope(), map) ::
+  @spec all(String.t(), [module], [{module, module}], module, State.scope(), map, map) ::
           {actual_mod_fun :: String.t(), docs :: Introspection.docs()}
-  def all(subject, imports, aliases, module, scope, mods_funs) do
+  def all(subject, imports, aliases, module, scope, mods_funs, metadata_types) do
     mod_fun =
       subject
       |> Source.split_module_and_func(module, aliases)
-      |> Introspection.actual_mod_fun(imports, aliases, module, mods_funs)
+      |> Introspection.actual_mod_fun(imports, aliases, module, mods_funs, metadata_types)
 
     {mod_fun_to_string(mod_fun), Introspection.get_all_docs(mod_fun, scope)}
   end

--- a/lib/elixir_sense/providers/signature.ex
+++ b/lib/elixir_sense/providers/signature.ex
@@ -19,7 +19,14 @@ defmodule ElixirSense.Providers.Signature do
     case Source.which_func(prefix, module) do
       %{candidate: {mod, fun}, npar: npar, pipe_before: pipe_before} ->
         {mod, fun} =
-          Introspection.actual_mod_fun({mod, fun}, imports, aliases, module, metadata.mods_funs, metadata.types)
+          Introspection.actual_mod_fun(
+            {mod, fun},
+            imports,
+            aliases,
+            module,
+            metadata.mods_funs,
+            metadata.types
+          )
 
         signatures = find_signatures({mod, fun}, metadata)
         %{active_param: npar, pipe_before: pipe_before, signatures: signatures}

--- a/lib/elixir_sense/providers/signature.ex
+++ b/lib/elixir_sense/providers/signature.ex
@@ -19,7 +19,7 @@ defmodule ElixirSense.Providers.Signature do
     case Source.which_func(prefix, module) do
       %{candidate: {mod, fun}, npar: npar, pipe_before: pipe_before} ->
         {mod, fun} =
-          Introspection.actual_mod_fun({mod, fun}, imports, aliases, module, metadata.mods_funs)
+          Introspection.actual_mod_fun({mod, fun}, imports, aliases, module, metadata.mods_funs, metadata.types)
 
         signatures = find_signatures({mod, fun}, metadata)
         %{active_param: npar, pipe_before: pipe_before, signatures: signatures}

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -528,8 +528,8 @@ defmodule ElixirSense.Providers.Suggestion do
           arity: length(type_info.args),
           signature: "#{type_info.name}(#{args})",
           origin: origin,
-          # doc: type_info.doc,
-          # spec: type_info.spec
+          doc: "",
+          spec: ""
         }
       _ ->
         %{

--- a/test/alchemist/helpers/module_info_test.exs
+++ b/test/alchemist/helpers/module_info_test.exs
@@ -21,14 +21,6 @@ defmodule Alchemist.Helpers.ModuleTest do
     assert ModuleInfo.docs?(nil, :dance) == false
   end
 
-  test "expand_alias return expanded module alias" do
-    aliases = [{MyList, List}, {MyGenServer, :gen_server}]
-
-    assert ModuleInfo.expand_alias([MyList], aliases) == List
-    assert ModuleInfo.expand_alias([MyGenServer], aliases) == :gen_server
-    assert ModuleInfo.expand_alias([MyList], aliases) == List
-  end
-
   test "has_function? return true" do
     assert ModuleInfo.has_function?(List, :flatten) == true
     assert ModuleInfo.has_function?(List, :to_string) == true

--- a/test/elixir_sense/core/introspection_test.exs
+++ b/test/elixir_sense/core/introspection_test.exs
@@ -1,6 +1,6 @@
 defmodule ElixirSense.Core.IntrospectionTest do
   use ExUnit.Case, async: true
-
+  doctest ElixirSense.Core.Introspection
   alias ElixirSense.Core.TypeInfo
   import ElixirSense.Core.Introspection
 

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -920,7 +920,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
     assert get_line_imports(state, 3) == [List]
 
-    # import requires module to make module's macros available
+    # note that `import` causes `require` module's macros available
     assert get_line_requires(state, 3) == [List]
 
     assert get_line_imports(state, 6) == [List, Enum]
@@ -1951,6 +1951,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
 
     assert get_line_behaviours(state, 4) == [ElixirSenseExample.ExampleBehaviour]
 
+    # note that `use` causes `require` to be able to execute `__using__/1` macro
     assert get_line_requires(state, 4) == [
              MyMacros.Two.Three,
              MyMacros.One,

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -2520,6 +2520,59 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
     assert state.calls == %{3 => [%{arity: 1, col: 6, func: :func, line: 3, mod: nil}]}
   end
 
+  test "registers types" do
+    state =
+      """
+      defmodule My do
+        @type no_arg_no_parens :: integer
+        @typep no_args() :: integer
+        @opaque with_args(a, b) :: {a, b}
+        IO.puts("")
+      end
+      IO.puts("")
+      """
+      |> string_to_state
+
+    assert state.types == %{
+             {My, :no_arg_no_parens, 0} => %ElixirSense.Core.State.TypeInfo{
+               args: [],
+               kind: :type,
+               name: :no_arg_no_parens,
+               position: %{col: 3, line: 2}
+             },
+             {My, :no_arg_no_parens, nil} => %ElixirSense.Core.State.TypeInfo{
+               args: [],
+               kind: :type,
+               name: :no_arg_no_parens,
+               position: %{col: 3, line: 2}
+             },
+             {My, :no_args, 0} => %ElixirSense.Core.State.TypeInfo{
+               args: [],
+               kind: :typep,
+               name: :no_args,
+               position: %{col: 3, line: 3}
+             },
+             {My, :no_args, nil} => %ElixirSense.Core.State.TypeInfo{
+               args: [],
+               kind: :typep,
+               name: :no_args,
+               position: %{col: 3, line: 3}
+             },
+             {My, :with_args, 2} => %ElixirSense.Core.State.TypeInfo{
+               args: [:a, :b],
+               kind: :opaque,
+               name: :with_args,
+               position: %{col: 3, line: 4}
+             },
+             {My, :with_args, nil} => %ElixirSense.Core.State.TypeInfo{
+               args: [:a, :b],
+               kind: :opaque,
+               name: :with_args,
+               position: %{col: 3, line: 4}
+             }
+           }
+  end
+
   defp string_to_state(string) do
     string
     |> Code.string_to_quoted(columns: true)

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -531,6 +531,38 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert %{found: false} = ElixirSense.definition(buffer, 2, 23)
   end
 
+  test "find local metadata type definition" do
+    buffer = """
+    defmodule MyModule do
+      @typep my_t :: integer
+
+      @type remote_list_t :: [my_t]
+      #                         ^
+    end
+    """
+
+    %{found: true, type: :typespec, file: nil, line: 2, column: 3} =
+      ElixirSense.definition(buffer, 4, 29)
+  end
+
+  test "find remote metadata type definition" do
+    buffer = """
+    defmodule MyModule.Other do
+      @type my_t :: integer
+    end
+
+    defmodule MyModule do
+      alias MyModule.Other
+
+      @type remote_list_t :: [Other.my_t]
+      #                               ^
+    end
+    """
+
+    %{found: true, type: :typespec, file: nil, line: 2, column: 3} =
+      ElixirSense.definition(buffer, 8, 35)
+  end
+
   defp read_line(file, {line, column}) do
     file
     |> File.read!()

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -60,7 +60,21 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for 'Str'" do
-    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, %{}, "") ==
+    assert Suggestion.find(
+             "Str",
+             [],
+             [],
+             SomeModule,
+             [],
+             [],
+             [],
+             SomeModule,
+             nil,
+             %{},
+             %{},
+             %{},
+             ""
+           ) ==
              [
                %{type: :hint, value: "Str"},
                %{
@@ -193,7 +207,21 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   test "local calls should not return built-in functions" do
     list =
-      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, %{}, "")
+      Suggestion.find(
+        "mo",
+        [MyModule],
+        [],
+        SomeModule,
+        [],
+        [],
+        [],
+        SomeModule,
+        nil,
+        %{},
+        %{},
+        %{},
+        ""
+      )
       |> Enum.filter(fn item -> item.type in [:hint, :function, :function] end)
 
     assert list == [%{type: :hint, value: "mo"}]
@@ -201,7 +229,21 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   test "empty hint should not return built-in functions" do
     suggestions_names =
-      Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, %{}, "")
+      Suggestion.find(
+        "",
+        [MyModule],
+        [],
+        SomeModule,
+        [],
+        [],
+        [],
+        SomeModule,
+        nil,
+        %{},
+        %{},
+        %{},
+        ""
+      )
       |> Enum.filter(&Map.has_key?(&1, :name))
       |> Enum.map(& &1.name)
 

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -22,6 +22,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
         nil,
         %{},
         %{},
+        %{},
         ""
       )
 
@@ -59,7 +60,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
   end
 
   test "return completion candidates for 'Str'" do
-    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "") ==
+    assert Suggestion.find("Str", [], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, %{}, "") ==
              [
                %{type: :hint, value: "Str"},
                %{
@@ -117,6 +118,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                nil,
                %{},
                %{},
+               %{},
                ""
              )
   end
@@ -155,6 +157,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                nil,
                %{},
                %{},
+               %{},
                ""
              )
   end
@@ -170,6 +173,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
              [],
              SomeModule,
              nil,
+             %{},
              %{},
              %{},
              ""
@@ -189,7 +193,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   test "local calls should not return built-in functions" do
     list =
-      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "")
+      Suggestion.find("mo", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, %{}, "")
       |> Enum.filter(fn item -> item.type in [:hint, :function, :function] end)
 
     assert list == [%{type: :hint, value: "mo"}]
@@ -197,7 +201,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   test "empty hint should not return built-in functions" do
     suggestions_names =
-      Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, "")
+      Suggestion.find("", [MyModule], [], SomeModule, [], [], [], SomeModule, nil, %{}, %{}, %{}, "")
       |> Enum.filter(&Map.has_key?(&1, :name))
       |> Enum.map(& &1.name)
 
@@ -222,6 +226,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                nil,
                %{},
                %{},
+               %{},
                ""
              )
   end
@@ -238,6 +243,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                [],
                {:func, 0},
                nil,
+               %{},
                %{},
                %{},
                ""
@@ -258,6 +264,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                nil,
                %{},
                %{},
+               %{},
                ""
              )
   end
@@ -274,6 +281,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                [],
                {:func, 0},
                nil,
+               %{},
                %{},
                %{},
                ""
@@ -298,6 +306,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                  }
                },
                %{},
+               %{},
                ""
              )
 
@@ -315,6 +324,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                %{
                  SomeModule => %{}
                },
+               %{},
                %{},
                ""
              )
@@ -339,6 +349,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                  SomeModule => %{}
                },
                %{SomeModule => {:defstruct, [str_field: 1]}},
+               %{},
                "%SomeModule{st"
              )
   end

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -1688,6 +1688,30 @@ defmodule ElixirSense.SuggestionsTest do
       assert %{arity: 0, name: "my_local_t", origin: "MyModule", type: :type_spec, signature: "my_local_t()"} == suggestion2
       assert %{arity: 2, name: "my_local_arg_t", origin: "MyModule", type: :type_spec, signature: "my_local_arg_t(a, b)"} == suggestion1
     end
+
+    test "remote public and opaque types from metadata" do
+      buffer = """
+      defmodule SomeModule do
+        @typep my_local_priv_t :: integer
+        @type my_local_pub_t(a, b) :: {a, b}
+        @opaque my_local_op_t() :: my_local_priv_t
+      end
+
+      defmodule MyModule do
+        alias SomeModule, as: Some
+        @type my_type :: Some.my_loc
+        #                           ^
+      end
+      """
+
+      list =
+        ElixirSense.suggestions(buffer, 9, 31)
+        |> Enum.filter(fn %{type: t} -> t == :type_spec end)
+
+      assert [suggestion1, suggestion2] = list
+      assert %{arity: 2, name: "my_local_pub_t", origin: "SomeModule", type: :type_spec, signature: "my_local_pub_t(a, b)"} == suggestion2
+      assert %{arity: 0, name: "my_local_op_t", origin: "SomeModule", type: :type_spec, signature: "my_local_op_t()"} == suggestion1
+    end
   end
 
   defmodule ElixirSenseExample.SameModule do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -1685,8 +1685,26 @@ defmodule ElixirSense.SuggestionsTest do
         |> Enum.filter(fn %{type: t} -> t == :type_spec end)
 
       assert [suggestion1, suggestion2] = list
-      assert %{arity: 0, name: "my_local_t", origin: "MyModule", type: :type_spec, signature: "my_local_t()"} == suggestion2
-      assert %{arity: 2, name: "my_local_arg_t", origin: "MyModule", type: :type_spec, signature: "my_local_arg_t(a, b)"} == suggestion1
+
+      assert %{
+               arity: 0,
+               name: "my_local_t",
+               origin: "MyModule",
+               type: :type_spec,
+               signature: "my_local_t()",
+               doc: "",
+               spec: ""
+             } == suggestion2
+
+      assert %{
+               arity: 2,
+               name: "my_local_arg_t",
+               origin: "MyModule",
+               type: :type_spec,
+               signature: "my_local_arg_t(a, b)",
+               doc: "",
+               spec: ""
+             } == suggestion1
     end
 
     test "remote public and opaque types from metadata" do
@@ -1709,8 +1727,26 @@ defmodule ElixirSense.SuggestionsTest do
         |> Enum.filter(fn %{type: t} -> t == :type_spec end)
 
       assert [suggestion1, suggestion2] = list
-      assert %{arity: 2, name: "my_local_pub_t", origin: "SomeModule", type: :type_spec, signature: "my_local_pub_t(a, b)"} == suggestion2
-      assert %{arity: 0, name: "my_local_op_t", origin: "SomeModule", type: :type_spec, signature: "my_local_op_t()"} == suggestion1
+
+      assert %{
+               arity: 2,
+               name: "my_local_pub_t",
+               origin: "SomeModule",
+               type: :type_spec,
+               signature: "my_local_pub_t(a, b)",
+               doc: "",
+               spec: ""
+             } == suggestion2
+
+      assert %{
+               arity: 0,
+               name: "my_local_op_t",
+               origin: "SomeModule",
+               type: :type_spec,
+               signature: "my_local_op_t()",
+               doc: "",
+               spec: ""
+             } == suggestion1
     end
   end
 

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -1669,6 +1669,25 @@ defmodule ElixirSense.SuggestionsTest do
       assert suggestion.doc == "Proper list ([]-terminated)"
       assert suggestion.origin == ""
     end
+
+    test "local types from metadata" do
+      buffer = """
+      defmodule MyModule do
+        @typep my_local_t :: integer
+        @typep my_local_arg_t(a, b) :: {a, b}
+        @type my_type :: my_loc
+        #                      ^
+      end
+      """
+
+      list =
+        ElixirSense.suggestions(buffer, 4, 26)
+        |> Enum.filter(fn %{type: t} -> t == :type_spec end)
+
+      assert [suggestion1, suggestion2] = list
+      assert %{arity: 0, name: "my_local_t", origin: "MyModule", type: :type_spec, signature: "my_local_t()"} == suggestion2
+      assert %{arity: 2, name: "my_local_arg_t", origin: "MyModule", type: :type_spec, signature: "my_local_arg_t(a, b)"} == suggestion1
+    end
   end
 
   defmodule ElixirSenseExample.SameModule do


### PR DESCRIPTION
This PR extends metadata builder to collect typespec info. It was relatively easy to use this in suggestion and definition providers. I also fixed some corner cases and added tests to alias expansion.