### PR TITLE
Introduce a simple static type analyser

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.10.3
-erlang 22.3.2
+erlang 23.0.1

--- a/lib/elixir_sense/core/binding.ex
+++ b/lib/elixir_sense/core/binding.ex
@@ -1,0 +1,430 @@
+defmodule ElixirSense.Core.Binding do
+  @moduledoc false
+
+  alias ElixirSense.Core.Binding
+  alias ElixirSense.Core.Normalized.Typespec
+  alias ElixirSense.Core.State
+  alias ElixirSense.Core.Struct
+  alias ElixirSense.Core.TypeInfo
+
+  defstruct structs: %{},
+            variables: [],
+            attributes: [],
+            current_module: nil,
+            imports: [],
+            specs: %{},
+            types: %{},
+            mods_and_funs: %{}
+
+  defp get_fields_from({:map, fields, _}), do: fields
+  defp get_fields_from({:struct, fields, _, _}), do: fields
+  defp get_fields_from(_), do: []
+
+  defp get_struct_fields(%Binding{structs: structs}, fields, module) do
+    if Struct.is_struct(module, structs) do
+      fields_values =
+        for field <- Struct.get_fields(module, structs), field != :__struct__ do
+          {field, fields[field]}
+        end
+
+      struct =
+        case fields[:__struct__] do
+          nil -> {:atom, module}
+          other -> other
+        end
+
+      {Keyword.put(fields_values, :__struct__, struct), module}
+    else
+      {Keyword.put_new(fields, :__struct__, nil), nil}
+    end
+  end
+
+  def expand(%Binding{variables: variables} = env, {:variable, variable}) do
+    type =
+      case Enum.find(variables, fn %{name: name} -> name == variable end) do
+        nil ->
+          # no variable found - treat a local call
+          expand(env, {:local_call, variable, 0})
+
+        %State.VarInfo{name: name, type: type} ->
+          # filter underscored variables
+          unless name |> Atom.to_string() |> String.starts_with?("_") do
+            type
+          end
+      end
+
+    expand(env, type)
+  end
+
+  def expand(%Binding{attributes: attributes} = env, {:attribute, attribute}) do
+    type =
+      case Enum.find(attributes, fn %{name: name} -> name == attribute end) do
+        nil -> nil
+        %State.AttributeInfo{type: type} -> type
+      end
+
+    expand(env, type)
+  end
+
+  def expand(%Binding{structs: structs} = env, {:struct, fields, module, updated_struct}) do
+    # struct type must be a compile time atom or attribute
+    module =
+      case module do
+        {:atom, atom} -> {:atom, atom}
+        {:attribute, attr} -> {:attribute, attr}
+        _ -> nil
+      end
+
+    module =
+      case expand(env, module) do
+        {:atom, atom} -> atom
+        _ -> nil
+      end
+
+    if module == nil or Struct.is_struct(module, structs) do
+      expanded = expand(env, updated_struct)
+
+      {fields, module} =
+        get_struct_fields(env, get_fields_from(expanded) |> Keyword.merge(fields), module)
+
+      {:struct, fields, module, nil}
+    end
+  end
+
+  def expand(env, {:map, fields, updated_map}) do
+    case expand(env, updated_map) do
+      {:map, expanded_fields, nil} ->
+        {:map, expanded_fields |> Keyword.merge(fields), nil}
+
+      {:struct, expanded_fields, type, nil} ->
+        {:struct, expanded_fields |> Keyword.merge(fields), type, nil}
+
+      _ ->
+        {:map, fields, nil}
+    end
+  end
+
+  # remote call
+  def expand(env, {:call, target, function, arity}) do
+    expanded_target = expand(env, target)
+    # do not include private funs on remote call
+    expand_call(env, expanded_target, function, arity, false)
+    |> drop_no_spec
+  end
+
+  # local call
+  def expand(
+        %Binding{imports: imports, current_module: current_module} = env,
+        {:local_call, function, arity}
+      ) do
+    candidate_targets = [current_module] ++ imports ++ [Kernel, Kernel.SpecialForms]
+
+    # take first matching
+    Enum.find_value(candidate_targets, fn candidate ->
+      # include private from current module
+      include_private = candidate == current_module
+      expand_call(env, {:atom, candidate}, function, arity, include_private)
+    end)
+    |> drop_no_spec
+  end
+
+  def expand(_env, {:atom, atom}), do: {:atom, atom}
+
+  def expand(_env, _other), do: nil
+
+  defp drop_no_spec(:no_spec), do: nil
+  defp drop_no_spec(other), do: other
+
+  # not supported
+  defp expand_call(_env, nil, _, _, _), do: nil
+
+  # map field access
+  defp expand_call(env, {:map, fields, _}, field, arity, _) do
+    # field access is a call with arity 0, other are not allowed
+    if arity == 0 do
+      expand(env, fields[field])
+    end
+  end
+
+  # struct field access
+  defp expand_call(env, {:struct, fields, _, _}, field, arity, _) do
+    # field access is a call with arity 0, other are not allowed
+    if arity == 0 do
+      expand(env, fields[field])
+    end
+  end
+
+  # function call
+  defp expand_call(env, {:atom, mod}, fun, arity, include_private)
+       when mod not in [nil, true, false] and fun not in [nil, true, false] do
+    case expand_call_from_metadata(env, mod, fun, arity, include_private) do
+      result when not is_nil(result) -> result
+      nil -> expand_call_from_introspection(env, mod, fun, arity, include_private)
+    end
+  end
+
+  # not a module
+  defp expand_call(_env, {:atom, _mod}, _fun, _arity, _include_private), do: nil
+
+  defp call_arity_match?(fun_arity, fun_defaults, call_arity) do
+    fun_arity - fun_defaults <= call_arity and call_arity <= fun_arity
+  end
+
+  defp expand_call_from_introspection(env, mod, fun, arity, include_private) do
+    arity =
+      case ElixirSense.Core.Normalized.Code.get_docs(mod, :docs) do
+        nil ->
+          # no docs - use call arity if fun exported
+          if function_exported?(mod, fun, arity) do
+            arity
+          end
+
+        list ->
+          # correct arity for calls with default params
+          list
+          |> Enum.find_value(arity, fn {{f, a}, _, _, _, _, map} ->
+            if f == fun and call_arity_match?(a, Map.get(map, :defaults, 0), arity) do
+              a
+            end
+          end)
+      end
+
+    # TODO maybe callback from behaviour
+    if arity do
+      type = TypeInfo.get_spec(mod, fun, arity)
+      return_type = get_return_from_spec(env, type, mod, include_private)
+      expand(env, return_type) || :no_spec
+    end
+  end
+
+  defp expand_call_from_metadata(
+         %Binding{specs: specs, mods_and_funs: mods_and_funs} = env,
+         mod,
+         fun,
+         arity,
+         include_private
+       ) do
+    arity =
+      case mods_and_funs[{mod, fun, nil}] do
+        %State.ModFunInfo{type: fun_type} = info
+        when (include_private and fun_type != :def) or
+               fun_type in [:def, :defmacro, :defguard, :defdelegate] ->
+          # correct arity for calls with default params
+          State.ModFunInfo.get_arities(info)
+          |> Enum.find_value(arity, fn {a, defaults} ->
+            if call_arity_match?(a, defaults, arity) do
+              a
+            end
+          end)
+
+        _ ->
+          nil
+      end
+
+    case {arity, specs[{mod, fun, arity}]} do
+      {nil, _} ->
+        # fun not found
+        nil
+
+      {_, %State.SpecInfo{} = spec} ->
+        get_return_from_metadata(env, mod, spec, include_private) || :no_spec
+
+      _ ->
+        :no_spec
+    end
+  end
+
+  defp extract_type({:"::", _, [_, type]}), do: type
+
+  defp extract_type({:when, _, [{:"::", _, [_, type]}, type_params]}) do
+    # substitute type params
+    Macro.prewalk(type, fn
+      {atom, _, nil} = var ->
+        Keyword.get(type_params, atom, var)
+
+      other ->
+        other
+    end)
+  end
+
+  defp get_return_from_metadata(env, mod, %State.SpecInfo{specs: [func_spec]}, include_private) do
+    case Code.string_to_quoted(func_spec) do
+      {:ok, {:@, _, [{_kind, _, [ast]}]}} ->
+        type = extract_type(ast)
+        parsed_type = parse_type(env, type, mod, include_private)
+        expand(env, parsed_type)
+
+      _ ->
+        nil
+    end
+  end
+
+  # intersection specs
+  defp get_return_from_metadata(
+         env,
+         mod,
+         %State.SpecInfo{specs: [_ | _] = variants} = spec,
+         include_private
+       ) do
+    # check if all variants return the same type
+    # if so return it, otherwise nil
+    Enum.reduce_while(variants, :none, fn variant, acc ->
+      case {acc,
+            get_return_from_metadata(
+              env,
+              mod,
+              %State.SpecInfo{spec | specs: [variant]},
+              include_private
+            )} do
+        {:none, expanded} -> {:cont, expanded}
+        {last, last} -> {:cont, last}
+        {_, _} -> {:halt, nil}
+      end
+    end)
+  end
+
+  defp get_return_from_spec(_env, nil, _, _include_private), do: nil
+
+  defp get_return_from_spec(env, {{fun, _arity}, [ast]}, mod, include_private) do
+    type = Typespec.spec_to_quoted(fun, ast) |> extract_type
+    parse_type(env, type, mod, include_private)
+  end
+
+  # intersection specs
+  defp get_return_from_spec(env, {{fun, arity}, [_ast | _] = variants}, mod, include_private) do
+    # check if all variants return the same type
+    # if so return it, otherwise nil
+    Enum.reduce_while(variants, :none, fn variant, acc ->
+      case {acc, get_return_from_spec(env, {{fun, arity}, [variant]}, mod, include_private)} do
+        {:none, expanded} -> {:cont, expanded}
+        {last, last} -> {:cont, last}
+        {_, _} -> {:halt, nil}
+      end
+    end)
+  end
+
+  # union type
+  defp parse_type(env, {:|, _, variants}, mod, include_private) do
+    # check if all variants expand to the same type
+    # if so return it, otherwise nil
+    Enum.reduce_while(variants, :none, fn variant, acc ->
+      case {acc, parse_type(env, variant, mod, include_private)} do
+        {:none, expanded} -> {:cont, expanded}
+        {last, last} -> {:cont, last}
+        {_, _} -> {:halt, nil}
+      end
+    end)
+  end
+
+  # struct
+  defp parse_type(
+         env,
+         {:%, _,
+          [
+            struct_mod,
+            {:%{}, _, fields}
+          ]},
+         mod,
+         include_private
+       ) do
+    fields =
+      for {field, type} <- fields,
+          is_atom(field),
+          do: {field, parse_type(env, type, mod, include_private)}
+
+    module =
+      case struct_mod do
+        m when is_atom(m) ->
+          m
+
+        {:__aliases__, _, list} ->
+          Module.concat(list)
+      end
+
+    {:struct, fields, {:atom, module}, nil}
+  end
+
+  # map
+  defp parse_type(env, {:%{}, _, fields}, mod, include_private) do
+    fields =
+      for {field, type} <- fields,
+          field = drop_optional(field),
+          is_atom(field),
+          do: {field, parse_type(env, type, mod, include_private)}
+
+    {:map, fields, nil}
+  end
+
+  # remote user type
+  defp parse_type(env, {{:., _, [mod, atom]}, _, args}, _mod, _include_private)
+       when is_atom(mod) and is_atom(atom) do
+    # do not propagate include_private when expanding remote types
+    expand_type(env, mod, atom, args, false)
+  end
+
+  # local user type
+  defp parse_type(env, {atom, _, args}, mod, include_private) when is_atom(atom) do
+    # propagate include_private when expanding local types
+    expand_type(env, mod, atom, args, include_private)
+  end
+
+  # atom
+  defp parse_type(_env, atom, _, _include_private) when is_atom(atom), do: {:atom, atom}
+
+  # other
+  defp parse_type(_env, _, _, _include_private), do: nil
+
+  defp expand_type(env, mod, type_name, args, include_private) do
+    arity = length(args || [])
+
+    case expand_type_from_metadata(env, mod, type_name, arity, include_private) do
+      nil -> expand_type_from_introspection(env, mod, type_name, arity, include_private)
+      res -> res
+    end
+    |> drop_no_spec
+  end
+
+  defguardp type_is_public(kind, include_private) when kind == :type or include_private
+
+  defp expand_type_from_metadata(
+         %Binding{types: types} = env,
+         mod,
+         type_name,
+         arity,
+         include_private
+       ) do
+    case types[{mod, type_name, arity}] do
+      %State.TypeInfo{specs: [type_spec], kind: kind}
+      when type_is_public(kind, include_private) ->
+        case Code.string_to_quoted(type_spec) do
+          {:ok, {:@, _, [{_kind, _, [ast]}]}} ->
+            type = extract_type(ast)
+            parse_type(env, type, mod, include_private) || :no_spec
+
+          _ ->
+            :no_spec
+        end
+
+      nil ->
+        nil
+
+      _ ->
+        :no_spec
+    end
+  end
+
+  defp expand_type_from_introspection(env, mod, type_name, arity, include_private) do
+    case TypeInfo.get_type_spec(mod, type_name, arity) do
+      {kind, spec} when type_is_public(kind, include_private) ->
+        {:"::", _, [_, type]} = Typespec.type_to_quoted(spec)
+
+        parse_type(env, type, mod, include_private)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp drop_optional({:optional, _, [key]}), do: key
+  defp drop_optional(other), do: other
+end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -8,7 +8,6 @@ defmodule ElixirSense.Core.MetadataBuilder do
   alias ElixirSense.Core.BuiltinFunctions
   alias ElixirSense.Core.Introspection
   alias ElixirSense.Core.State
