### PR TITLE
Add def_arity to func suggestion

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -152,7 +152,7 @@ defmodule ElixirSense do
       ...> end
       ...> '''
       iex> ElixirSense.suggestions(code, 3, 12)
-      [%{origin: "List", type: :function, args: "list, index, value", arity: 3,
+      [%{origin: "List", type: :function, args: "list, index, value", arity: 3, def_arity: 3,
         name: "insert_at", metadata: %{}, snippet: nil, visibility: :public,
         spec: "@spec insert_at(list, integer, any) :: list", summary: "Returns a list with `value` inserted at the specified `index`."}]
   """

--- a/lib/elixir_sense/providers/suggestion/reducers/common.ex
+++ b/lib/elixir_sense/providers/suggestion/reducers/common.ex
@@ -22,6 +22,7 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Common do
           visibility: :public | :private,
           name: String.t(),
           arity: non_neg_integer,
+          def_arity: non_neg_integer,
           args: String.t(),
           origin: String.t(),
           summary: String.t(),

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -26,6 +26,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
     assert result |> Enum.at(0) == %{
              args: "atom",
              arity: 1,
+             def_arity: 1,
              name: "__info__",
              origin: "ElixirSenseExample.EmptyModule",
              spec:
@@ -40,6 +41,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
     assert result |> Enum.at(1) == %{
              args: "",
              arity: 0,
+             def_arity: 0,
              name: "module_info",
              origin: "ElixirSenseExample.EmptyModule",
              spec:
@@ -54,6 +56,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
     assert result |> Enum.at(2) == %{
              args: "key",
              arity: 1,
+             def_arity: 1,
              name: "module_info",
              origin: "ElixirSenseExample.EmptyModule",
              spec:
@@ -138,6 +141,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                %{
                  args: "",
                  arity: 0,
+                 def_arity: 0,
                  name: "say_hi",
                  origin: "ElixirSense.Providers.SuggestionTest.MyModule",
                  spec: "",
@@ -165,6 +169,56 @@ defmodule ElixirSense.Providers.SuggestionTest do
       |> Enum.map(& &1.name)
 
     refute "module_info" in suggestions_names
+  end
+
+  test "a function with default args generate multiple derived entries with same info, except arity" do
+    assert [
+             %{
+               arity: 1,
+               def_arity: 2,
+               name: "all?",
+               summary: "all?/2 docs",
+               type: :function
+             },
+             %{
+               arity: 2,
+               def_arity: 2,
+               name: "all?",
+               summary: "all?/2 docs",
+               type: :function
+             }
+           ] =
+             Suggestion.find(
+               "ElixirSenseExample.FunctionsWithTheSameName.all",
+               "",
+               @env,
+               %Metadata{}
+             )
+  end
+
+  test "functions with the same name but different arities generates independent entries" do
+    assert [
+             %{
+               arity: 1,
+               def_arity: 1,
+               name: "concat",
+               summary: "concat/1 docs",
+               type: :function
+             },
+             %{
+               arity: 2,
+               def_arity: 2,
+               name: "concat",
+               summary: "concat/2 docs",
+               type: :function
+             }
+           ] =
+             Suggestion.find(
+               "ElixirSenseExample.FunctionsWithTheSameName.conca",
+               "",
+               @env,
+               %Metadata{}
+             )
   end
 
   defmodule MyStruct do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -15,6 +15,7 @@ defmodule ElixirSense.SuggestionsTest do
     assert Enum.find(list, fn s -> match?(%{name: "import", arity: 2}, s) end) == %{
              args: "module, opts",
              arity: 2,
+             def_arity: 2,
              name: "import",
              origin: "Kernel.SpecialForms",
              spec: "",
@@ -27,6 +28,7 @@ defmodule ElixirSense.SuggestionsTest do
 
     assert Enum.find(list, fn s -> match?(%{name: "quote", arity: 2}, s) end) == %{
              arity: 2,
+             def_arity: 2,
              origin: "Kernel.SpecialForms",
              spec: "",
              type: :macro,
@@ -40,6 +42,7 @@ defmodule ElixirSense.SuggestionsTest do
 
     assert Enum.find(list, fn s -> match?(%{name: "require", arity: 2}, s) end) == %{
              arity: 2,
+             def_arity: 2,
              origin: "Kernel.SpecialForms",
              spec: "",
              type: :macro,
@@ -65,6 +68,7 @@ defmodule ElixirSense.SuggestionsTest do
              %{
                args: "term",
                arity: 1,
+               def_arity: 1,
                name: "is_binary",
                origin: "Kernel",
                spec: "@spec is_binary(term) :: boolean",
@@ -77,6 +81,7 @@ defmodule ElixirSense.SuggestionsTest do
              %{
                args: "term",
                arity: 1,
+               def_arity: 1,
                name: "is_bitstring",
                origin: "Kernel",
                spec: "@spec is_bitstring(term) :: boolean",
@@ -90,6 +95,7 @@ defmodule ElixirSense.SuggestionsTest do
              %{
                args: "term",
                arity: 1,
+               def_arity: 1,
                name: "is_boolean",
                origin: "Kernel",
                spec: "@spec is_boolean(term) :: boolean",
@@ -117,6 +123,7 @@ defmodule ElixirSense.SuggestionsTest do
              %{
                args: "list",
                arity: 1,
+               def_arity: 1,
                name: "flatten",
                origin: "List",
                spec: "@spec flatten(deep_list) :: list when deep_list: [any | deep_list]",
@@ -129,6 +136,7 @@ defmodule ElixirSense.SuggestionsTest do
              %{
                args: "list, tail",
                arity: 2,
+               def_arity: 2,
                name: "flatten",
                origin: "List",
                spec:
@@ -157,6 +165,7 @@ defmodule ElixirSense.SuggestionsTest do
              %{
                args: "var",
                arity: 1,
+               def_arity: 1,
                name: "some",
                origin: "ElixirSenseExample.BehaviourWithMacrocallback.Impl",
                spec: "@spec some(integer) :: Macro.t\n@spec some(b) :: Macro.t when b: float",
@@ -1268,6 +1277,7 @@ defmodule ElixirSense.SuggestionsTest do
     assert [
              %{
                arity: 1,
+               def_arity: 1,
                name: "test_fun_pub",
                origin: "ElixirSenseExample.ModuleO",
                type: :function,
@@ -2038,6 +2048,7 @@ defmodule ElixirSense.SuggestionsTest do
                type: :function,
                args: "",
                arity: 0,
+               def_arity: 0,
                origin: "MyServer",
                spec: "",
                summary: "",

--- a/test/support/functions_with_the_same_name.ex
+++ b/test/support/functions_with_the_same_name.ex
@@ -1,0 +1,16 @@
+defmodule ElixirSenseExample.FunctionsWithTheSameName do
+  @doc "all?/2 docs"
+  def all?(enumerable, fun \\ fn x -> x end) do
+    IO.inspect({enumerable, fun})
+  end
+
+  @doc "concat/1 docs"
+  def concat(enumerables) do
+    IO.inspect(enumerables)
+  end
+
+  @doc "concat/2 docs"
+  def concat(left, right) do
+    IO.inspect({left, right})
+  end
+end


### PR DESCRIPTION
This PR creates a new field `def_arity` for function/macro suggestions. The `def_arity` represents the arity of the original function as it was defined. 

For context, the reason we need this is that we can have two times of functions with the same name:

1. A function with default arguments which generates multiple derived functions with different arities. The derived functions share the same metadata, including documentation and spec, e.g. `Enum.all?/2` generates `Enum.all?/1` and `Enum.all?/2`.

2. Independent functions with the same name but different arities. Although they have the same name, they don't share the same metadata, e.g. `Enum.concat/1` and `Enum.concat/2`.

The problem with the current implementation is that it generates suggestions for all of those functions without keeping any information about the arity of the original function. After a suggestion is generated, there's no easy way to know what functions are related or not. If we need to know that on the client-side, we need to try to group them again and inspect other information like arguments, specs and docs to infer the ones that are related.

This PR allows us to correctly create unique suggestions based on `def_arity` instead of using [insertText](https://github.com/elixir-lsp/elixir-ls/blob/master/apps/language_server/lib/language_server/providers/completion.ex#L142), which is unreliable since unrelated functions might have the same `insertText`. I believe this could be the reason that some functions were showing the wrong docs. Most of the time we just don't realise it because the functions have the same name and the docs are usually similar, however, they are different.

This is needed to properly implement https://github.com/elixir-lsp/elixir-ls/issues/281 and continue the work done in https://github.com/elixir-lsp/elixir-ls/pull/273.