### PR TITLE
Provide signatures for erlang functions

### DIFF
--- a/lib/elixir_sense/core/type_info.ex
+++ b/lib/elixir_sense/core/type_info.ex
@@ -485,4 +485,18 @@ defmodule ElixirSense.Core.TypeInfo do
     |> String.split("#{kind} ")
     |> (&match?([_, _ | _], &1)).()
   end
+
+  def extract_params({:type, _, :fun, [{:type, _, :product, params_types}, _]}) do
+    params_types
+    |> Enum.map(&extract_params_from_args_spec/1)
+  end
+
+  def extract_params({:type, _, :bounded_fun, [type, _constraints]}) do
+    {:type, _, :fun, [{:type, _, :product, params}, _]} = type
+
+    params
+    |> Enum.map(&extract_params_from_args_spec/1)
+  end
+
+  defp extract_params_from_args_spec({:var, _, param}), do: param
 end

--- a/test/elixir_sense/signature_test.exs
+++ b/test/elixir_sense/signature_test.exs
@@ -5,6 +5,35 @@ defmodule ElixirSense.SignatureTest do
   doctest Signature
 
   describe "signature" do
+    test "find signatures from erlang module" do
+      code = """
+      defmodule MyModule do
+        :lists.flatten(par1,
+      end
+      """
+
+      assert ElixirSense.signature(code, 2, 24) == %{
+               active_param: 1,
+               pipe_before: false,
+               signatures: [
+                 %{
+                   name: "flatten",
+                   params: ["DeepList", "Tail"],
+                   documentation: "No documentation available",
+                   spec:
+                     "@spec flatten(deepList, tail) :: list when deepList: [term | deepList], tail: [term], list: [term]"
+                 },
+                 %{
+                   name: "flatten",
+                   params: ["DeepList"],
+                   documentation: "No documentation available",
+                   spec:
+                     "@spec flatten(deepList) :: list when deepList: [term | deepList], list: [term]"
+                 }
+               ]
+             }
+    end
+
     test "find signatures from aliased modules" do
       code = """
       defmodule MyModule do


### PR DESCRIPTION
As long as EEP 48 is not implemented in erlang, getting docs for erlang functions always fails with `{:error, :chunk_not_found}`. This PR adds fallback to typespecs that we are able to return at least something of a value.