-  alias ElixirSense.Core.State.AttributeInfo
   alias ElixirSense.Core.State.VarInfo
 
   @scope_keywords [:for, :try, :fn]
@@ -524,7 +523,15 @@ defmodule ElixirSense.Core.MetadataBuilder do
        )
        when kind in [:type, :typep, :opaque] and is_atom(name) and
               (is_nil(type_args) or is_list(type_args)) do
-    pre_type(ast, state, {line, column}, name, List.wrap(type_args), spec, kind)
+    pre_type(
+      ast,
+      state,
+      {line, column},
+      name,
+      List.wrap(type_args),
+      expand_aliases_in_ast(state, spec),
+      kind
+    )
   end
 
   defp pre(
@@ -537,7 +544,15 @@ defmodule ElixirSense.Core.MetadataBuilder do
        )
        when kind in [:spec, :callback, :macrocallback] and is_atom(name) and
               (is_nil(type_args) or is_list(type_args)) do
-    pre_spec(ast, state, {line, column}, name, List.wrap(type_args), spec, kind)
+    pre_spec(
+      ast,
+      state,
+      {line, column},
+      name,
+      expand_aliases_in_ast(state, List.wrap(type_args)),
+      expand_aliases_in_ast(state, spec),
+      kind
+    )
   end
 
   defp pre(
@@ -548,7 +563,15 @@ defmodule ElixirSense.Core.MetadataBuilder do
        )
        when kind in [:spec, :callback, :macrocallback] and is_atom(name) and
               (is_nil(type_args) or is_list(type_args)) do
-    pre_spec(ast, state, {line, column}, name, List.wrap(type_args), spec, kind)
+    pre_spec(
+      ast,
+      state,
+      {line, column},
+      name,
+      expand_aliases_in_ast(state, List.wrap(type_args)),
+      expand_aliases_in_ast(state, spec),
+      kind
+    )
   end
 
   defp pre({:@, [line: line, column: column] = meta_attr, [{name, meta, params}]}, state) do
