### PR TITLE
Provide definitions for erlang types

### DIFF
--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -224,13 +224,6 @@ defmodule ElixirSense.Core.Introspection do
     |> Enum.at(0)
   end
 
-  def get_type_position(mod, type_name, file) do
-    # TODO: extend the metadata builder to hold type definitions
-    # so we can find private types and types from modules that
-    # can't be compiled. If it can't find, fallback to this one.
-    TypeInfo.get_type_position_using_docs(mod, type_name, file)
-  end
-
   defp format_type({kind, type}) do
     ast = Typespec.type_to_quoted(type)
     "@#{kind} #{format_spec_ast(ast)}"

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -6,6 +6,7 @@ defmodule ElixirSense.Core.Metadata do
   alias ElixirSense.Core.State
   alias ElixirSense.Core.Introspection
   alias ElixirSense.Core.Normalized.Code, as: NormalizedCode
+  alias alias ElixirSense.Core.TypeInfo
 
   defstruct source: nil,
             mods_funs_to_positions: %{},
@@ -43,6 +44,16 @@ defmodule ElixirSense.Core.Metadata do
     case Map.get(metadata.mods_funs_to_positions, {module, function, nil}) do
       nil -> get_function_position_using_docs(module, function)
       %{positions: positions} -> List.last(positions)
+    end
+  end
+
+  def get_type_position(%__MODULE__{} = metadata, module, type, file) do
+    case Map.get(metadata.types, {module, type, nil}) do
+      nil ->
+        TypeInfo.get_type_position_using_docs(module, type, file)
+
+      %ElixirSense.Core.State.TypeInfo{position: %{col: col, line: line}} ->
+        {line, col}
     end
   end
 

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -100,7 +100,7 @@ defmodule ElixirSense.Core.Metadata do
     docs = NormalizedCode.get_docs(module, :docs)
 
     for {{func, _arity}, line, _kind, _, _} <- docs, func == function do
-      {line, 0}
+      {line, 1}
     end
     |> Enum.at(0)
   end

--- a/lib/elixir_sense/core/type_info.ex
+++ b/lib/elixir_sense/core/type_info.ex
@@ -66,16 +66,19 @@ defmodule ElixirSense.Core.TypeInfo do
         {kind, _} = get_type_spec(module, type_name)
         kind_str = "@#{kind}"
 
-        {str, index} =
-          File.read!(file)
-          |> Source.text_after(doc_line, 1)
-          |> String.split("\n")
-          |> Enum.with_index()
-          |> Enum.find(fn {str, _} -> starts_with_type_def?(str, kind_str) end)
+        case File.read!(file)
+             |> Source.text_after(doc_line, 1)
+             |> String.split("\n")
+             |> Enum.with_index()
+             |> Enum.find(fn {str, _} -> starts_with_type_def?(str, kind_str) end) do
+          {str, index} ->
+            kind_col = String.split(str, kind_str) |> Enum.at(0) |> String.length()
+            col = kind_col + String.length(kind_str) + 2
+            {doc_line + index, col}
 
-        kind_col = String.split(str, kind_str) |> Enum.at(0) |> String.length()
-        col = kind_col + String.length(kind_str) + 2
-        {doc_line + index, col}
+          nil ->
+            {doc_line, 1}
+        end
 
       _ ->
         nil

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -150,14 +150,15 @@ defmodule ElixirSense.Providers.Definition do
       if file && File.exists?(file) do
         file
       else
-        erl_file =
-          module
-          |> :code.which()
-          |> to_string
-          |> String.replace(Regex.recompile!(~r/(.+)\/ebin\/([^\s]+)\.beam$/), "\\1/src/\\2.erl")
-
-        if File.exists?(erl_file) do
+        with {_module, _binary, beam_filename} <- :code.get_object_code(module),
+        erl_file = beam_filename
+        |> to_string
+        |> String.replace(Regex.recompile!(~r/(.+)\/ebin\/([^\s]+)\.beam$/), "\\1/src/\\2.erl"),
+        true <- File.exists?(erl_file)
+        do
           erl_file
