### PR TITLE
Fix dialyzer error

### DIFF
--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -332,7 +332,7 @@ defmodule ElixirSense.Providers.Suggestion do
 
       {result, if(fields_so_far == [], do: :maybe_struct_update)}
     else
-      {:_, fields_so_far, false} ->
+      {:_, fields_so_far, false} when is_list(fields_so_far) ->
         result =
           [:__struct__]
           |> Kernel.--(fields_so_far)


### PR DESCRIPTION
This should unbreak the build 🙂

```
lib/elixir_sense/providers/suggestion.ex:338:call
The function call will not succeed.

:erlang.--([:__struct__], _fields_so_far :: atom())

will never return since it differs in arguments with
positions 2nd from the success typing arguments:

([any()], [any()])

________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2

```

```elixir
      {:_, fields_so_far, false} ->
        result =
          [:__struct__]
          |> Kernel.--(fields_so_far)
          |> Enum.filter(fn field -> String.starts_with?("#{field}", hint) end)
          # ...
```

The problem is that `fields_so_far` is expected to come from `Source.which_struct`, but it can also be a response from `Introspection.actual_mod_fun`. This guard removes the ambiguity.