@@ -734,8 +757,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> result({:=, meta, [:_, rhs]})
   end
 
-  defp pre({var_or_call, [line: line, column: column], context} = ast, state)
-       when is_atom(var_or_call) and var_or_call != :__MODULE__ and context in [nil, Elixir] do
+  defp pre({var_or_call, [line: line, column: column], nil} = ast, state)
+       when is_atom(var_or_call) and var_or_call != :__MODULE__ do
     if Enum.any?(get_current_vars(state), &(&1.name == var_or_call)) do
       state
       |> add_vars(find_vars(state, ast), false)
@@ -1102,10 +1125,10 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   defp match_var(
          _state,
-         {var, [line: line, column: column], context} = ast,
+         {var, [line: line, column: column], nil} = ast,
          {vars, match_context}
        )
-       when is_atom(var) and context in [nil, Elixir] do
+       when is_atom(var) do
     var_info = %VarInfo{name: var, positions: [{line, column}], type: match_context}
     {ast, {[var_info | vars], nil}}
   end
@@ -1119,151 +1142,135 @@ defmodule ElixirSense.Core.MetadataBuilder do
     {ast, {vars, nil}}
   end
 
-  defp get_binding_type(
-         state,
-         {:%, _meta,
-          [
-            struct_ast,
-            {:%{}, _, _} = ast
-          ]}
-       ) do
-    fields =
+  # map
+  {:%{}, [line: 1], [adff: "sdf"]}
+
+  # struct
+  {:%, [line: 1],
+   [
+     {:__aliases__, [line: 1], [:A]},
+     {:%{}, [line: 1], [adff: "sdf"]}
+   ]}
+
+  # map update
+  {:%{}, [line: 1],
+   [
+     {:|, [line: 1],
+      [
+        {:x, [line: 1], nil},
+        [adff: "sdf"]
+      ]}
+   ]}
+
+  # struct update
+  {:%, [line: 1],
+   [
+     {:__aliases__, [line: 1], [:A]},
+     {:%{}, [line: 1],
+      [
+        {:|, [line: 1],
+         [
+           {:x, [line: 1], nil},
+           [adff: "sdf"]
+         ]}
+      ]}
+   ]}
+
+  # struct or struct update
+  def get_binding_type(
+        state,
+        {:%, _meta,
+         [
+           struct_ast,
+           {:%{}, _, _} = ast
+         ]}
+      ) do
+    {fields, updated_struct} =
       case get_binding_type(state, ast) do
-        {:map, fields} -> fields
-        {:struct, fields, _} -> fields
-        _ -> []
+        {:map, fields, updated_map} -> {fields, updated_map}
+        {:struct, fields, _, updated_struct} -> {fields, updated_struct}
+        _ -> {[], nil}
       end
 
-    case struct_ast do
-      atom when is_atom(atom) ->
-        # erlang module
-        {:struct, fields, atom}
+    # expand struct type - only compile type atoms or attributes are supported
+    type =
+      case get_binding_type(state, struct_ast) do
+        {:atom, atom} -> {:atom, atom}
+        {:attribute, attribute} -> {:attribute, attribute}
+        _ -> nil
+      end
 
-      {:__MODULE__, _, nil} ->
-        # current module
-        {:struct, fields, state |> get_current_module}
-
-      {:__aliases__, _, list} when is_list(list) ->
-        # elixir module
-        {:struct, fields, expand_alias(state, list)}
-
-      {var, _, context} when is_atom(var) and context in [nil, Elixir] ->
-        # variable
-        {:struct, fields, nil}
-
-      {:@, _, [{attribute, _, context}]} when is_atom(attribute) and context in [nil, Elixir] ->
-        attributes = get_current_attributes(state)
-
-        type =
-          case attributes |> Enum.find(&(&1.name == attribute)) do
-            # attribute bound to a module
-            %AttributeInfo{type: {:atom, atom}} -> atom
-            # other or not found
-            _ -> nil
-          end
-
-        {:struct, fields, type}
-
-      _ ->
-        # other
-        {:struct, fields, nil}
-    end
+    {:struct, fields, type, updated_struct}
   end
 
-  defp get_binding_type(state, {:__MODULE__, _, nil}) do
+  # pipe
+  def get_binding_type(state, {:|>, _, [params_1, {call, meta, params_rest}]}) do
+    params = [params_1 | params_rest || []]
+    get_binding_type(state, {call, meta, params})
+  end
+
+  # remote call
+  def get_binding_type(state, {{:., _, [target, fun]}, _, args})
+      when is_atom(fun) and is_list(args) do
+    target = get_binding_type(state, target)
+    {:call, target, fun, length(args)}
+  end
+
+  # current module
+  def get_binding_type(state, {:__MODULE__, _, nil}) do
     {:atom, state |> get_current_module}
   end
 
-  defp get_binding_type(state, {:__aliases__, _, list}) when is_list(list) do
+  # elixir module
+  def get_binding_type(state, {:__aliases__, _, list}) when is_list(list) do
     {:atom, expand_alias(state, list)}
   end
 
-  defp get_binding_type(state, {var, _, context})
-       when is_atom(var) and context in [nil, Elixir] do
-    vars = get_current_vars(state)
-
-    case vars |> Enum.find(&(&1.name == var)) do
-      %VarInfo{type: type} -> type
-      nil -> nil
-    end
+  # variable or local no parens call
+  def get_binding_type(_state, {var, _, nil}) when is_atom(var) do
+    {:variable, var}
   end
 
-  defp get_binding_type(state, {:@, _, [{attribute, _, context}]})
-       when is_atom(attribute) and context in [nil, Elixir] do
-    attributes = get_current_attributes(state)
-
-    case attributes |> Enum.find(&(&1.name == attribute)) do
-      %AttributeInfo{type: type} -> type
-      nil -> nil
-    end
+  # attribute
+  def get_binding_type(_state, {:@, _, [{attribute, _, nil}]})
+      when is_atom(attribute) do
+    {:attribute, attribute}
   end
 
-  defp get_binding_type(_state, atom) when is_atom(atom) do
+  # erlang module or atom
+  def get_binding_type(_state, atom) when is_atom(atom) do
     {:atom, atom}
   end
 
-  defp get_binding_type(
-         state,
-         {:%{}, _meta,
-          [
-            {:|, _meta1,
-             [
-               var_or_attr,
-               fields
-             ]}
-          ]}
-       )
-       when is_list(fields) do
-    updated_fields =
-      for {field, value} <- fields,
-          is_atom(field) do
-        {field, get_binding_type(state, value)}
-      end
-
-    get_type = fn vars, var ->
-      case vars |> Enum.find(&(&1.name == var)) do
-        %_{type: {:map, fields}} ->
-          {:map, fields |> Keyword.merge(updated_fields)}
-
-        %_{type: {:struct, fields, struct}} ->
-          {:struct, fields |> Keyword.merge(updated_fields), struct}
-
-        _ ->
-          # var not found or unknown type
-          {:map, updated_fields}
-      end
-    end
-
-    case var_or_attr do
-      {var, _, context} when is_atom(var) and context in [nil, Elixir] ->
-        get_current_vars(state)
-        |> get_type.(var)
-
-      {:@, _, [{attribute, _, context}]} when is_atom(attribute) and context in [nil, Elixir] ->
-        get_current_attributes(state)
-        |> get_type.(attribute)
-
-      _ ->
-        {:map, updated_fields}
-    end
+  # map update
+  def get_binding_type(
+        state,
+        {:%{}, _meta,
+         [
+           {:|, _meta1,
+            [
+              updated_map,
+              fields
+            ]}
+         ]}
+      )
+      when is_list(fields) do
+    {:map, get_fields_binding_type(state, fields), get_binding_type(state, updated_map)}
   end
 