+        else
+          _ -> nil
         end
       end
 

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -218,10 +218,8 @@ defmodule ElixirSense.Providers.Definition do
       if String.ends_with?(file, ".erl") do
         find_type_position_in_erl_file(file, name)
       else
-        # file_metadata = Parser.parse_file(file, false, false, nil)
-        # Metadata.get_function_position(file_metadata, mod, fun)
-        # TODO
-        Introspection.get_type_position(mod, name, file)
+        file_metadata = Parser.parse_file(file, false, false, nil)
+        Metadata.get_type_position(file_metadata, mod, name, file)
       end
 
     case position do

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -151,11 +151,14 @@ defmodule ElixirSense.Providers.Definition do
         file
       else
         with {_module, _binary, beam_filename} <- :code.get_object_code(module),
-        erl_file = beam_filename
-        |> to_string
-        |> String.replace(Regex.recompile!(~r/(.+)\/ebin\/([^\s]+)\.beam$/), "\\1/src/\\2.erl"),
-        true <- File.exists?(erl_file)
-        do
+             erl_file =
+               beam_filename
+               |> to_string
+               |> String.replace(
+                 Regex.recompile!(~r/(.+)\/ebin\/([^\s]+)\.beam$/),
+                 "\\1/src/\\2.erl"
+               ),
+             true <- File.exists?(erl_file) do
           erl_file
         else
           _ -> nil
@@ -185,24 +188,43 @@ defmodule ElixirSense.Providers.Definition do
   defp fun_to_type(nil), do: :module
   defp fun_to_type(_), do: :function
 
-  defp find_fun_position_in_erl_file(file, fun) do
-    fun_name = Atom.to_string(fun)
+  defp find_fun_position_in_erl_file(_file, nil), do: {1, 1}
 
