### PR TITLE
decouple make test/server_test.exs:38 from project root name

### DIFF
--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -55,7 +55,7 @@ defmodule ElixirSense.ServerTest do
       column: 7
     } = send_request(socket, request)
 
-    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert file =~ "#{File.cwd!}/test/support/module_with_functions.ex"
   end
 
   test "signature request", %{socket: socket, auth_token: auth_token} do


### PR DESCRIPTION
This pull request makes the success of [`test/server_test.exs:38`](https://github.com/elixir-lsp/elixir_sense/blob/master/test/server_test.exs#L38) independent of project root name.

#### Motivation

Running the aforementioned test inside `docker run -it -v $(pwd):/project_name_of_your_choosing elixir bash` no longer fails.

#### Rationale

The rationale is the same for preferring `__MODULE__` over unaliased literal module name.

#### Alternatives considered

The [alias](https://dockyard.com/blog/2017/08/15/elixir-tips) here could be achieved by something along the following lines:
```elixir
    project_root = Path.expand(Path.join(__ENV__.file, "../.."))
    assert file =~ "#{project_root}/test/support/module_with_functions.ex"
```

The above alternative would couple to test file path, making it position-dependent, in addition to being a bit more verbose in this single use case.