-  defp get_binding_type(state, {:%{}, _meta, fields}) when is_list(fields) do
-    res =
-      for {field, value} <- fields,
-          is_atom(field) do
-        {field, get_binding_type(state, value)}
-      end
-
-    {:map, res}
+  # map
+  def get_binding_type(state, {:%{}, _meta, fields}) when is_list(fields) do
+    {:map, get_fields_binding_type(state, fields), nil}
   end
 
-  defp get_binding_type(state, {:=, _, [_, ast]}) do
+  # match
+  def get_binding_type(state, {:=, _, [_, ast]}) do
     get_binding_type(state, ast)
   end
 
-  defp get_binding_type(_state, {:.., _, [_, _]}) do
-    {:struct, [], Range}
+  # range struct
+  def get_binding_type(_state, {:.., _, [_, _]}) do
+    {:struct, [], {:atom, Range}}
   end
 
   @builtin_sigils %{
@@ -1275,15 +1282,37 @@ defmodule ElixirSense.Core.MetadataBuilder do
     sigil_r: Regex
   }
 
-  defp get_binding_type(_state, {sigil, _, _}) when is_atom(sigil) do
+  @builtin_sigils_list [
+    :sigil_D,
+    :sigil_T,
+    :sigil_U,
+    :sigil_N,
+    :sigil_R,
+    :sigil_r
+  ]
+
+  # builtin sigil struct
+  # TODO refactor to is_map_key(@builtin_sigils, sigil) when elixir 1.10 is required
+  def get_binding_type(_state, {sigil, _, _})
+      when is_atom(sigil) and sigil in @builtin_sigils_list do
     # TODO support custom sigils
-    case @builtin_sigils[sigil] do
-      nil -> nil
-      type -> {:struct, [], type}
-    end
+    {:struct, [], {:atom, @builtin_sigils |> Map.fetch!(sigil)}}
   end
 
-  defp get_binding_type(_state, _), do: nil
+  # local call
+  def get_binding_type(_state, {var, _, args}) when is_atom(var) and is_list(args) do
+    {:local_call, var, length(args)}
+  end
+
+  # other
+  def get_binding_type(_state, _), do: nil
+
+  defp get_fields_binding_type(state, fields) do
+    for {field, value} <- fields,
+        is_atom(field) do
+      {field, get_binding_type(state, value)}
+    end
+  end
 
   defp add_no_call(meta) do
     [{:no_call, true} | meta]
@@ -1441,5 +1470,23 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
     state
     |> add_struct(type, fields)
+  end
+
+  defp expand_aliases_in_ast(state, ast) do
+    Macro.prewalk(ast, fn
+      {:__aliases__, meta, [Elixir]} ->
+        {:__aliases__, meta, [Elixir]}
+
+      {:__aliases__, meta, list} ->
+        list = state |> expand_alias(list) |> Module.split() |> Enum.map(&String.to_atom/1)
+        {:__aliases__, meta, list}
+
+      {:__MODULE__, meta, nil} ->
+        list = state |> get_current_module |> Module.split() |> Enum.map(&String.to_atom/1)
+        {:__aliases__, meta, list}
+
+      other ->
+        other
+    end)
   end
 end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -1142,40 +1142,6 @@ defmodule ElixirSense.Core.MetadataBuilder do
     {ast, {vars, nil}}
   end
 