+  defp find_fun_position_in_erl_file(file, name) do
+    find_line_by_regex(file, Regex.recompile!(~r/^#{name}\b/))
+  end
+
+  defp find_type_position_in_erl_file(file, name) do
+    find_line_by_regex(file, Regex.recompile!(~r/^-(typep?|opaque)\s#{name}\b/))
+  end
+
+  defp find_line_by_regex(file, regex) do
     index =
       file
       |> File.read!()
       |> String.split(["\n", "\r\n"])
-      |> Enum.find_index(&String.match?(&1, Regex.recompile!(~r/^#{fun_name}\b/)))
+      |> Enum.find_index(&String.match?(&1, regex))
 
-    {(index || 0) + 1, 1}
+    case index do
+      nil -> nil
+      i -> {i + 1, 1}
+    end
   end
 
-  defp find_type_position({_, file}, _fun) when file in ["non_existing", nil, ""] do
-    %Location{found: false}
-  end
+  defp find_type_position(_, nil), do: nil
 
   defp find_type_position({mod, file}, name) do
-    case Introspection.get_type_position(mod, name, file) do
+    position =
+      if String.ends_with?(file, ".erl") do
+        find_type_position_in_erl_file(file, name)
+      else
+        # file_metadata = Parser.parse_file(file, false, false, nil)
+        # Metadata.get_function_position(file_metadata, mod, fun)
+        # TODO
+        Introspection.get_type_position(mod, name, file)
+      end
+
+    case position do
       {line, column} ->
         %Location{found: true, type: :typespec, file: file, line: line, column: column}
 

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -116,6 +116,22 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert read_line(file, {line, column}) =~ "function_arity_one"
   end
 
+  test "find function definition macro generated" do
+    buffer = """
+    defmodule MyModule do
+      alias ElixirSenseExample.MacroGenerated, as: Local
+      Local.my_fun()
+      #        ^
+    end
+    """
+
+    %{found: true, type: :function, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 3, 12)
+
+    assert file =~ "elixir_sense/test/support/macro_generated.ex"
+    assert read_line(file, {line, column}) =~ "ElixirSenseExample.Macros.go"
+  end
+
   test "find definition of delegated functions" do
     buffer = """
     defmodule MyModule do
@@ -489,7 +505,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
       ElixirSense.definition(buffer, 2, 31)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
-    assert read_line(file, {line, column}) =~ ~r/^remote_t ::/
+    assert read_line(file, {line, column}) =~ ~r/^@type remote_t/
   end
 
   test "find remote type definition" do
@@ -505,7 +521,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
-    assert read_line(file, {line, column}) =~ ~r/^remote_t ::/
+    assert read_line(file, {line, column}) =~ ~r/^@type remote_t/
   end
 
   test "find type definition without @typedoc" do
@@ -521,7 +537,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
-    assert read_line(file, {line, column}) =~ ~r/^remote_option_t ::/
+    assert read_line(file, {line, column}) =~ ~r/@type remote_option_t ::/
   end
 
   test "find opaque type definition" do
@@ -537,7 +553,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
-    assert read_line(file, {line, column}) =~ ~r/^opaque_t ::/
+    assert read_line(file, {line, column}) =~ ~r/@opaque opaque_t/
   end
 
   test "find erlang type definition" do

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -239,7 +239,9 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %Location{found: true, line: 1, column: 1, type: :module, file: file} = ElixirSense.definition(buffer, 2, 5)
+    assert %Location{found: true, line: 1, column: 1, type: :module, file: file} =
+             ElixirSense.definition(buffer, 2, 5)
+
     assert file =~ "/src/erlang.erl"
   end
 
@@ -536,6 +538,36 @@ defmodule ElixirSense.Providers.DefinitionTest do
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
     assert read_line(file, {line, column}) =~ ~r/^opaque_t ::/
+  end
+
+  test "find erlang type definition" do
+    buffer = """
+    defmodule MyModule do
+      :ets.tab
+      #     ^
+    end
+    """
+
+    %{found: true, type: :typespec, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 2, 9)
+
+    assert file =~ "/src/ets.erl"
+    assert read_line(file, {line, column}) =~ "-type tab()"
+  end
+
+  test "find erlang type definition from preloaded module" do
+    buffer = """
+    defmodule MyModule do
+      :erlang.time_unit
+      #        ^
+    end
+    """
+
+    %{found: true, type: :typespec, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 2, 12)
+
+    assert file =~ "/src/erlang.erl"
+    assert read_line(file, {line, column}) =~ "-type time_unit()"
   end
 
   test "builtin types cannot now be found" do

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -556,6 +556,22 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert read_line(file, {line, column}) =~ ~r/@opaque opaque_t/
   end
 
+  test "find type definition macro generated" do
+    buffer = """
+    defmodule MyModule do
+      alias ElixirSenseExample.MacroGenerated, as: Local
+      Local.my_type
+      #        ^
+    end
+    """
+
+    %{found: true, type: :typespec, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 3, 12)
+
+    assert file =~ "elixir_sense/test/support/macro_generated.ex"
+    assert read_line(file, {line, column}) =~ "ElixirSenseExample.Macros.go"
+  end
+
   test "find erlang type definition" do
     buffer = """
     defmodule MyModule do

--- a/test/support/macro_generated.ex
+++ b/test/support/macro_generated.ex
@@ -1,0 +1,14 @@
+defmodule ElixirSenseExample.Macros do
+  defmacro go do
+    quote do
+      @type my_type :: nil
+      def my_fun(), do: :ok
+    end
+  end
+end
+
+defmodule ElixirSenseExample.MacroGenerated do
+  require ElixirSenseExample.Macros
+
+  ElixirSenseExample.Macros.go()
+end


### PR DESCRIPTION
With this PR definition provider is able to get definitions of types from erlang modules. Moreover, I was able to improve definition retrieval from erlang modules in case of preloaded modules (by using `:code.get_object_code/1` instead of `:code.which/1`).
For elixir types I implemented a mechanism similar to the one used for functions and modules i.e. try metadata and fall back to docs.