### PR TITLE
Fetch docs from behaviour callback docs

### DIFF
--- a/lib/elixir_sense/core/normalized/code.ex
+++ b/lib/elixir_sense/core/normalized/code.ex
@@ -108,8 +108,8 @@ defmodule ElixirSense.Core.Normalized.Code do
     Enum.map(
       docs_from_module,
       fn
-        {name_arity, line, :def, args, nil} ->
-          {name_arity, line, :def, args, Map.get(docs_from_behaviours, name_arity)}
+        {name_arity, line, type, args, nil} ->
+          {name_arity, line, type, args, Map.get(docs_from_behaviours, name_arity)}
 
         other ->
           other

--- a/lib/elixir_sense/core/normalized/code.ex
+++ b/lib/elixir_sense/core/normalized/code.ex
@@ -132,9 +132,8 @@ defmodule ElixirSense.Core.Normalized.Code do
   end
 
   defp callback_documentation(module) do
-    module
-    |> get_docs(:callback_docs)
-    |> Stream.map(fn {name_arity, _line, _, doc} -> {name_arity, doc} end)
+    docs = get_docs(module, :callback_docs) || []
+    Stream.map(docs, fn {name_arity, _line, _, doc} -> {name_arity, doc} end)
   end
 
   defp behaviours(module) do

--- a/lib/elixir_sense/core/normalized/code.ex
+++ b/lib/elixir_sense/core/normalized/code.ex
@@ -100,16 +100,16 @@ defmodule ElixirSense.Core.Normalized.Code do
 
     non_documented =
       docs_from_module
-      |> Stream.filter(&match?({_name_arity, _line, _, _args, nil}, &1))
-      |> Enum.into(MapSet.new(), fn {name_arity, _line, _, _args, nil} -> name_arity end)
+      |> Stream.filter(fn {_name_arity, _line, _, _args, doc} -> doc in [nil, false] end)
+      |> Enum.into(MapSet.new(), fn {name_arity, _line, _, _args, _doc} -> name_arity end)
 
     docs_from_behaviours = get_docs_from_behaviour(module, non_documented)
 
     Enum.map(
       docs_from_module,
       fn
-        {name_arity, line, type, args, nil} ->
-          {name_arity, line, type, args, Map.get(docs_from_behaviours, name_arity)}
+        {name_arity, line, type, args, doc} ->
+          {name_arity, line, type, args, Map.get(docs_from_behaviours, name_arity, doc)}
 
         other ->
           other

--- a/test/elixir_sense/docs_test.exs
+++ b/test/elixir_sense/docs_test.exs
@@ -850,4 +850,28 @@ defmodule ElixirSense.DocsTest do
            Docs for foo
            """
   end
+
+  test "retrieve macro documentation from behaviour if available" do
+    buffer = """
+    defmodule MyModule do
+      import ElixirSenseExample.ExampleBehaviourWithDocCallback
+      bar()
+    end
+    """
+
+    %{
+      subject: subject,
+      actual_subject: actual_subject,
+      docs: %{docs: docs}
+    } = ElixirSense.docs(buffer, 3, 5)
+
+    assert subject == "bar"
+    assert actual_subject == "ElixirSenseExample.ExampleBehaviourWithDocCallback.bar"
+
+    assert docs =~ """
+           > ElixirSenseExample.ExampleBehaviourWithDocCallback.bar()
+
+           Docs for bar
+           """
+  end
 end

--- a/test/elixir_sense/docs_test.exs
+++ b/test/elixir_sense/docs_test.exs
@@ -851,6 +851,30 @@ defmodule ElixirSense.DocsTest do
            """
   end
 
+  test "retrieve function documentation from behaviour even if @doc is set to false" do
+    buffer = """
+    defmodule MyModule do
+      import ElixirSenseExample.ExampleBehaviourWithDocCallback
+      baz()
+    end
+    """
+
+    %{
+      subject: subject,
+      actual_subject: actual_subject,
+      docs: %{docs: docs}
+    } = ElixirSense.docs(buffer, 3, 5)
+
+    assert subject == "baz"
+    assert actual_subject == "ElixirSenseExample.ExampleBehaviourWithDocCallback.baz"
+
+    assert docs =~ """
+           > ElixirSenseExample.ExampleBehaviourWithDocCallback.baz()
+
+           Docs for baz
+           """
+  end
+
   test "retrieve macro documentation from behaviour if available" do
     buffer = """
     defmodule MyModule do

--- a/test/elixir_sense/docs_test.exs
+++ b/test/elixir_sense/docs_test.exs
@@ -826,4 +826,28 @@ defmodule ElixirSense.DocsTest do
                ElixirSense.docs(buffer, 8, 5)
     end
   end
+
+  test "retrieve function documentation from behaviour if available" do
+    buffer = """
+    defmodule MyModule do
+      import ElixirSenseExample.ExampleBehaviourWithDocCallback
+      foo()
+    end
+    """
+
+    %{
+      subject: subject,
+      actual_subject: actual_subject,
+      docs: %{docs: docs}
+    } = ElixirSense.docs(buffer, 3, 5)
+
+    assert subject == "foo"
+    assert actual_subject == "ElixirSenseExample.ExampleBehaviourWithDocCallback.foo"
+
+    assert docs =~ """
+           > ElixirSenseExample.ExampleBehaviourWithDocCallback.foo()
+
+           Docs for foo
+           """
+  end
 end

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -204,10 +204,15 @@ end
 defmodule ElixirSenseExample.ExampleBehaviourWithDoc do
   @doc "Docs for foo"
   @callback foo() :: :ok
+
+  @doc "Docs for bar"
+  @macrocallback bar() :: Macro.t()
 end
 
 defmodule ElixirSenseExample.ExampleBehaviourWithDocCallback do
   @behaviour ElixirSenseExample.ExampleBehaviourWithDoc
 
   def foo(), do: :ok
+
+  defmacro bar(), do: quote(do: :ok)
 end

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -205,6 +205,9 @@ defmodule ElixirSenseExample.ExampleBehaviourWithDoc do
   @doc "Docs for foo"
   @callback foo() :: :ok
 
+  @doc "Docs for baz"
+  @callback baz() :: :ok
+
   @doc "Docs for bar"
   @macrocallback bar() :: Macro.t()
 end
@@ -215,6 +218,9 @@ defmodule ElixirSenseExample.ExampleBehaviourWithDocCallback do
   @behaviour :gen_statem
 
   def foo(), do: :ok
+
+  @impl true
+  def baz(), do: :ok
 
   defmacro bar(), do: quote(do: :ok)
 end

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -200,3 +200,14 @@ defmodule ElixirSenseExample.ExampleBehaviour do
     :ok
   end
 end
+
+defmodule ElixirSenseExample.ExampleBehaviourWithDoc do
+  @doc "Docs for foo"
+  @callback foo() :: :ok
+end
+
+defmodule ElixirSenseExample.ExampleBehaviourWithDocCallback do
+  @behaviour ElixirSenseExample.ExampleBehaviourWithDoc
+
+  def foo(), do: :ok
+end

--- a/test/support/example_behaviour.ex
+++ b/test/support/example_behaviour.ex
@@ -211,6 +211,8 @@ end
 
 defmodule ElixirSenseExample.ExampleBehaviourWithDocCallback do
   @behaviour ElixirSenseExample.ExampleBehaviourWithDoc
+  @behaviour GenServer
+  @behaviour :gen_statem
 
   def foo(), do: :ok
 


### PR DESCRIPTION
This PR aims to improve docs fetching when docs are not available in the module itself, but they can be derived from callback docs of the behaviour module.

A typical example of this is the repo module. For example, currently, vscode-elixirls produces the following:

![image](https://user-images.githubusercontent.com/202498/74322491-4d87f900-4d84-11ea-9391-3b3c85f86866.png)

With these changes, it can fetch docs from the behaviour module:

![image](https://user-images.githubusercontent.com/202498/74322056-a014e580-4d83-11ea-8a2c-083a65dfd9a1.png)

Testing this manually with VSCode turned out to be quite a challenge. It appears that this project moved much further compared to elixir-ls, so I ultimately had to create a temporary branch in the past. Even with that, I got some compilation warnings in elixir-ls, and some exceptions in VSCode, but this particular functionality seems to work correctly. My impression is that these exceptions are a consequence of sync loss between elixir-ls master and elixir_sense, but I'm not quite sure.

In any case, I'd advise you to test this yourself before you merge it.