-  # map
-  {:%{}, [line: 1], [adff: "sdf"]}
-
-  # struct
-  {:%, [line: 1],
-   [
-     {:__aliases__, [line: 1], [:A]},
-     {:%{}, [line: 1], [adff: "sdf"]}
-   ]}
-
-  # map update
-  {:%{}, [line: 1],
-   [
-     {:|, [line: 1],
-      [
-        {:x, [line: 1], nil},
-        [adff: "sdf"]
-      ]}
-   ]}
-
-  # struct update
-  {:%, [line: 1],
-   [
-     {:__aliases__, [line: 1], [:A]},
-     {:%{}, [line: 1],
-      [
-        {:|, [line: 1],
-         [
-           {:x, [line: 1], nil},
-           [adff: "sdf"]
-         ]}
-      ]}
-   ]}
-
   # struct or struct update
   def get_binding_type(
         state,

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -227,7 +227,7 @@ defmodule ElixirSense.Core.Source do
 
   @spec which_struct(String.t(), nil | module) ::
           nil
-          | {module | {:attribute, atom} | :_, [atom], boolean, var_or_attr_t}
+          | {{:atom, atom} | {:attribute, atom} | nil, [atom], boolean, var_or_attr_t}
           | {:map, [atom], var_or_attr_t}
   def which_struct(text_before, current_module) do
     code = text_before |> String.reverse()
@@ -303,7 +303,8 @@ defmodule ElixirSense.Core.Source do
 
   defp do_extract_struct_module({var, _, nil}, fields, _current_module, updated_var)
        when is_atom(var) and var != :__MODULE__ do
-    {:_, get_field_names(fields), false, updated_var}
+    # variable struct type is not supported
+    {nil, get_field_names(fields), false, updated_var}
   end
 
   defp do_extract_struct_module({:@, _, [{attr, _, nil}]}, fields, _current_module, updated_var)
@@ -314,10 +315,10 @@ defmodule ElixirSense.Core.Source do
   defp do_extract_struct_module(module, fields, current_module, updated_var) do
     case extract_module(module, current_module) do
       {:ok, extracted_module, elixir_prefix} ->
-        {extracted_module, get_field_names(fields), elixir_prefix, updated_var}
+        {{:atom, extracted_module}, get_field_names(fields), elixir_prefix, updated_var}
 
       _ ->
-        nil
+        {nil, get_field_names(fields), false, updated_var}
     end
   end
 

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -226,12 +226,7 @@ defmodule ElixirSense.Core.State do
     def get_arities(%ModFunInfo{params: params_variants}) do
       params_variants
       |> Enum.map(fn params ->
-        default_args =
-          params
-          |> Enum.count(&match?({:\\, _, _}, &1))
-
-        total = length(params)
-        {total, default_args}
+        {length(params), Introspection.count_defaults(params)}
       end)
     end
 

--- a/lib/elixir_sense/core/struct.ex
+++ b/lib/elixir_sense/core/struct.ex
@@ -4,7 +4,9 @@ defmodule ElixirSense.Core.Struct do
   alias ElixirSense.Core.Introspection
   alias ElixirSense.Core.State
 
-  @spec is_struct(module, State.structs_t()) :: boolean
+  @spec is_struct(module | nil, State.structs_t()) :: boolean
+  def is_struct(nil, _metadata_structs), do: false
+
   def is_struct(module, metadata_structs) do
     Map.has_key?(metadata_structs, module) or Introspection.module_is_struct?(module)
   end

--- a/lib/elixir_sense/providers/references.ex
+++ b/lib/elixir_sense/providers/references.ex
@@ -190,16 +190,11 @@ defmodule ElixirSense.Providers.References do
   defp check_arity(call_arity, buffer_arity, %State.ModFunInfo{} = info) do
     State.ModFunInfo.get_arities(info)
     |> Enum.any?(fn
-      {arity, default_args}
-      when arity - default_args == call_arity and buffer_arity == arity ->
-        true
+      {arity, default_args} ->
+        min_arity = arity - default_args
 
-      {arity, default_args}
-      when buffer_arity + default_args == call_arity and call_arity == arity ->
-        true
-
-      _ ->
-        false
+        min_arity <= call_arity and call_arity <= arity and
+          min_arity <= buffer_arity and buffer_arity <= arity
     end)
   end
 

--- a/run.exs
+++ b/run.exs
@@ -17,6 +17,7 @@ requires = [
   "elixir_sense/core/normalized/tokenizer.ex",
   "elixir_sense/core/normalized/typespec.ex",
   "elixir_sense/core/struct.ex",
+  "elixir_sense/core/binding.ex",
   "elixir_sense/providers/suggestion/complete.ex",
   "elixir_sense/providers/suggestion/hint.ex",
   "elixir_sense/providers/definition.ex",

--- a/test/elixir_sense/core/binding_test.exs
+++ b/test/elixir_sense/core/binding_test.exs
@@ -1,0 +1,961 @@
+defmodule ElixirSense.Core.BindingTest do
+  use ExUnit.Case, async: true
+  alias ElixirSense.Core.Binding
+  alias ElixirSense.Core.State.AttributeInfo
+  alias ElixirSense.Core.State.VarInfo
+  alias ElixirSense.Core.State.ModFunInfo
+  alias ElixirSense.Core.State.SpecInfo
+  alias ElixirSense.Core.State.StructInfo
+  alias ElixirSense.Core.State.TypeInfo
+
+  @env %Binding{}
+
+  describe "expand" do
+    test "map" do
+      assert {:map, [abc: nil, cde: {:variable, :a}], nil} ==
+               Binding.expand(@env, {:map, [abc: nil, cde: {:variable, :a}], nil})
+    end
+
+    test "map update" do
+      assert {:map, [{:efg, {:atom, :a}}, {:abc, nil}, {:cde, {:variable, :a}}], nil} ==
+               Binding.expand(
+                 @env,
+                 {:map, [abc: nil, cde: {:variable, :a}],
+                  {:map, [abc: nil, cde: nil, efg: {:atom, :a}], nil}}
+               )
+    end
+
+    test "introspection struct" do
+      assert {:struct,
+              [
+                __struct__: {:atom, ElixirSenseExample.ModuleWithTypedStruct},
+                other: nil,
+                typed_field: nil
+              ], ElixirSenseExample.ModuleWithTypedStruct,
+              nil} ==
+               Binding.expand(
+                 @env,
+                 {:struct, [], {:atom, ElixirSenseExample.ModuleWithTypedStruct}, nil}
+               )
+    end
+
+    test "introspection module not a stuct" do
+      assert nil ==
+               Binding.expand(@env, {:struct, [], {:atom, ElixirSenseExample.EmptyModule}, nil})
+    end
+
+    test "introspection struct update" do
+      assert {:struct,
+              [
+                __struct__: {:atom, ElixirSenseExample.ModuleWithTypedStruct},
+                other: {:atom, :a},
+                typed_field: {:atom, :b}
+              ], ElixirSenseExample.ModuleWithTypedStruct,
+              nil} ==
+               Binding.expand(
+                 @env,
+                 {:struct, [typed_field: {:atom, :b}],
+                  {:atom, ElixirSenseExample.ModuleWithTypedStruct},
+                  {:struct, [other: {:atom, :a}],
+                   {:atom, ElixirSenseExample.ModuleWithTypedStruct}, nil}}
+               )
+    end
+
+    test "introspection struct update as map" do
+      assert {:struct,
+              [
+                __struct__: {:atom, ElixirSenseExample.ModuleWithTypedStruct},
+                other: {:atom, :a},
+                typed_field: {:atom, :b}
+              ], ElixirSenseExample.ModuleWithTypedStruct,
+              nil} ==
+               Binding.expand(
+                 @env,
+                 {:map, [typed_field: {:atom, :b}],
+                  {:struct, [other: {:atom, :a}],
+                   {:atom, ElixirSenseExample.ModuleWithTypedStruct}, nil}}
+               )
+    end
+
+    test "introspection struct from attribute" do
+      assert {:struct,
+              [
+                __struct__: {:atom, ElixirSenseExample.ModuleWithTypedStruct},
+                other: nil,
+                typed_field: nil
+              ], ElixirSenseExample.ModuleWithTypedStruct,
+              nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:attributes, [
+                   %AttributeInfo{
+                     name: :v,
+                     type: {:atom, ElixirSenseExample.ModuleWithTypedStruct}
+                   }
+                 ]),
+                 {:struct, [], {:attribute, :v}, nil}
+               )
+    end
+
+    test "introspection struct from variable" do
+      assert {:struct, [__struct__: nil], nil, nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :v, type: {:atom, ElixirSenseExample.ModuleWithTypedStruct}}
+                 ]),
+                 {:struct, [], {:variable, :v}, nil}
+               )
+    end
+
+    test "metadata struct" do
+      assert {:struct, [__struct__: {:atom, MyMod}, abc: nil], MyMod, nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   structs: %{
+                     MyMod => %StructInfo{
+                       fields: [abc: nil, __struct__: MyMod]
+                     }
+                   }
+                 }),
+                 {:struct, [], {:atom, MyMod}, nil}
+               )
+    end
+
+    test "atom" do
+      assert {:atom, :abc} == Binding.expand(@env, {:atom, :abc})
+    end
+
+    test "nil" do
+      assert nil == Binding.expand(@env, nil)
+    end
+
+    test "other" do
+      assert nil == Binding.expand(@env, 123)
+    end
+
+    test "known variable" do
+      assert {:atom, :abc} ==
+               Binding.expand(
+                 @env |> Map.put(:variables, [%VarInfo{name: :v, type: {:atom, :abc}}]),
+                 {:variable, :v}
+               )
+    end
+
+    test "anonymous variable" do
+      assert nil ==
+               Binding.expand(
+                 @env |> Map.put(:variables, [%VarInfo{name: :_, type: {:atom, :abc}}]),
+                 {:variable, :_}
+               )
+    end
+
+    test "unknown variable" do
+      assert nil == Binding.expand(@env, {:variable, :v})
+    end
+
+    test "known attribute" do
+      assert {:atom, :abc} ==
+               Binding.expand(
+                 @env |> Map.put(:attributes, [%AttributeInfo{name: :v, type: {:atom, :abc}}]),
+                 {:attribute, :v}
+               )
+    end
+
+    test "unknown attribute" do
+      assert nil == Binding.expand(@env, {:attribute, :v})
+    end
+
+    test "call existing map field access" do
+      assert {:atom, :a} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :map, type: {:map, [field: {:atom, :a}], nil}},
+                   %VarInfo{name: :ref, type: {:call, {:variable, :map}, :field, 0}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "call existing map field access invalid arity" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :map, type: {:map, [field: {:atom, :a}], nil}},
+                   %VarInfo{name: :ref, type: {:call, {:variable, :map}, :field, 1}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "call not existing map field access" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :map, type: {:map, [field: {:atom, :a}], nil}},
+                   %VarInfo{name: :ref, type: {:call, {:variable, :map}, :not_existing, 0}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "call existing struct field access" do
+      assert {:atom, :abc} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :map,
+                     type:
+                       {:struct, [typed_field: {:atom, :abc}],
+                        {:atom, ElixirSenseExample.ModuleWithTypedStruct}, nil}
+                   },
+                   %VarInfo{name: :ref, type: {:call, {:variable, :map}, :typed_field, 0}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "call not existing struct field access" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :map,
+                     type:
+                       {:struct, [typed_field: {:atom, :abc}],
+                        {:atom, ElixirSenseExample.ModuleWithTypedStruct}, nil}
+                   },
+                   %VarInfo{name: :ref, type: {:call, {:variable, :map}, :not_existing, 0}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "call existing struct field access invalid arity" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :map,
+                     type:
+                       {:struct, [typed_field: {:atom, :abc}],
+                        {:atom, ElixirSenseExample.ModuleWithTypedStruct}, nil}
+                   },
+                   %VarInfo{name: :ref, type: {:call, {:variable, :map}, :typed_field, 1}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "call on nil" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :ref, type: {:call, nil, :not_existing, 0}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call not existing fun" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type:
+                       {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :not_existing,
+                        0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call existing fun invalid arity" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f1, 1}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec t undefined" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f01, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec t expanding to atom" do
+      assert {:atom, :asd} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f02, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec t expanding to number" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f03, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec local t expanding to struct" do
+      assert {:struct,
+              [
+                __struct__: {:atom, ElixirSenseExample.FunctionsWithReturnSpec},
+                abc: {:map, [key: {:atom, nil}], nil}
+              ], ElixirSenseExample.FunctionsWithReturnSpec,
+              nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f1, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec remote t expanding to struct" do
+      assert {:struct,
+              [__struct__: {:atom, ElixirSenseExample.FunctionsWithReturnSpec.Remote}, abc: nil],
+              ElixirSenseExample.FunctionsWithReturnSpec.Remote,
+              nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f3, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec struct" do
+      assert {:struct,
+              [__struct__: {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, abc: nil],
+              ElixirSenseExample.FunctionsWithReturnSpec,
+              nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f5, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec local t expanding to map" do
+      assert {:map, [{:abc, {:atom, :asd}}, {:cde, {:atom, :asd}}], nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f2, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec remote t expanding to map" do
+      assert {:map, [abc: nil], nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f4, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec map" do
+      assert {:map, [abc: nil], nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f6, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec intersection different returns" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f7, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec intersection same returns" do
+      assert {:map, [abc: nil], nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f71, 1}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec union" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f8, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with spec parametrized map" do
+      assert {:map, [abc: nil], nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f91, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "local call metadata fun returning struct" do
+      assert {:struct, [{:__struct__, {:atom, MyMod}}, {:abc, nil}], MyMod, nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:local_call, :fun, 0}}
+                   ],
+                   current_module: MyMod,
+                   specs: %{
+                     {MyMod, :fun, nil} => %SpecInfo{
+                       specs: ["@spec fun() :: %MyMod{}"]
+                     },
+                     {MyMod, :fun, 0} => %SpecInfo{
+                       specs: ["@spec fun() :: %MyMod{}"]
+                     }
+                   },
+                   mods_and_funs: %{
+                     {MyMod, :fun, nil} => %ModFunInfo{
+                       params: [[]],
+                       type: :defp
+                     }
+                   },
+                   structs: %{
+                     MyMod => %StructInfo{
+                       fields: [abc: nil, __struct__: MyMod]
+                     }
+                   }
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "local call metadata fun returning local type expanding to struct" do
+      assert {:struct, [{:__struct__, {:atom, MyMod}}, {:abc, nil}], MyMod, nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:local_call, :fun, 0}}
+                   ],
+                   current_module: MyMod,
+                   specs: %{
+                     {MyMod, :fun, nil} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     },
+                     {MyMod, :fun, 0} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     }
+                   },
+                   mods_and_funs: %{
+                     {MyMod, :fun, nil} => %ModFunInfo{
+                       params: [[]],
+                       type: :def
+                     }
+                   },
+                   structs: %{
+                     MyMod => %StructInfo{
+                       fields: [abc: nil, __struct__: MyMod]
+                     }
+                   },
+                   types: %{
+                     {MyMod, :t, nil} => %TypeInfo{
+                       specs: ["@type t() :: %MyMod{}"]
+                     },
+                     {MyMod, :t, 0} => %TypeInfo{
+                       specs: ["@type t() :: %MyMod{}"]
+                     }
+                   }
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "local call metadata fun returning local type expanding to private type" do
+      assert {:struct, [{:__struct__, {:atom, MyMod}}, {:abc, nil}], MyMod, nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:local_call, :fun, 0}}
+                   ],
+                   current_module: MyMod,
+                   specs: %{
+                     {MyMod, :fun, nil} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     },
+                     {MyMod, :fun, 0} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     }
+                   },
+                   mods_and_funs: %{
+                     {MyMod, :fun, nil} => %ModFunInfo{
+                       params: [[]],
+                       type: :def
+                     }
+                   },
+                   structs: %{
+                     MyMod => %StructInfo{
+                       fields: [abc: nil, __struct__: MyMod]
+                     }
+                   },
+                   types: %{
+                     {MyMod, :t, nil} => %TypeInfo{
+                       kind: :typep,
+                       specs: ["@type t() :: %MyMod{}"]
+                     },
+                     {MyMod, :t, 0} => %TypeInfo{
+                       kind: :typep,
+                       specs: ["@type t() :: %MyMod{}"]
+                     }
+                   }
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call metadata public fun returning local type expanding to struct" do
+      assert {:struct, [{:__struct__, {:atom, MyMod}}, {:abc, nil}], MyMod, nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:call, {:atom, MyMod}, :fun, 0}}
+                   ],
+                   current_module: SomeMod,
+                   specs: %{
+                     {MyMod, :fun, nil} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     },
+                     {MyMod, :fun, 0} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     }
+                   },
+                   mods_and_funs: %{
+                     {MyMod, :fun, nil} => %ModFunInfo{
+                       params: [[]],
+                       type: :def
+                     }
+                   },
+                   structs: %{
+                     MyMod => %StructInfo{
+                       fields: [abc: nil, __struct__: MyMod]
+                     }
+                   },
+                   types: %{
+                     {MyMod, :t, nil} => %TypeInfo{
+                       specs: ["@type t() :: %MyMod{}"]
+                     },
+                     {MyMod, :t, 0} => %TypeInfo{
+                       specs: ["@type t() :: %MyMod{}"]
+                     }
+                   }
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call metadata public fun returning local type expanding to opaque" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:call, {:atom, MyMod}, :fun, 0}}
+                   ],
+                   current_module: SomeMod,
+                   specs: %{
+                     {MyMod, :fun, nil} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     },
+                     {MyMod, :fun, 0} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     }
+                   },
+                   mods_and_funs: %{
+                     {MyMod, :fun, nil} => %ModFunInfo{
+                       params: [[]],
+                       type: :def
+                     }
+                   },
+                   structs: %{
+                     MyMod => %StructInfo{
+                       fields: [abc: nil, __struct__: MyMod]
+                     }
+                   },
+                   types: %{
+                     {MyMod, :t, nil} => %TypeInfo{
+                       kind: :opaque,
+                       specs: ["@type t() :: %MyMod{}"]
+                     },
+                     {MyMod, :t, 0} => %TypeInfo{
+                       kind: :opaque,
+                       specs: ["@type t() :: %MyMod{}"]
+                     }
+                   }
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call metadata private fun returning local type expanding to struct" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:call, {:atom, MyMod}, :fun, 0}}
+                   ],
+                   current_module: SomeMod,
+                   specs: %{
+                     {MyMod, :fun, nil} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     },
+                     {MyMod, :fun, 0} => %SpecInfo{
+                       specs: ["@spec fun() :: t()"]
+                     }
+                   },
+                   mods_and_funs: %{
+                     {MyMod, :fun, nil} => %ModFunInfo{
+                       params: [[]],
+                       type: :defp
+                     }
+                   },
+                   structs: %{
+                     MyMod => %StructInfo{
+                       fields: [abc: nil, __struct__: MyMod]
+                     }
+                   },
+                   types: %{
+                     {MyMod, :t, nil} => %TypeInfo{
+                       specs: ["@type t() :: %MyMod{}"]
+                     },
+                     {MyMod, :t, 0} => %TypeInfo{
+                       specs: ["@type t() :: %MyMod{}"]
+                     }
+                   }
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "local call metadata fun with default args returning struct" do
+      env =
+        @env
+        |> Map.merge(%{
+          current_module: MyMod,
+          specs: %{
+            {MyMod, :fun, nil} => %SpecInfo{
+              specs: ["@spec fun(integer(), integer(), any()) :: %MyMod{}"]
+            },
+            {MyMod, :fun, 3} => %SpecInfo{
+              specs: ["@spec fun(integer(), integer(), any()) :: %MyMod{}"]
+            }
+          },
+          mods_and_funs: %{
+            {MyMod, :fun, nil} => %ModFunInfo{
+              params: [
+                [
+                  {:\\, [], []},
+                  {:\\, [], []},
+                  {:x, [], []}
+                ]
+              ],
+              type: :def
+            }
+          },
+          structs: %{
+            MyMod => %StructInfo{
+              fields: [abc: nil, __struct__: MyMod]
+            }
+          }
+        })
+
+      assert nil ==
+               Binding.expand(
+                 env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :ref, type: {:local_call, :fun, 0}}
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert {:struct, [{:__struct__, {:atom, MyMod}}, {:abc, nil}], MyMod, nil} ==
+               Binding.expand(
+                 env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :ref, type: {:local_call, :fun, 1}}
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert {:struct, [{:__struct__, {:atom, MyMod}}, {:abc, nil}], MyMod, nil} ==
+               Binding.expand(
+                 env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :ref, type: {:local_call, :fun, 2}}
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert {:struct, [{:__struct__, {:atom, MyMod}}, {:abc, nil}], MyMod, nil} ==
+               Binding.expand(
+                 env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :ref, type: {:local_call, :fun, 3}}
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert nil ==
+               Binding.expand(
+                 env
+                 |> Map.put(:variables, [
+                   %VarInfo{name: :ref, type: {:local_call, :fun, 4}}
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "remote call fun with default args" do
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f10, 0}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert {:atom, String} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f10, 1}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert {:atom, String} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f10, 2}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert {:atom, String} ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f10, 3}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+
+      assert nil ==
+               Binding.expand(
+                 @env
+                 |> Map.put(:variables, [
+                   %VarInfo{
+                     name: :ref,
+                     type: {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f10, 4}
+                   }
+                 ]),
+                 {:variable, :ref}
+               )
+    end
+
+    test "local call imported fun with spec t expanding to atom" do
+      assert {:atom, :asd} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:local_call, :f02, 0}}
+                   ],
+                   imports: [ElixirSenseExample.FunctionsWithReturnSpec]
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "local call no parens imported fun with spec t expanding to atom" do
+      assert {:atom, :asd} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{name: :ref, type: {:variable, :f02}}
+                   ],
+                   imports: [ElixirSenseExample.FunctionsWithReturnSpec]
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "extract struct key type from typespec" do
+      assert {:map, [key: {:atom, nil}], nil} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{
+                       name: :ref,
+                       type:
+                         {:call,
+                          {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f1, 0},
+                          :abc, 0}
+                     }
+                   ],
+                   imports: [ElixirSenseExample.FunctionsWithReturnSpec]
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "extract required map key type from typespec" do
+      assert {:atom, :asd} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{
+                       name: :ref,
+                       type:
+                         {:call,
+                          {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f2, 0},
+                          :abc, 0}
+                     }
+                   ],
+                   imports: [ElixirSenseExample.FunctionsWithReturnSpec]
+                 }),
+                 {:variable, :ref}
+               )
+    end
+
+    test "optimisticallyb extract optional map key type from typespec" do
+      assert {:atom, :asd} ==
+               Binding.expand(
+                 @env
+                 |> Map.merge(%{
+                   variables: [
+                     %VarInfo{
+                       name: :ref,
+                       type:
+                         {:call,
+                          {:call, {:atom, ElixirSenseExample.FunctionsWithReturnSpec}, :f2, 0},
+                          :cde, 0}
+                     }
+                   ],
+                   imports: [ElixirSenseExample.FunctionsWithReturnSpec]
+                 }),
+                 {:variable, :ref}
+               )
+    end
+  end
+end

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -842,7 +842,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     %{found: false} = ElixirSense.definition(buffer, 2, 12)
   end
 
