### PR TITLE
Update elixir and otp versions in .tool-versions and .travis.yml

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.0.5
-elixir ref:v1.9.1
+elixir 1.9.4
+erlang 22.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ otp_release:
 env:
   EX_HOME: ${TRAVIS_BUILD_DIR}/elixir
   EX_BIN: ${TRAVIS_BUILD_DIR}/elixir/bin
-  EX_VSN: 1.9.1
+  EX_VSN: 1.9.4
 
 before_script:
   - git clone https://github.com/elixir-lang/elixir.git ${EX_HOME}


### PR DESCRIPTION
If you wish 😁

PS: locally I've been running it for a while on macOS Catalina without noticing any problems (elixir `1.9.4`, first with erlang `22.1.8`, then with `22.2.1`).