-  test "builtin types cannot now be found" do
+  test "builtin types cannot be found" do
     buffer = """
     defmodule MyModule do
       @type my_type :: integer
@@ -853,7 +853,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert %{found: false} = ElixirSense.definition(buffer, 2, 23)
   end
 
-  test "builtin elixir types cannot now be found" do
+  test "builtin elixir types cannot be found" do
     buffer = """
     defmodule MyModule do
       @type my_type :: Elixir.keyword

--- a/test/elixir_sense/providers/suggestion/complete_test.exs
+++ b/test/elixir_sense/providers/suggestion/complete_test.exs
@@ -302,7 +302,7 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
       vars: [
         %VarInfo{
           name: :map,
-          type: {:map, [foo: 1, bar_1: 23, bar_2: 14]}
+          type: {:map, [foo: 1, bar_1: 23, bar_2: 14], nil}
         }
       ]
     }
@@ -338,7 +338,7 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
       attributes: [
         %AttributeInfo{
           name: :map,
-          type: {:map, [foo: 1, bar_1: 23, bar_2: 14]}
+          type: {:map, [foo: 1, bar_1: 23, bar_2: 14], nil}
         }
       ]
     }
@@ -388,9 +388,9 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
                          bar_2: 14,
                          mod: {:atom, String},
                          num: 1
-                       ]}
-                  ]}
-             ]}
+                       ], nil}
+                  ], nil}
+             ], nil}
         }
       ]
     }
@@ -439,7 +439,7 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
       vars: [
         %VarInfo{
           name: :map,
-          type: {:map, [{"foo", 124}]}
+          type: {:map, [{"foo", 124}], nil}
         }
       ]
     }
@@ -452,7 +452,7 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
       vars: [
         %VarInfo{
           name: :map,
-          type: {:map, [nested: {:map, [num: 23]}]}
+          type: {:map, [nested: {:map, [num: 23], nil}], nil}
         }
       ]
     }
@@ -460,6 +460,40 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
     assert expand('num.print', env) == {:no, '', []}
     assert expand('map.nested.num.f', env) == {:no, '', []}
     assert expand('map.nested.num.key.f', env) == {:no, '', []}
+  end
+
+  test "autocomplete map fields from call binding" do
+    env = %Env{
+      vars: [
+        %VarInfo{
+          name: :map,
+          type: {:map, [{:foo, {:atom, String}}], nil}
+        },
+        %VarInfo{
+          name: :call,
+          type: {:call, {:variable, :map}, :foo, 0}
+        }
+      ]
+    }
+
+    assert {:yes, 'able?', _} = expand('call.print', env)
+  end
+
+  test "autocomplete call return binding" do
+    env = %Env{
+      vars: [
+        %VarInfo{
+          name: :call,
+          type: {:call, {:atom, DateTime}, :utc_now, 0}
+        }
+      ]
+    }
+
+    assert {:yes, 'ur', _} = expand('call.ho', env)
+    assert {:yes, 'ur', _} = expand('DateTime.utc_now.ho', env)
+    # FIXME Complete.reduce(expr) breaks things...
+    # assert {:yes, 'ur', _} = expand('DateTime.utc_now().', env)
+    # assert {:yes, 'ur', _} = expand('DateTime.utc_now().ho', env)
   end
 
   test "autocompletion off of unbound variables is not supported" do
@@ -884,10 +918,10 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
             {:struct,
              [
                a_mod: {:atom, String},
-               some_map: {:map, [asdf: 1]},
-               str: {:struct, [], MyStruct},
-               unknown_str: {:struct, [abc: nil], nil}
-             ], MyStruct}
+               some_map: {:map, [asdf: 1], nil},
+               str: {:struct, [], {:atom, MyStruct}, nil},
+               unknown_str: {:struct, [abc: nil], nil, nil}
+             ], {:atom, MyStruct}, nil}
         }
       ]
     }

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -1256,6 +1256,13 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
+               name: "__struct__",
+               origin: "IO.Stream",
+               type: :field,
+               call?: false,
+               subtype: :struct_field
+             },
+             %{
                name: "device",
                origin: "IO.Stream",
                type: :field,
@@ -1271,13 +1278,6 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "raw",
-               origin: "IO.Stream",
-               type: :field,
-               call?: false,
-               subtype: :struct_field
-             },
-             %{
-               name: "__struct__",
                origin: "IO.Stream",
                type: :field,
                call?: false,
@@ -1299,14 +1299,14 @@ defmodule ElixirSense.SuggestionsTest do
                subtype: :struct_field
              },
              %{
-               name: "message",
+               name: "__struct__",
                origin: "ArgumentError",
                type: :field,
                call?: false,
                subtype: :struct_field
              },
              %{
-               name: "__struct__",
+               name: "message",
                origin: "ArgumentError",
                type: :field,
                call?: false,
@@ -1330,6 +1330,13 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
+               name: "__struct__",
+               origin: "IO.Stream",
+               type: :field,
+               call?: false,
+               subtype: :struct_field
+             },
+             %{
                name: "device",
                origin: "IO.Stream",
                type: :field,
@@ -1345,13 +1352,6 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "raw",
-               origin: "IO.Stream",
-               type: :field,
-               call?: false,
-               subtype: :struct_field
-             },
-             %{
-               name: "__struct__",
                origin: "IO.Stream",
                type: :field,
                call?: false,
@@ -1414,6 +1414,13 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
+               name: "__struct__",
+               origin: "IO.Stream",
+               type: :field,
+               call?: false,
+               subtype: :struct_field
+             },
+             %{
                name: "device",
                origin: "IO.Stream",
                type: :field,
@@ -1429,13 +1436,6 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "raw",
-               origin: "IO.Stream",
-               type: :field,
-               call?: false,
-               subtype: :struct_field
-             },
-             %{
-               name: "__struct__",
                origin: "IO.Stream",
                type: :field,
                call?: false,
@@ -1466,6 +1466,13 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
+               name: "__struct__",
+               origin: "MyServer",
+               type: :field,
+               call?: false,
+               subtype: :struct_field
+             },
+             %{
                name: "field_1",
                origin: "MyServer",
                type: :field,
@@ -1478,13 +1485,6 @@ defmodule ElixirSense.SuggestionsTest do
                type: :field,
                call?: false,
                subtype: :struct_field
-             },
-             %{
-               name: "__struct__",
-               origin: "MyServer",
-               type: :field,
-               call?: false,
-               subtype: :struct_field
              }
            ]
 
@@ -1493,14 +1493,14 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
-               name: "field_1",
+               name: "__struct__",
                origin: "MyServer",
                type: :field,
                call?: false,
                subtype: :struct_field
              },
              %{
-               name: "__struct__",
+               name: "field_1",
                origin: "MyServer",
                type: :field,
                call?: false,
@@ -1531,6 +1531,13 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
+               name: "__struct__",
+               origin: ":my_server",
+               type: :field,
+               call?: false,
+               subtype: :struct_field
+             },
+             %{
                name: "field_1",
                origin: ":my_server",
                type: :field,
@@ -1543,13 +1550,6 @@ defmodule ElixirSense.SuggestionsTest do
                type: :field,
                call?: false,
                subtype: :struct_field
-             },
-             %{
-               name: "__struct__",
-               origin: ":my_server",
-               type: :field,
-               call?: false,
-               subtype: :struct_field
              }
            ]
 
@@ -1558,14 +1558,14 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
-               name: "field_1",
+               name: "__struct__",
                origin: ":my_server",
                type: :field,
                call?: false,
                subtype: :struct_field
              },
              %{
-               name: "__struct__",
+               name: "field_1",
                origin: ":my_server",
                type: :field,
                call?: false,
@@ -1596,14 +1596,14 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
-               name: "field_1",
+               name: "__struct__",
                origin: "MyServer",
                type: :field,
                call?: false,
                subtype: :struct_field
              },
              %{
-               name: "__struct__",
+               name: "field_1",
                origin: "MyServer",
                type: :field,
                call?: false,
@@ -1631,14 +1631,14 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{type: :hint, value: ""},
              %{
-               name: "field_1",
+               name: "__struct__",
                origin: "MyServer",
                type: :field,
                call?: false,
                subtype: :struct_field
              },
              %{
-               name: "__struct__",
+               name: "field_1",
                origin: "MyServer",
                type: :field,
                call?: false,
@@ -1954,6 +1954,31 @@ defmodule ElixirSense.SuggestionsTest do
 
     list = ElixirSense.suggestions(buffer, 2, 9)
     assert Enum.any?(list, fn %{type: type} -> type == :field end) == false
+  end
+
+  test "suggest struct fields when metadata function evaluates to struct" do
+    buffer = """
+    defmodule Mod do
+      defstruct [field: nil]
+      @type t :: %__MODULE__{}
+
+      @spec fun() :: t
+      def fun(), do: %Mod{}
+
+      def some do
+        var = fun()
+        var.
+      end
+    end
+    """
+
+    list = ElixirSense.suggestions(buffer, 10, 9)
+
+    assert [
+             %{type: :hint, value: "var."},
+             %{call?: true, name: "__struct__", origin: "Mod"},
+             %{call?: true, name: "field", origin: "Mod", subtype: :struct_field, type: :field}
+           ] = list
   end
 
   test "suggest modules to alias" do

--- a/test/support/functions_with_return_spec.ex
+++ b/test/support/functions_with_return_spec.ex
@@ -1,0 +1,63 @@
+defmodule ElixirSenseExample.FunctionsWithReturnSpec do
+  defstruct [:abc]
+
+  @type t :: %ElixirSenseExample.FunctionsWithReturnSpec{
+          abc: %{key: nil}
+        }
+  @type x :: %{required(:abc) => atom_1, optional(:cde) => atom_1}
+  @type atom_1 :: :asd
+  @type num :: number
+
+  @spec f01() :: Abc.non_existing()
+  def f01(), do: :ok
+
+  @spec f02() :: atom_1
+  def f02(), do: :ok
+
+  @spec f03() :: num
+  def f03(), do: :ok
+
+  @spec f1() :: t
+  def f1(), do: :ok
+
+  @spec f2() :: x
+  def f2(), do: :ok
+
+  @spec f3() :: ElixirSenseExample.FunctionsWithReturnSpec.Remote.t()
+  def f3(), do: :ok
+
+  @spec f4() :: ElixirSenseExample.FunctionsWithReturnSpec.Remote.x()
+  def f4(), do: :ok
+
+  @spec f5() :: %ElixirSenseExample.FunctionsWithReturnSpec{}
+  def f5(), do: :ok
+
+  @spec f6() :: %{abc: atom}
+  def f6(), do: :ok
+
+  @spec f7() :: %{abc: atom}
+  @spec f7() :: nil
+  def f7(), do: :ok
+
+  @spec f71(integer) :: %{abc: atom}
+  @spec f71(boolean) :: %{abc: atom}
+  def f71(x), do: :ok
+
+  @spec f8() :: %{abc: atom} | nil
+  def f8(), do: :ok
+
+  @spec f9(a) :: %{abc: atom} when a: integer
+  def f9(a), do: :ok
+
+  @spec f91() :: a when a: %{abc: atom}
+  def f91(), do: :ok
+
+  @spec f10(integer, integer, any) :: String
+  def f10(a \\ 0, b \\ 0, c), do: String
+end
+
+defmodule ElixirSenseExample.FunctionsWithReturnSpec.Remote do
+  defstruct [:abc]
+  @type t :: %ElixirSenseExample.FunctionsWithReturnSpec.Remote{}
+  @type x :: %{abc: atom}
+end

--- a/test/support/module_with_struct.ex
+++ b/test/support/module_with_struct.ex
@@ -1,3 +1,11 @@
 defmodule ElixirSenseExample.ModuleWithStruct do
   defstruct [:field_1, field_2: 1]
 end
+
+defmodule ElixirSenseExample.ModuleWithTypedStruct do
+  @type t :: %ElixirSenseExample.ModuleWithTypedStruct{
+          typed_field: %ElixirSenseExample.ModuleWithStruct{},
+          other: integer
+        }
+  defstruct [:typed_field, other: 1]
+end


### PR DESCRIPTION
With this PR elixir_sense is able to use typespecs to statically infere types of variables and use that info in suggestions engine. e.g. with code like
```
var = DateTime.utc_now()
var.h
        ^
```
the suggestions engine is able to complete struct field `hour`