### PR TITLE
Add implementations provider

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -133,7 +133,9 @@ defmodule ElixirSense do
 
         Implementation.find(
           subject,
-          env
+          env,
+          buffer_file_metadata.mods_funs_to_positions,
+          buffer_file_metadata.types
         )
     end
   end

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -108,6 +108,18 @@ defmodule ElixirSense do
     end
   end
 
+  @doc ~S"""
+  Returns the locations (file and line) where a behaviour or protocol was implemented.
+
+  ## Example
+
+      iex> code = ~S'''
+      ...> ElixirSenseExample.ExampleProtocol.some()
+      ...> '''
+      iex>  [%{file: path, line: line, column: column}, _] = ElixirSense.implementations(code, 1, 37)
+      iex> "#{Path.basename(path)}:#{to_string(line)}:#{to_string(column)}"
+      "example_protocol.ex:7:7"
+  """
   @spec implementations(String.t(), pos_integer, pos_integer) :: [Location.t()]
   def implementations(code, line, column) do
     case Source.subject(code, line, column) do
@@ -119,19 +131,9 @@ defmodule ElixirSense do
 
         env = Metadata.get_env(buffer_file_metadata, line)
 
-        calls =
-          buffer_file_metadata.calls[line]
-          |> List.wrap()
-          |> Enum.filter(fn %State.CallInfo{position: {_call_line, call_column}} ->
-            call_column <= column
-          end)
-
         Implementation.find(
           subject,
-          env,
-          buffer_file_metadata.mods_funs_to_positions,
-          calls,
-          buffer_file_metadata.types
+          env
         )
     end
   end

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -75,15 +75,15 @@ defmodule ElixirSense do
       ...>   MyMod.function_arity_one("some string")
       ...> end
       ...> '''
-      iex>  %{found: true, file: path, line: line, column: column} = ElixirSense.definition(code, 3, 11)
+      iex>  %{file: path, line: line, column: column} = ElixirSense.definition(code, 3, 11)
       iex> "#{Path.basename(path)}:#{to_string(line)}:#{to_string(column)}"
       "module_with_functions.ex:6:7"
   """
-  @spec definition(String.t(), pos_integer, pos_integer) :: Location.t()
+  @spec definition(String.t(), pos_integer, pos_integer) :: Location.t() | nil
   def definition(code, line, column) do
     case Source.subject(code, line, column) do
       nil ->
-        %Location{found: false}
+        nil
 
       subject ->
         buffer_file_metadata = Parser.parse_string(code, true, true, line)

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -24,6 +24,7 @@ defmodule ElixirSense.Core.Introspection do
   A collection of functions to introspect/format docs, specs, types and callbacks.
   """
 
+  alias ElixirSense.Core.Applications
   alias ElixirSense.Core.BuiltinFunctions
   alias ElixirSense.Core.BuiltinTypes
   alias ElixirSense.Core.EdocReader
@@ -1339,4 +1340,10 @@ defmodule ElixirSense.Core.Introspection do
   end
 
   def is_pub(type), do: type in [:def, :defmacro, :defdelegate, :defguard]
+
+  @spec get_all_behaviour_implementations(module) :: [module]
+  def get_all_behaviour_implementations(behaviour) do
+    Applications.get_modules_from_applications()
+    |> Enum.filter(&(behaviour in List.wrap(&1.module_info()[:attributes][:behaviour])))
+  end
 end

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -40,9 +40,12 @@ defmodule ElixirSense.Core.Introspection do
 
   @no_documentation "No documentation available\n"
 
+  # TODO consider removing this when EEP 48 support lands
   @wrapped_behaviours %{
     :gen_server => GenServer,
-    :gen_event => GenEvent
+    :gen_event => GenEvent,
+    :supervisor => Supervisor,
+    :application => Application
   }
 
   @spec get_exports(module) :: [{atom, non_neg_integer}]

--- a/lib/elixir_sense/location.ex
+++ b/lib/elixir_sense/location.ex
@@ -1,0 +1,13 @@
+defmodule ElixirSense.Location do
+  @moduledoc """
+  A location in a source file or buffer
+  """
+
+  @type t :: %ElixirSense.Location{
+          type: :module | :function | :variable | :typespec | :macro | :attribute | nil,
+          file: String.t() | nil,
+          line: pos_integer | nil,
+          column: pos_integer | nil
+        }
+  defstruct [:type, :file, :line, :column]
+end

--- a/lib/elixir_sense/location.ex
+++ b/lib/elixir_sense/location.ex
@@ -10,10 +10,10 @@ defmodule ElixirSense.Location do
   alias ElixirSense.Location
 
   @type t :: %Location{
-          type: :module | :function | :variable | :typespec | :macro | :attribute | nil,
+          type: :module | :function | :variable | :typespec | :macro | :attribute,
           file: String.t() | nil,
-          line: pos_integer | nil,
-          column: pos_integer | nil
+          line: pos_integer,
+          column: pos_integer
         }
   defstruct [:type, :file, :line, :column]
 

--- a/lib/elixir_sense/location.ex
+++ b/lib/elixir_sense/location.ex
@@ -3,11 +3,159 @@ defmodule ElixirSense.Location do
   A location in a source file or buffer
   """
 
-  @type t :: %ElixirSense.Location{
+  alias ElixirSense.Core.Metadata
+  alias ElixirSense.Core.Parser
+  alias ElixirSense.Core.Source
+  alias ElixirSense.Core.State.ModFunInfo
+  alias ElixirSense.Location
+
+  @type t :: %Location{
           type: :module | :function | :variable | :typespec | :macro | :attribute | nil,
           file: String.t() | nil,
           line: pos_integer | nil,
           column: pos_integer | nil
         }
   defstruct [:type, :file, :line, :column]
+
+  @spec find_source({module, atom}, atom) :: Location.t() | nil
+  def find_source({mod, fun}, current_module) do
+    with(
+      {mod, file} when file not in ["non_existing", nil, ""] <- find_mod_file(mod),
+      nil <- find_fun_position({mod, file}, fun),
+      nil <- find_type_position({mod, file}, fun),
+      nil <- find_type_position({current_module, file}, fun)
+    ) do
+      nil
+    else
+      %Location{} = location ->
+        location
+
+      _ ->
+        nil
+    end
+  end
+
+  defp find_mod_file(Elixir), do: nil
+
+  defp find_mod_file(module) do
+    file =
+      if Code.ensure_loaded?(module) do
+        case module.module_info(:compile)[:source] do
+          nil -> nil
+          source -> List.to_string(source)
+        end
+      end
+
+    file =
+      if file && File.exists?(file, [:raw]) do
+        file
+      else
+        with {_module, _binary, beam_filename} <- :code.get_object_code(module),
+             erl_file =
+               beam_filename
+               |> to_string
+               |> String.replace(
+                 Regex.recompile!(~r/(.+)\/ebin\/([^\s]+)\.beam$/),
+                 "\\1/src/\\2.erl"
+               ),
+             true <- File.exists?(erl_file, [:raw]) do
+          erl_file
+        else
+          _ -> nil
+        end
+      end
+
+    {module, file}
+  end
+
+  defp find_fun_position({mod, file}, fun) do
+    {position, category} =
+      if String.ends_with?(file, ".erl") do
+        # no macros in erlang modules, assume :function when fun != nil
+        category = fun_to_type(fun)
+        {find_fun_position_in_erl_file(file, fun), category}
+      else
+        %Metadata{mods_funs_to_positions: mods_funs_to_positions} =
+          file_metadata = Parser.parse_file(file, false, false, nil)
+
+        category =
+          case mods_funs_to_positions[{mod, fun, nil}] do
+            %ModFunInfo{} = mi ->
+              ModFunInfo.get_category(mi)
+
+            nil ->
+              # not found, fall back to :function when fun != nil
+              # TODO use docs?
+              fun_to_type(fun)
+          end
+
+        {Metadata.get_function_position(file_metadata, mod, fun), category}
+      end
+
+    case position do
+      {line, column} ->
+        %Location{type: category, file: file, line: line, column: column}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp fun_to_type(nil), do: :module
+  defp fun_to_type(_), do: :function
+
+  defp find_fun_position_in_erl_file(file, nil) do
+    find_line_by_regex(file, Regex.recompile!(~r/^-module/))
+  end
+
+  defp find_fun_position_in_erl_file(file, name) do
+    escaped =
+      name
+      |> Atom.to_string()
+      |> Regex.escape()
+
+    find_line_by_regex(file, Regex.recompile!(~r/^#{escaped}\b/))
+  end
+
+  defp find_type_position_in_erl_file(file, name) do
+    escaped =
+      name
+      |> Atom.to_string()
+      |> Regex.escape()
+
+    find_line_by_regex(file, Regex.recompile!(~r/^-(typep?|opaque)\s#{escaped}\b/))
+  end
+
+  defp find_line_by_regex(file, regex) do
+    index =
+      file
+      |> File.read!()
+      |> Source.split_lines()
+      |> Enum.find_index(&String.match?(&1, regex))
+
+    case index do
+      nil -> nil
+      i -> {i + 1, 1}
+    end
+  end
+
+  defp find_type_position(_, nil), do: nil
+
+  defp find_type_position({mod, file}, name) do
+    position =
+      if String.ends_with?(file, ".erl") do
+        find_type_position_in_erl_file(file, name)
+      else
+        file_metadata = Parser.parse_file(file, false, false, nil)
+        Metadata.get_type_position(file_metadata, mod, name, file)
+      end
+
+    case position do
+      {line, column} ->
+        %Location{type: :typespec, file: file, line: line, column: column}
+
+      _ ->
+        nil
+    end
+  end
 end

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -8,8 +8,6 @@ defmodule ElixirSense.Providers.Definition do
 
   alias ElixirSense.Core.Binding
   alias ElixirSense.Core.Introspection
-  alias ElixirSense.Core.Metadata
-  alias ElixirSense.Core.Parser
   alias ElixirSense.Core.Source
   alias ElixirSense.Core.State
   alias ElixirSense.Core.State.ModFunInfo
@@ -192,7 +190,7 @@ defmodule ElixirSense.Providers.Definition do
       {mod, fun, true} ->
         case mods_funs_to_positions[{mod, fun, nil}] || metadata_types[{mod, fun, nil}] do
           nil ->
-            {mod, fun} |> find_source(current_module)
+            Location.find_source({mod, fun}, current_module)
 
           %TypeInfo{positions: positions} ->
             # for simplicity take last position here as positions are reversed
@@ -226,147 +224,6 @@ defmodule ElixirSense.Providers.Definition do
               column: column
             }
         end
-    end
-  end
-
-  defp find_source({mod, fun}, current_module) do
-    with(
-      {mod, file} when file not in ["non_existing", nil, ""] <- find_mod_file(mod),
-      nil <- find_fun_position({mod, file}, fun),
-      nil <- find_type_position({mod, file}, fun),
-      nil <- find_type_position({current_module, file}, fun)
-    ) do
-      nil
-    else
-      %Location{} = location ->
-        location
-
-      _ ->
-        nil
-    end
-  end
-
-  defp find_mod_file(Elixir), do: nil
-
-  defp find_mod_file(module) do
-    file =
-      if Code.ensure_loaded?(module) do
-        case module.module_info(:compile)[:source] do
-          nil -> nil
-          source -> List.to_string(source)
-        end
-      end
-
-    file =
-      if file && File.exists?(file, [:raw]) do
-        file
-      else
-        with {_module, _binary, beam_filename} <- :code.get_object_code(module),
-             erl_file =
-               beam_filename
-               |> to_string
-               |> String.replace(
-                 Regex.recompile!(~r/(.+)\/ebin\/([^\s]+)\.beam$/),
-                 "\\1/src/\\2.erl"
-               ),
-             true <- File.exists?(erl_file, [:raw]) do
-          erl_file
-        else
-          _ -> nil
-        end
-      end
-
-    {module, file}
-  end
-
-  defp find_fun_position({mod, file}, fun) do
-    {position, category} =
-      if String.ends_with?(file, ".erl") do
-        # no macros in erlang modules, assume :function when fun != nil
-        category = fun_to_type(fun)
-        {find_fun_position_in_erl_file(file, fun), category}
-      else
-        %Metadata{mods_funs_to_positions: mods_funs_to_positions} =
-          file_metadata = Parser.parse_file(file, false, false, nil)
-
-        category =
-          case mods_funs_to_positions[{mod, fun, nil}] do
-            %ModFunInfo{} = mi ->
-              ModFunInfo.get_category(mi)
-
-            nil ->
-              # not found, fall back to :function when fun != nil
-              # TODO use docs?
-              fun_to_type(fun)
-          end
-
-        {Metadata.get_function_position(file_metadata, mod, fun), category}
-      end
-
-    case position do
-      {line, column} ->
-        %Location{type: category, file: file, line: line, column: column}
-
-      _ ->
-        nil
-    end
-  end
-
-  defp fun_to_type(nil), do: :module
-  defp fun_to_type(_), do: :function
-
-  defp find_fun_position_in_erl_file(file, nil) do
-    find_line_by_regex(file, Regex.recompile!(~r/^-module/))
-  end
-
-  defp find_fun_position_in_erl_file(file, name) do
-    escaped =
-      name
-      |> Atom.to_string()
-      |> Regex.escape()
-
-    find_line_by_regex(file, Regex.recompile!(~r/^#{escaped}\b/))
-  end
-
-  defp find_type_position_in_erl_file(file, name) do
-    escaped =
-      name
-      |> Atom.to_string()
-      |> Regex.escape()
-
-    find_line_by_regex(file, Regex.recompile!(~r/^-(typep?|opaque)\s#{escaped}\b/))
-  end
-
-  defp find_line_by_regex(file, regex) do
-    index =
-      file
-      |> File.read!()
-      |> Source.split_lines()
-      |> Enum.find_index(&String.match?(&1, regex))
-
-    case index do
-      nil -> nil
-      i -> {i + 1, 1}
-    end
-  end
-
-  defp find_type_position(_, nil), do: nil
-
-  defp find_type_position({mod, file}, name) do
-    position =
-      if String.ends_with?(file, ".erl") do
-        find_type_position_in_erl_file(file, name)
-      else
-        file_metadata = Parser.parse_file(file, false, false, nil)
-        Metadata.get_type_position(file_metadata, mod, name, file)
-      end
-
-    case position do
-      {line, column} ->
-        %Location{type: :typespec, file: file, line: line, column: column}
-
-      _ ->
-        nil
     end
   end
 end

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -113,6 +113,7 @@ defmodule ElixirSense.Providers.Definition do
     end
   end
 
+  # credo:disable-for-lines:20
   defp do_find_function_or_module(
          {{:attribute, _attr} = type, function},
          mods_funs_to_positions,
@@ -167,8 +168,8 @@ defmodule ElixirSense.Providers.Definition do
          mods_funs_to_positions,
          env,
          metadata_types,
-         binding_env,
-         visited
+         _binding_env,
+         _visited
        ) do
     %State.Env{
       module: current_module,
@@ -202,16 +203,6 @@ defmodule ElixirSense.Providers.Definition do
               line: line,
               column: column
             }
-
-          %ModFunInfo{type: :defdelegate, target: target} when not is_nil(target) ->
-            find_function_or_module(
-              target,
-              mods_funs_to_positions,
-              env,
-              metadata_types,
-              binding_env,
-              visited
-            )
 
           %ModFunInfo{positions: positions} = mi ->
             # for simplicity take last position here as positions are reversed

--- a/lib/elixir_sense/providers/implementation.ex
+++ b/lib/elixir_sense/providers/implementation.ex
@@ -1,0 +1,210 @@
+defmodule ElixirSense.Providers.Implementation do
+  @moduledoc """
+  Provides a function to find out where symbols are implemented.
+  """
+
+  alias ElixirSense.Core.Binding
+  alias ElixirSense.Core.Introspection
+  alias ElixirSense.Core.Metadata
+  alias ElixirSense.Core.Parser
+  alias ElixirSense.Core.Source
+  alias ElixirSense.Core.State
+  alias ElixirSense.Core.State.ModFunInfo
+  alias ElixirSense.Core.State.TypeInfo
+  alias ElixirSense.Core.State.VarInfo
+  alias ElixirSense.Location
+
+  @doc """
+  Finds out where a module, function, macro or variable was defined.
+  """
+  @spec find(
+          String.t(),
+          State.Env.t(),
+          State.mods_funs_to_positions_t(),
+          list(State.CallInfo.t()),
+          State.types_t()
+        ) :: [%Location{}]
+  def find(
+        subject,
+        %State.Env{
+          aliases: aliases,
+          module: module,
+          vars: vars,
+          attributes: attributes
+        } = env,
+        mods_funs_to_positions,
+        calls,
+        metadata_types
+      ) do
+    binding_env = %Binding{
+      attributes: attributes,
+      variables: vars,
+      current_module: module
+    }
+
+    case Source.split_module_and_func(subject, module, aliases) do
+      {found_module, nil} ->
+        Introspection.get_all_behaviour_implementations(found_module)
+        |> Enum.map(fn implementation ->
+          Location.find_source({implementation, nil}, nil)
+        end)
+    end
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # defp subject_is_call?(subject, calls) do
+  #   Enum.find(calls, fn
+  #     %State.CallInfo{func: func} ->
+  #       Atom.to_string(func) == subject
+
+  #     _ ->
+  #       false
+  #   end) != nil
+  # end
+
+  # defp find_attribute("@" <> attribute_name, attributes) do
+  #   Enum.find(attributes, fn
+  #     %State.AttributeInfo{name: name} ->
+  #       Atom.to_string(name) == attribute_name
+
+  #     _ ->
+  #       false
+  #   end)
+  # end
+
+  # defp find_attribute(_, _attributes), do: nil
+
+  # defp find_function_or_module(
+  #        {module, function},
+  #        mods_funs_to_positions,
+  #        env,
+  #        metadata_types,
+  #        binding_env,
+  #        visited \\ []
+  #      ) do
+  #   unless {module, function} in visited do
+  #     do_find_function_or_module(
+  #       {module, function},
+  #       mods_funs_to_positions,
+  #       env,
+  #       metadata_types,
+  #       binding_env,
+  #       [{module, function} | visited]
+  #     )
+  #   end
+  # end
+
+  # defp do_find_function_or_module(
+  #        {{:attribute, _attr} = type, function},
+  #        mods_funs_to_positions,
+  #        env,
+  #        metadata_types,
+  #        binding_env,
+  #        visited
+  #      ) do
+  #   case Binding.expand(binding_env, type) do
+  #     {:atom, module} ->
+  #       do_find_function_or_module(
+  #         {Introspection.expand_alias(module, env.aliases), function},
+  #         mods_funs_to_positions,
+  #         env,
+  #         metadata_types,
+  #         binding_env,
+  #         visited
+  #       )
+
+  #     _ ->
+  #       nil
+  #   end
+  # end
+
+  # defp do_find_function_or_module(
+  #        {nil, :super},
+  #        mods_funs_to_positions,
+  #        %State.Env{scope: {function, arity}, module: module} = env,
+  #        metadata_types,
+  #        binding_env,
+  #        visited
+  #      ) do
+  #   case mods_funs_to_positions[{module, function, arity}] do
+  #     %ModFunInfo{overridable: {true, origin}} ->
+  #       # overridable function is most likely defined by __using__ macro
+  #       do_find_function_or_module(
+  #         {origin, :__using__},
+  #         mods_funs_to_positions,
+  #         env,
+  #         metadata_types,
+  #         binding_env,
+  #         visited
+  #       )
+
+  #     _ ->
+  #       nil
+  #   end
+  # end
+
+  # defp do_find_function_or_module(
+  #        {module, function},
+  #        mods_funs_to_positions,
+  #        env,
+  #        metadata_types,
+  #        binding_env,
+  #        visited
+  #      ) do
+  #   %State.Env{
+  #     module: current_module,
+  #     imports: imports,
+  #     aliases: aliases
+  #   } = env
+
+  #   case {module, function}
+  #        |> Introspection.actual_mod_fun(
+  #          imports,
+  #          aliases,
+  #          current_module,
+  #          mods_funs_to_positions,
+  #          metadata_types
+  #        ) do
+  #     {_, _, false} ->
+  #       nil
+
+  #     {mod, fun, true} ->
+  #       case mods_funs_to_positions[{mod, fun, nil}] || metadata_types[{mod, fun, nil}] do
+  #         nil ->
+  #           {mod, fun} |> find_source(current_module)
+
+  #         %TypeInfo{positions: positions} ->
+  #           # for simplicity take last position here as positions are reversed
+  #           {line, column} = positions |> Enum.at(-1)
+
+  #           %Location{
+  #             file: nil,
+  #             type: :typespec,
+  #             line: line,
+  #             column: column
+  #           }
+
+  #         %ModFunInfo{type: :defdelegate, target: target} when not is_nil(target) ->
+  #           find_function_or_module(
+  #             target,
+  #             mods_funs_to_positions,
+  #             env,
+  #             metadata_types,
+  #             binding_env,
+  #             visited
+  #           )
+
+  #         %ModFunInfo{positions: positions} = mi ->
+  #           # for simplicity take last position here as positions are reversed
+  #           {line, column} = positions |> Enum.at(-1)
+
+  #           %Location{
+  #             file: nil,
+  #             type: ModFunInfo.get_category(mi),
+  #             line: line,
+  #             column: column
+  #           }
+  #       end
+  #   end
+  # end
+end

--- a/lib/elixir_sense/providers/implementation.ex
+++ b/lib/elixir_sense/providers/implementation.ex
@@ -3,193 +3,215 @@ defmodule ElixirSense.Providers.Implementation do
   Provides a function to find out where symbols are implemented.
   """
 
+  alias ElixirSense.Core.Binding
   alias ElixirSense.Core.Introspection
+  alias ElixirSense.Core.Normalized
   alias ElixirSense.Core.Source
   alias ElixirSense.Core.State
+  alias ElixirSense.Core.State.ModFunInfo
   alias ElixirSense.Location
 
   @doc """
-  Finds out where a module, function, macro or variable was defined.
+  Finds out where a callback, protocol or delegate was implemented.
   """
   @spec find(
           String.t(),
-          State.Env.t()
+          State.Env.t(),
+          State.mods_funs_to_positions_t(),
+          State.types_t()
         ) :: [%Location{}]
   def find(
         subject,
         %State.Env{
           aliases: aliases,
-          module: module
-        }
+          module: module,
+          vars: vars,
+          attributes: attributes
+        } = env,
+        mods_funs_to_positions,
+        metadata_types
       ) do
+    binding_env = %Binding{
+      attributes: attributes,
+      variables: vars,
+      current_module: module
+    }
+
     {maybe_found_module, maybe_fun} = Source.split_module_and_func(subject, module, aliases)
 
+    behaviour_implementations =
+      find_behaviour_implementations(maybe_found_module, maybe_fun, module, env, binding_env)
+
+    if behaviour_implementations == [] do
+      find_delegatee(
+        {maybe_found_module, maybe_fun},
+        mods_funs_to_positions,
+        env,
+        metadata_types,
+        binding_env
+      )
+      |> List.wrap()
+    else
+      behaviour_implementations
+    end
+  end
+
+  def find_behaviour_implementations(maybe_found_module, maybe_fun, module, env, binding_env) do
     case maybe_found_module || module do
       nil ->
         []
 
       found_module ->
-        Introspection.get_all_behaviour_implementations(found_module)
-        |> Enum.map(fn implementation ->
-          Location.find_source({implementation, maybe_fun}, nil)
-        end)
+        found_module = expand(found_module, binding_env)
+
+        cond do
+          maybe_fun == nil or is_callback(found_module, maybe_fun) ->
+            get_locations(found_module, maybe_fun)
+
+          maybe_fun != nil ->
+            for behaviour <- env.behaviours,
+                is_callback(behaviour, maybe_fun) do
+              get_locations(behaviour, maybe_fun)
+            end
+            |> List.flatten()
+
+          true ->
+            []
+        end
     end
     |> Enum.reject(&is_nil/1)
   end
 
-  # defp subject_is_call?(subject, calls) do
-  #   Enum.find(calls, fn
-  #     %State.CallInfo{func: func} ->
-  #       Atom.to_string(func) == subject
+  defp expand({:attribute, _attr} = type, binding_env) do
+    case Binding.expand(binding_env, type) do
+      {:atom, atom} -> atom
+      _ -> nil
+    end
+  end
 
-  #     _ ->
-  #       false
-  #   end) != nil
-  # end
+  defp expand(other, _binding_env), do: other
 
-  # defp find_attribute("@" <> attribute_name, attributes) do
-  #   Enum.find(attributes, fn
-  #     %State.AttributeInfo{name: name} ->
-  #       Atom.to_string(name) == attribute_name
+  defp get_locations(behaviour, maybe_callback) do
+    Introspection.get_all_behaviour_implementations(behaviour)
+    |> Enum.map(fn implementation ->
+      Location.find_source({implementation, maybe_callback}, nil)
+    end)
+  end
 
-  #     _ ->
-  #       false
-  #   end)
-  # end
+  defp is_callback(behaviour, fun) when is_atom(behaviour) do
+    Code.ensure_loaded?(behaviour) and
+      function_exported?(behaviour, :behaviour_info, 1) and
+      behaviour.behaviour_info(:callbacks)
+      |> Enum.any?(&match?({^fun, _}, &1))
+  end
 
-  # defp find_attribute(_, _attributes), do: nil
+  defp find_delegatee(
+         {module, function},
+         mods_funs_to_positions,
+         env,
+         metadata_types,
+         binding_env,
+         visited \\ []
+       ) do
+    unless {module, function} in visited do
+      do_find_delegatee(
+        {module, function},
+        mods_funs_to_positions,
+        env,
+        metadata_types,
+        binding_env,
+        [{module, function} | visited]
+      )
+    end
+  end
 
-  # defp find_function_or_module(
-  #        {module, function},
-  #        mods_funs_to_positions,
-  #        env,
-  #        metadata_types,
-  #        binding_env,
-  #        visited \\ []
-  #      ) do
-  #   unless {module, function} in visited do
-  #     do_find_function_or_module(
-  #       {module, function},
-  #       mods_funs_to_positions,
-  #       env,
-  #       metadata_types,
-  #       binding_env,
-  #       [{module, function} | visited]
-  #     )
-  #   end
-  # end
+  # credo:disable-for-lines:20
+  defp do_find_delegatee(
+         {{:attribute, _attr} = type, function},
+         mods_funs_to_positions,
+         env,
+         metadata_types,
+         binding_env,
+         visited
+       ) do
+    case Binding.expand(binding_env, type) do
+      {:atom, module} ->
+        do_find_delegatee(
+          {Introspection.expand_alias(module, env.aliases), function},
+          mods_funs_to_positions,
+          env,
+          metadata_types,
+          binding_env,
+          visited
+        )
 
-  # defp do_find_function_or_module(
-  #        {{:attribute, _attr} = type, function},
-  #        mods_funs_to_positions,
-  #        env,
-  #        metadata_types,
-  #        binding_env,
-  #        visited
-  #      ) do
-  #   case Binding.expand(binding_env, type) do
-  #     {:atom, module} ->
-  #       do_find_function_or_module(
-  #         {Introspection.expand_alias(module, env.aliases), function},
-  #         mods_funs_to_positions,
-  #         env,
-  #         metadata_types,
-  #         binding_env,
-  #         visited
-  #       )
+      _ ->
+        nil
+    end
+  end
 
-  #     _ ->
-  #       nil
-  #   end
-  # end
+  defp do_find_delegatee(
+         {module, function},
+         mods_funs_to_positions,
+         env,
+         metadata_types,
+         binding_env,
+         visited
+       ) do
+    %State.Env{
+      module: current_module,
+      imports: imports,
+      aliases: aliases
+    } = env
 
-  # defp do_find_function_or_module(
-  #        {nil, :super},
-  #        mods_funs_to_positions,
-  #        %State.Env{scope: {function, arity}, module: module} = env,
-  #        metadata_types,
-  #        binding_env,
-  #        visited
-  #      ) do
-  #   case mods_funs_to_positions[{module, function, arity}] do
-  #     %ModFunInfo{overridable: {true, origin}} ->
-  #       # overridable function is most likely defined by __using__ macro
-  #       do_find_function_or_module(
-  #         {origin, :__using__},
-  #         mods_funs_to_positions,
-  #         env,
-  #         metadata_types,
-  #         binding_env,
-  #         visited
-  #       )
+    case {module, function}
+         |> Introspection.actual_mod_fun(
+           imports,
+           aliases,
+           current_module,
+           mods_funs_to_positions,
+           metadata_types
+         ) do
+      {mod, fun, true} when not is_nil(fun) ->
+        case mods_funs_to_positions[{mod, fun, nil}] do
+          nil ->
+            find_delegatee_location(mod, fun, current_module, visited)
 
-  #     _ ->
-  #       nil
-  #   end
-  # end
+          %ModFunInfo{type: :defdelegate, target: target} when not is_nil(target) ->
+            find_delegatee(
+              target,
+              mods_funs_to_positions,
+              env,
+              metadata_types,
+              binding_env,
+              visited
+            )
 
-  # defp do_find_function_or_module(
-  #        {module, function},
-  #        mods_funs_to_positions,
-  #        env,
-  #        metadata_types,
-  #        binding_env,
-  #        visited
-  #      ) do
-  #   %State.Env{
-  #     module: current_module,
-  #     imports: imports,
-  #     aliases: aliases
-  #   } = env
+          _ ->
+            # not a delegate
+            nil
+        end
 
-  #   case {module, function}
-  #        |> Introspection.actual_mod_fun(
-  #          imports,
-  #          aliases,
-  #          current_module,
-  #          mods_funs_to_positions,
-  #          metadata_types
-  #        ) do
-  #     {_, _, false} ->
-  #       nil
+      _ ->
+        nil
+    end
+  end
 
-  #     {mod, fun, true} ->
-  #       case mods_funs_to_positions[{mod, fun, nil}] || metadata_types[{mod, fun, nil}] do
-  #         nil ->
-  #           {mod, fun} |> find_source(current_module)
+  defp find_delegatee_location(mod, fun, current_module, visited) do
+    case Normalized.Code.get_docs(mod, :docs)
+         |> List.wrap()
+         |> Enum.find(&match?({{^fun, _}, _, :function, _, _, %{delegate_to: _}}, &1)) do
+      nil ->
+        # ensure we are expanding a delegate
+        if length(visited) > 1 do
+          Location.find_source({mod, fun}, current_module)
+        end
 
-  #         %TypeInfo{positions: positions} ->
-  #           # for simplicity take last position here as positions are reversed
-  #           {line, column} = positions |> Enum.at(-1)
-
-  #           %Location{
-  #             file: nil,
-  #             type: :typespec,
-  #             line: line,
-  #             column: column
-  #           }
-
-  #         %ModFunInfo{type: :defdelegate, target: target} when not is_nil(target) ->
-  #           find_function_or_module(
-  #             target,
-  #             mods_funs_to_positions,
-  #             env,
-  #             metadata_types,
-  #             binding_env,
-  #             visited
-  #           )
-
-  #         %ModFunInfo{positions: positions} = mi ->
-  #           # for simplicity take last position here as positions are reversed
-  #           {line, column} = positions |> Enum.at(-1)
-
-  #           %Location{
-  #             file: nil,
-  #             type: ModFunInfo.get_category(mi),
-  #             line: line,
-  #             column: column
-  #           }
-  #       end
-  #   end
-  # end
+      {_, _, _, _, _,
+       %{
+         delegate_to: {delegate_mod, delegate_fun, _}
+       }} ->
+        Location.find_source({delegate_mod, delegate_fun}, current_module)
+    end
+  end
 end

--- a/lib/elixir_sense/server/request_handler.ex
+++ b/lib/elixir_sense/server/request_handler.ex
@@ -17,6 +17,10 @@ defmodule ElixirSense.Server.RequestHandler do
     ElixirSense.definition(buffer, line, column)
   end
 
+  def handle_request("implementations", %{"buffer" => buffer, "line" => line, "column" => column}) do
+    ElixirSense.implementations(buffer, line, column)
+  end
+
   def handle_request("suggestions", %{"buffer" => buffer, "line" => line, "column" => column}) do
     ElixirSense.suggestions(buffer, line, column)
   end

--- a/run.exs
+++ b/run.exs
@@ -18,6 +18,7 @@ requires = [
   "elixir_sense/core/normalized/typespec.ex",
   "elixir_sense/core/struct.ex",
   "elixir_sense/core/binding.ex",
+  "elixir_sense/location.ex",
   "elixir_sense/providers/suggestion/complete.ex",
   "elixir_sense/providers/definition.ex",
   "elixir_sense/providers/docs.ex",

--- a/test/elixir_sense/core/introspection_test.exs
+++ b/test/elixir_sense/core/introspection_test.exs
@@ -69,21 +69,18 @@ defmodule ElixirSense.Core.IntrospectionTest do
   end
 
   test "get_callbacks_with_docs for erlang behaviours" do
-    assert get_callbacks_with_docs(:supervisor) == [
+    assert [
              %{
-               name: :init,
-               arity: 1,
-               callback: """
-               @callback init(args :: term) ::
-                 {:ok, {supFlags :: sup_flags, [childSpec :: child_spec]}} |
-                 :ignore\
-               """,
-               signature: "init(args)",
+               arity: 0,
+               callback: "@callback callback_mode :: callback_mode_result",
                doc: nil,
+               kind: :callback,
                metadata: %{optional: false},
-               kind: :callback
+               name: :callback_mode,
+               signature: "callback_mode()"
              }
-           ]
+             | _
+           ] = get_callbacks_with_docs(:gen_statem)
   end
 
   test "get_callbacks_with_docs for Elixir behaviours with no docs defined" do

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -38,7 +38,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %{type: :macro, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 1, 2)
 
     assert file =~ "lib/elixir/lib/kernel.ex"
@@ -54,7 +54,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %{type: :macro, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 4)
 
     assert file =~ "lib/elixir/lib/kernel/special_forms.ex"

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -38,8 +38,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :macro, file: file, line: line, column: column} =
-      ElixirSense.definition(buffer, 1, 2)
+    %{type: :macro, file: file, line: line, column: column} = ElixirSense.definition(buffer, 1, 2)
 
     assert file =~ "lib/elixir/lib/kernel.ex"
     assert read_line(file, {line, column}) =~ "defmodule("
@@ -54,8 +53,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :macro, file: file, line: line, column: column} =
-      ElixirSense.definition(buffer, 2, 4)
+    %{type: :macro, file: file, line: line, column: column} = ElixirSense.definition(buffer, 2, 4)
 
     assert file =~ "lib/elixir/lib/kernel/special_forms.ex"
     assert read_line(file, {line, column}) =~ "import"

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -7,11 +7,11 @@ defmodule ElixirSense.Providers.DefinitionTest do
   doctest Definition
 
   test "dont crash on empty buffer" do
-    assert %{found: false} = ElixirSense.definition("", 1, 1)
+    refute ElixirSense.definition("", 1, 1)
   end
 
   test "dont error on __MODULE__ when no module" do
-    assert %{found: false} = ElixirSense.definition("__MODULE__", 1, 1)
+    refute ElixirSense.definition("__MODULE__", 1, 1)
   end
 
   test "find definition of aliased modules in `use`" do
@@ -23,7 +23,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :module, file: file, line: line, column: column} =
+    %{type: :module, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/use_example.ex"
@@ -38,7 +38,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 1, 2)
 
     assert file =~ "lib/elixir/lib/kernel.ex"
@@ -54,7 +54,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 4)
 
     assert file =~ "lib/elixir/lib/kernel/special_forms.ex"
@@ -70,7 +70,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 4)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -86,7 +86,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 11)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -102,7 +102,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :macro, file: file, line: line, column: column} =
+    %{type: :macro, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/behaviour_with_macrocallbacks.ex"
@@ -118,7 +118,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 17)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -134,7 +134,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 17)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -150,7 +150,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/macro_generated.ex"
@@ -166,7 +166,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 11)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -181,7 +181,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 15)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -196,7 +196,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 15)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -211,7 +211,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{found: false} = ElixirSense.definition(buffer, 2, 15)
+    refute ElixirSense.definition(buffer, 2, 15)
   end
 
   test "find definition of modules" do
@@ -223,7 +223,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :module, file: file, line: line, column: column} =
+    %{type: :module, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 23)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -238,11 +238,9 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :module, file: file_1, line: line_1} =
-      ElixirSense.definition(buffer, 2, 30)
+    %{type: :module, file: file_1, line: line_1} = ElixirSense.definition(buffer, 2, 30)
 
-    %{found: true, type: :module, file: file_2, line: line_2} =
-      ElixirSense.definition(buffer, 3, 38)
+    %{type: :module, file: file_2, line: line_2} = ElixirSense.definition(buffer, 3, 38)
 
     assert file_1 == file_2
     assert line_1 == line_2
@@ -258,7 +256,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %Location{found: true, type: :module, file: file, line: 20, column: 1} =
+    %Location{type: :module, file: file, line: 20, column: 1} =
       ElixirSense.definition(buffer, 3, 7)
 
     assert file =~ "/src/lists.erl"
@@ -274,7 +272,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 15)
 
     assert file =~ "/src/lists.erl"
@@ -291,7 +289,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :function, file: file, line: line, column: column} =
+    %{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 15)
 
     assert file =~ "/src/erlang.erl"
@@ -305,7 +303,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert ElixirSense.definition(buffer, 2, 24) == %Location{found: false}
+    refute ElixirSense.definition(buffer, 2, 24)
   end
 
   test "cannot find map field calls" do
@@ -317,7 +315,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert ElixirSense.definition(buffer, 3, 16) == %Location{found: false}
+    refute ElixirSense.definition(buffer, 3, 16)
   end
 
   test "cannot find map fields" do
@@ -328,7 +326,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert ElixirSense.definition(buffer, 2, 12) == %Location{found: false}
+    refute ElixirSense.definition(buffer, 2, 12)
   end
 
   test "preloaded modules" do
@@ -339,7 +337,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %Location{found: true, line: 20, column: 1, type: :module, file: file} =
+    assert %Location{line: 20, column: 1, type: :module, file: file} =
              ElixirSense.definition(buffer, 2, 5)
 
     assert file =~ "/src/erlang.erl"
@@ -360,15 +358,15 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{column: column, file: file, found: true, line: line, type: :function} =
+    assert %{column: column, file: file, line: line, type: :function} =
              ElixirSense.definition(buffer, 2, 42)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
     assert read_line(file, {line, column}) =~ "ElixirSenseExample.ModuleWithFunctions do"
 
-    assert %{found: true, type: :function} = ElixirSense.definition(buffer, 4, 42)
+    assert %{type: :function} = ElixirSense.definition(buffer, 4, 42)
 
-    assert %{found: true, type: :function} = ElixirSense.definition(buffer, 6, 42)
+    assert %{type: :function} = ElixirSense.definition(buffer, 6, 42)
   end
 
   test "built-in functions cannot be called locally" do
@@ -388,11 +386,11 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{found: false} = ElixirSense.definition(buffer, 4, 5)
+    refute ElixirSense.definition(buffer, 4, 5)
 
-    assert %{found: false} = ElixirSense.definition(buffer, 6, 5)
+    refute ElixirSense.definition(buffer, 6, 5)
 
-    assert %{found: false} = ElixirSense.definition(buffer, 8, 5)
+    refute ElixirSense.definition(buffer, 8, 5)
   end
 
   test "does not find built-in erlang functions" do
@@ -405,9 +403,9 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{found: false} = ElixirSense.definition(buffer, 2, 14)
+    refute ElixirSense.definition(buffer, 2, 14)
 
-    assert %{found: false} = ElixirSense.definition(buffer, 4, 12)
+    refute ElixirSense.definition(buffer, 4, 12)
   end
 
   test "find definition of variables" do
@@ -423,7 +421,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 13) == %Location{
-             found: true,
              type: :variable,
              file: nil,
              line: 3,
@@ -431,7 +428,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
            }
 
     assert ElixirSense.definition(buffer, 6, 21) == %Location{
-             found: true,
              type: :variable,
              file: nil,
              line: 4,
@@ -452,7 +448,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 6) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 2,
@@ -473,7 +468,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 6) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 2,
@@ -494,7 +488,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 6) == %Location{
-             found: true,
              type: :variable,
              file: nil,
              line: 5,
@@ -515,7 +508,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 6) == %Location{
-             found: true,
              type: :variable,
              file: nil,
              line: 5,
@@ -536,7 +528,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 15) == %Location{
-             found: true,
              type: :attribute,
              file: nil,
              line: 3,
@@ -544,7 +535,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
            }
 
     assert ElixirSense.definition(buffer, 6, 24) == %Location{
-             found: true,
              type: :attribute,
              file: nil,
              line: 4,
@@ -564,7 +554,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 5, 6) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 2,
@@ -585,7 +574,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 17) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 2,
@@ -606,7 +594,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 13) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 2,
@@ -627,7 +614,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 14) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 2,
@@ -648,7 +634,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 6, 24) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 2,
@@ -668,7 +653,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 5, 6) == %Location{
-             found: true,
              type: :macro,
              file: nil,
              line: 2,
@@ -691,7 +675,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 8, 7) == %Location{
-             found: true,
              type: :function,
              file: nil,
              line: 3,
@@ -712,9 +695,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert ElixirSense.definition(buffer, 7, 25) == %Location{
-             found: false
-           }
+    refute ElixirSense.definition(buffer, 7, 25)
   end
 
   test "find definition of local module" do
@@ -731,7 +712,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 7, 16) == %Location{
-             found: true,
              type: :module,
              file: nil,
              line: 2,
@@ -751,7 +731,6 @@ defmodule ElixirSense.Providers.DefinitionTest do
     """
 
     assert ElixirSense.definition(buffer, 4, 21) == %Location{
-             found: true,
              type: :variable,
              file: nil,
              line: 2,
@@ -767,7 +746,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: file, line: line, column: column} =
+    %{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 31)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -783,7 +762,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: file, line: line, column: column} =
+    %{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -799,7 +778,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: file, line: line, column: column} =
+    %{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -815,7 +794,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: file, line: line, column: column} =
+    %{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -831,7 +810,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: file, line: line, column: column} =
+    %{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/macro_generated.ex"
@@ -846,7 +825,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: file, line: line, column: column} =
+    %{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 9)
 
     assert file =~ "/src/ets.erl"
@@ -861,7 +840,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: file, line: line, column: column} =
+    %{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 12)
 
     assert file =~ "/src/erlang.erl"
@@ -876,7 +855,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: false} = ElixirSense.definition(buffer, 2, 12)
+    refute ElixirSense.definition(buffer, 2, 12)
   end
 
   test "builtin types cannot be found" do
@@ -887,7 +866,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{found: false} = ElixirSense.definition(buffer, 2, 23)
+    refute ElixirSense.definition(buffer, 2, 23)
   end
 
   test "builtin elixir types cannot be found" do
@@ -898,7 +877,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{found: false} = ElixirSense.definition(buffer, 2, 29)
+    refute ElixirSense.definition(buffer, 2, 29)
   end
 
   test "find local metadata type definition" do
@@ -911,8 +890,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: nil, line: 2, column: 3} =
-      ElixirSense.definition(buffer, 4, 29)
+    %{type: :typespec, file: nil, line: 2, column: 3} = ElixirSense.definition(buffer, 4, 29)
   end
 
   test "find remote metadata type definition" do
@@ -930,8 +908,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: true, type: :typespec, file: nil, line: 2, column: 3} =
-      ElixirSense.definition(buffer, 9, 35)
+    %{type: :typespec, file: nil, line: 2, column: 3} = ElixirSense.definition(buffer, 9, 35)
   end
 
   test "do not find remote private type definition" do
@@ -949,7 +926,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{found: false} = ElixirSense.definition(buffer, 9, 35)
+    refute ElixirSense.definition(buffer, 9, 35)
   end
 
   test "find super inside overridable function" do
@@ -967,13 +944,13 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{found: true, type: :macro, file: file, line: line, column: column} =
+    assert %{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 5, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"
     assert read_line(file, {line, column}) =~ "__using__(_opts)"
 
-    assert %{found: true, type: :macro, file: file, line: line, column: column} =
+    assert %{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 9, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"
@@ -995,13 +972,13 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{found: true, type: :macro, file: file, line: line, column: column} =
+    assert %{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 5, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"
     assert read_line(file, {line, column}) =~ "__using__(_opts)"
 
-    assert %{found: true, type: :macro, file: file, line: line, column: column} =
+    assert %{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 9, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -23,7 +23,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :module, file: file, line: line, column: column} =
+    %Location{type: :module, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/use_example.ex"
@@ -38,7 +38,8 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :macro, file: file, line: line, column: column} = ElixirSense.definition(buffer, 1, 2)
+    %Location{type: :macro, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 1, 2)
 
     assert file =~ "lib/elixir/lib/kernel.ex"
     assert read_line(file, {line, column}) =~ "defmodule("
@@ -53,7 +54,8 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :macro, file: file, line: line, column: column} = ElixirSense.definition(buffer, 2, 4)
+    %Location{type: :macro, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 2, 4)
 
     assert file =~ "lib/elixir/lib/kernel/special_forms.ex"
     assert read_line(file, {line, column}) =~ "import"
@@ -68,7 +70,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 4)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -84,7 +86,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 11)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -100,7 +102,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :macro, file: file, line: line, column: column} =
+    %Location{type: :macro, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/behaviour_with_macrocallbacks.ex"
@@ -116,7 +118,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 17)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -132,7 +134,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 17)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -148,7 +150,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/macro_generated.ex"
@@ -164,52 +166,11 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 11)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
     assert read_line(file, {line, column}) =~ "delegated_function"
-  end
-
-  test "handle defdelegate" do
-    buffer = """
-    defmodule MyModule do
-      defdelegate delegated_function, to: ElixirSenseExample.ModuleWithFunctions.DelegatedModule
-      #            ^
-    end
-    """
-
-    %{type: :function, file: file, line: line, column: column} =
-      ElixirSense.definition(buffer, 2, 15)
-
-    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
-    assert read_line(file, {line, column}) =~ "delegated_function"
-  end
-
-  test "handle defdelegate with `as`" do
-    buffer = """
-    defmodule MyModule do
-      defdelegate my_function, to: ElixirSenseExample.ModuleWithFunctions.DelegatedModule, as: :delegated_function
-      #            ^
-    end
-    """
-
-    %{type: :function, file: file, line: line, column: column} =
-      ElixirSense.definition(buffer, 2, 15)
-
-    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
-    assert read_line(file, {line, column}) =~ "delegated_function"
-  end
-
-  test "handle recursion in defdelegate" do
-    buffer = """
-    defmodule MyModule do
-      defdelegate delegated_function, to: MyModule
-      #            ^
-    end
-    """
-
-    refute ElixirSense.definition(buffer, 2, 15)
   end
 
   test "find definition of modules" do
@@ -221,7 +182,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :module, file: file, line: line, column: column} =
+    %Location{type: :module, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 23)
 
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
@@ -236,9 +197,9 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :module, file: file_1, line: line_1} = ElixirSense.definition(buffer, 2, 30)
+    %Location{type: :module, file: file_1, line: line_1} = ElixirSense.definition(buffer, 2, 30)
 
-    %{type: :module, file: file_2, line: line_2} = ElixirSense.definition(buffer, 3, 38)
+    %Location{type: :module, file: file_2, line: line_2} = ElixirSense.definition(buffer, 3, 38)
 
     assert file_1 == file_2
     assert line_1 == line_2
@@ -270,7 +231,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 15)
 
     assert file =~ "/src/lists.erl"
@@ -287,7 +248,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :function, file: file, line: line, column: column} =
+    %Location{type: :function, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 15)
 
     assert file =~ "/src/erlang.erl"
@@ -362,9 +323,9 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert file =~ "elixir_sense/test/support/module_with_functions.ex"
     assert read_line(file, {line, column}) =~ "ElixirSenseExample.ModuleWithFunctions do"
 
-    assert %{type: :function} = ElixirSense.definition(buffer, 4, 42)
+    assert %Location{type: :function} = ElixirSense.definition(buffer, 4, 42)
 
-    assert %{type: :function} = ElixirSense.definition(buffer, 6, 42)
+    assert %Location{type: :function} = ElixirSense.definition(buffer, 6, 42)
   end
 
   test "built-in functions cannot be called locally" do
@@ -744,7 +705,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: file, line: line, column: column} =
+    %Location{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 31)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -760,7 +721,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: file, line: line, column: column} =
+    %Location{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -776,7 +737,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: file, line: line, column: column} =
+    %Location{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 13)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -792,7 +753,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: file, line: line, column: column} =
+    %Location{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/module_with_typespecs.ex"
@@ -808,7 +769,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: file, line: line, column: column} =
+    %Location{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 3, 12)
 
     assert file =~ "elixir_sense/test/support/macro_generated.ex"
@@ -823,7 +784,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: file, line: line, column: column} =
+    %Location{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 9)
 
     assert file =~ "/src/ets.erl"
@@ -838,7 +799,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: file, line: line, column: column} =
+    %Location{type: :typespec, file: file, line: line, column: column} =
       ElixirSense.definition(buffer, 2, 12)
 
     assert file =~ "/src/erlang.erl"
@@ -888,7 +849,8 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: nil, line: 2, column: 3} = ElixirSense.definition(buffer, 4, 29)
+    %Location{type: :typespec, file: nil, line: 2, column: 3} =
+      ElixirSense.definition(buffer, 4, 29)
   end
 
   test "find remote metadata type definition" do
@@ -906,7 +868,8 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    %{type: :typespec, file: nil, line: 2, column: 3} = ElixirSense.definition(buffer, 9, 35)
+    %Location{type: :typespec, file: nil, line: 2, column: 3} =
+      ElixirSense.definition(buffer, 9, 35)
   end
 
   test "do not find remote private type definition" do
@@ -942,13 +905,13 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{type: :macro, file: file, line: line, column: column} =
+    assert %Location{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 5, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"
     assert read_line(file, {line, column}) =~ "__using__(_opts)"
 
-    assert %{type: :macro, file: file, line: line, column: column} =
+    assert %Location{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 9, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"
@@ -970,13 +933,13 @@ defmodule ElixirSense.Providers.DefinitionTest do
     end
     """
 
-    assert %{type: :macro, file: file, line: line, column: column} =
+    assert %Location{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 5, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"
     assert read_line(file, {line, column}) =~ "__using__(_opts)"
 
-    assert %{type: :macro, file: file, line: line, column: column} =
+    assert %Location{type: :macro, file: file, line: line, column: column} =
              ElixirSense.definition(buffer, 9, 6)
 
     assert file =~ "elixir_sense/test/support/overridable_function.ex"

--- a/test/elixir_sense/implementation_test.exs
+++ b/test/elixir_sense/implementation_test.exs
@@ -1,0 +1,76 @@
+defmodule ElixirSense.Providers.ImplementationTest do
+  use ExUnit.Case, async: true
+  alias ElixirSense.Providers.Implementation
+  alias ElixirSense.Location
+  alias ElixirSense.Core.Source
+
+  doctest Implementation
+
+  test "dont crash on empty buffer" do
+    assert [] == ElixirSense.implementations("", 1, 1)
+  end
+
+  test "dont error on __MODULE__ when no module" do
+    assert [] == ElixirSense.implementations("__MODULE__", 1, 1)
+  end
+
+  test "dont error on Elixir" do
+    assert [] == ElixirSense.implementations("Elixir", 1, 1)
+  end
+
+  test "dont error on not existing module" do
+    assert [] == ElixirSense.implementations("SomeNotExistingMod", 1, 1)
+  end
+
+  test "dont error on non behaviour module" do
+    assert [] == ElixirSense.implementations("ElixirSenseExample.EmptyModule", 1, 32)
+  end
+
+  test "find implementations of behaviour module" do
+    buffer = """
+    defmodule ElixirSenseExample.ExampleBehaviourWithDoc do
+    end
+    """
+
+    [
+      %Location{type: :module, file: file1, line: line1, column: column1},
+      %Location{type: :module, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 1, 32)
+
+    assert file1 =~ "elixir_sense/test/support/example_behaviour.ex"
+
+    assert read_line(file1, {line1, column1}) =~
+             "ElixirSenseExample.ExampleBehaviourWithDocCallbackImpl"
+
+    assert file2 =~ "elixir_sense/test/support/example_behaviour.ex"
+
+    assert read_line(file2, {line2, column2}) =~
+             "ElixirSenseExample.ExampleBehaviourWithDocCallbackNoImpl"
+  end
+
+  test "find protocol implementations" do
+    buffer = """
+    defprotocol ElixirSenseExample.ExampleProtocol do
+    end
+    """
+
+    [
+      %Location{type: :module, file: file1, line: line1, column: column1},
+      %Location{type: :module, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 1, 32)
+
+    assert file1 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file1, {line1, column1}) =~ "ElixirSenseExample.ExampleProtocol, for: List"
+
+    assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file2, {line2, column2}) =~ "ElixirSenseExample.ExampleProtocol, for: Map"
+  end
+
+  defp read_line(file, {line, column}) do
+    file
+    |> File.read!()
+    |> Source.split_lines()
+    |> Enum.at(line - 1)
+    |> String.slice((column - 1)..-1)
+  end
+end

--- a/test/elixir_sense/implementation_test.exs
+++ b/test/elixir_sense/implementation_test.exs
@@ -26,7 +26,25 @@ defmodule ElixirSense.Providers.ImplementationTest do
     assert [] == ElixirSense.implementations("ElixirSenseExample.EmptyModule", 1, 32)
   end
 
+  test "dont error on erlang function calls" do
+    assert [] == ElixirSense.implementations(":ets.new", 1, 8)
+  end
+
+  test "dont return implementations for non callback functions on behaviour" do
+    assert [] == ElixirSense.implementations("GenServer.start_link", 1, 12)
+  end
+
   test "dont error on non behaviour module function" do
+    buffer = """
+    defmodule ElixirSenseExample.EmptyModule do
+      def abc(), do: :ok
+    end
+    """
+
+    assert [] == ElixirSense.implementations(buffer, 2, 8)
+  end
+
+  test "dont error on builtin macro" do
     buffer = """
     defmodule ElixirSenseExample.EmptyModule do
       def abc(), do: :ok
@@ -99,6 +117,30 @@ defmodule ElixirSense.Providers.ImplementationTest do
              "foo(), do: :ok"
   end
 
+  test "find implementations of behaviour module on callback in implementation" do
+    buffer = """
+    defmodule Some do
+      @behaviour ElixirSenseExample.ExampleBehaviourWithDoc
+      def foo(), do: :ok
+    end
+    """
+
+    [
+      %Location{type: :function, file: file1, line: line1, column: column1},
+      %Location{type: :function, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 3, 8)
+
+    assert file1 =~ "elixir_sense/test/support/example_behaviour.ex"
+
+    assert read_line(file1, {line1, column1}) =~
+             "foo(), do: :ok"
+
+    assert file2 =~ "elixir_sense/test/support/example_behaviour.ex"
+
+    assert read_line(file2, {line2, column2}) =~
+             "foo(), do: :ok"
+  end
+
   test "find protocol implementation functions" do
     buffer = """
     defprotocol ElixirSenseExample.ExampleProtocol do
@@ -111,6 +153,25 @@ defmodule ElixirSense.Providers.ImplementationTest do
       %Location{type: :function, file: file1, line: line1, column: column1},
       %Location{type: :function, file: file2, line: line2, column: column2}
     ] = ElixirSense.implementations(buffer, 3, 8)
+
+    assert file1 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file1, {line1, column1}) =~ "some(t), do: t"
+
+    assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file2, {line2, column2}) =~ "some(t), do: t"
+  end
+
+  test "find protocol implementation functions on implementation function" do
+    buffer = """
+    defimpl ElixirSenseExample.ExampleProtocol, for: String do
+      def some(t), do: t
+    end
+    """
+
+    [
+      %Location{type: :function, file: file1, line: line1, column: column1},
+      %Location{type: :function, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 2, 8)
 
     assert file1 =~ "elixir_sense/test/support/example_protocol.ex"
     assert read_line(file1, {line1, column1}) =~ "some(t), do: t"
@@ -134,6 +195,120 @@ defmodule ElixirSense.Providers.ImplementationTest do
 
     assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
     assert read_line(file2, {line2, column2}) =~ "some(t), do: t"
+  end
+
+  test "find protocol implementation functions on call with alias" do
+    buffer = """
+    defmodule Some do
+      alias ElixirSenseExample.ExampleProtocol, as: A
+      A.some()
+    end
+    """
+
+    [
+      %Location{type: :function, file: file1, line: line1, column: column1},
+      %Location{type: :function, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 3, 6)
+
+    assert file1 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file1, {line1, column1}) =~ "some(t), do: t"
+
+    assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file2, {line2, column2}) =~ "some(t), do: t"
+  end
+
+  test "find protocol implementation functions on call via @attr" do
+    buffer = """
+    defmodule Some do
+      @attr ElixirSenseExample.ExampleProtocol
+      @attr.some()
+    end
+    """
+
+    [
+      %Location{type: :function, file: file1, line: line1, column: column1},
+      %Location{type: :function, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 3, 10)
+
+    assert file1 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file1, {line1, column1}) =~ "some(t), do: t"
+
+    assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file2, {line2, column2}) =~ "some(t), do: t"
+  end
+
+  test "find implementation of delegated functions" do
+    buffer = """
+    defmodule MyModule do
+      alias ElixirSenseExample.ModuleWithFunctions, as: MyMod
+      MyMod.delegated_function()
+      #        ^
+    end
+    """
+
+    [%Location{type: :function, file: file, line: line, column: column}] =
+      ElixirSense.implementations(buffer, 3, 11)
+
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "delegated_function do"
+  end
+
+  test "find implementation of delegated functions via @attr" do
+    buffer = """
+    defmodule MyModule do
+      @attr ElixirSenseExample.ModuleWithFunctions
+      def a do
+        @attr.delegated_function()
+      end
+    end
+    """
+
+    [%Location{type: :function, file: file, line: line, column: column}] =
+      ElixirSense.implementations(buffer, 4, 13)
+
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "delegated_function do"
+  end
+
+  test "handle defdelegate" do
+    buffer = """
+    defmodule MyModule do
+      defdelegate delegated_function, to: ElixirSenseExample.ModuleWithFunctions.DelegatedModule
+      #            ^
+    end
+    """
+
+    [%Location{type: :function, file: file, line: line, column: column}] =
+      ElixirSense.implementations(buffer, 2, 15)
+
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "delegated_function"
+  end
+
+  test "handle defdelegate with `as`" do
+    buffer = """
+    defmodule MyModule do
+      defdelegate my_function, to: ElixirSenseExample.ModuleWithFunctions.DelegatedModule, as: :delegated_function
+      #            ^
+    end
+    """
+
+    [%Location{type: :function, file: file, line: line, column: column}] =
+      ElixirSense.implementations(buffer, 2, 15)
+
+    assert file =~ "elixir_sense/test/support/module_with_functions.ex"
+    assert read_line(file, {line, column}) =~ "delegated_function"
+  end
+
+  test "handle recursion in defdelegate" do
+    buffer = """
+    defmodule MyModule do
+      defdelegate delegated_function, to: MyModule
+      #            ^
+    end
+    """
+
+    assert [] == ElixirSense.implementations(buffer, 2, 15)
   end
 
   defp read_line(file, {line, column}) do

--- a/test/elixir_sense/implementation_test.exs
+++ b/test/elixir_sense/implementation_test.exs
@@ -26,6 +26,16 @@ defmodule ElixirSense.Providers.ImplementationTest do
     assert [] == ElixirSense.implementations("ElixirSenseExample.EmptyModule", 1, 32)
   end
 
+  test "dont error on non behaviour module function" do
+    buffer = """
+    defmodule ElixirSenseExample.EmptyModule do
+      def abc(), do: :ok
+    end
+    """
+
+    assert [] == ElixirSense.implementations(buffer, 1, 8)
+  end
+
   test "find implementations of behaviour module" do
     buffer = """
     defmodule ElixirSenseExample.ExampleBehaviourWithDoc do
@@ -64,6 +74,66 @@ defmodule ElixirSense.Providers.ImplementationTest do
 
     assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
     assert read_line(file2, {line2, column2}) =~ "ElixirSenseExample.ExampleProtocol, for: Map"
+  end
+
+  test "find implementations of behaviour module callback" do
+    buffer = """
+    defmodule ElixirSenseExample.ExampleBehaviourWithDoc do
+      @callback foo() :: :ok
+    end
+    """
+
+    [
+      %Location{type: :function, file: file1, line: line1, column: column1},
+      %Location{type: :function, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 2, 14)
+
+    assert file1 =~ "elixir_sense/test/support/example_behaviour.ex"
+
+    assert read_line(file1, {line1, column1}) =~
+             "foo(), do: :ok"
+
+    assert file2 =~ "elixir_sense/test/support/example_behaviour.ex"
+
+    assert read_line(file2, {line2, column2}) =~
+             "foo(), do: :ok"
+  end
+
+  test "find protocol implementation functions" do
+    buffer = """
+    defprotocol ElixirSenseExample.ExampleProtocol do
+      @spec some(t) :: any
+      def some(t)
+    end
+    """
+
+    [
+      %Location{type: :function, file: file1, line: line1, column: column1},
+      %Location{type: :function, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 3, 8)
+
+    assert file1 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file1, {line1, column1}) =~ "some(t), do: t"
+
+    assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file2, {line2, column2}) =~ "some(t), do: t"
+  end
+
+  test "find protocol implementation functions on call" do
+    buffer = """
+    ElixirSenseExample.ExampleProtocol.some()
+    """
+
+    [
+      %Location{type: :function, file: file1, line: line1, column: column1},
+      %Location{type: :function, file: file2, line: line2, column: column2}
+    ] = ElixirSense.implementations(buffer, 1, 37)
+
+    assert file1 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file1, {line1, column1}) =~ "some(t), do: t"
+
+    assert file2 =~ "elixir_sense/test/support/example_protocol.ex"
+    assert read_line(file2, {line2, column2}) =~ "some(t), do: t"
   end
 
   defp read_line(file, {line, column}) do

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -48,7 +48,6 @@ defmodule ElixirSense.ServerTest do
     }
 
     %{
-      found: true,
       type: :function,
       file: file,
       line: 2,

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -9,7 +9,7 @@ defmodule TCPHelper do
 
   def send_and_recv(socket, data) do
     :ok = :gen_tcp.send(socket, data)
-    {:ok, response} = :gen_tcp.recv(socket, 0, 1000)
+    {:ok, response} = :gen_tcp.recv(socket, 0, 3000)
     response
   end
 end
@@ -55,6 +55,31 @@ defmodule ElixirSense.ServerTest do
     } = send_request(socket, request)
 
     assert file =~ "#{File.cwd!()}/test/support/module_with_functions.ex"
+  end
+
+  test "implementations request", %{socket: socket, auth_token: auth_token} do
+    request = %{
+      "request_id" => 1,
+      "auth_token" => auth_token,
+      "request" => "implementations",
+      "payload" => %{
+        "buffer" => "ElixirSenseExample.ExampleProtocol.some()",
+        "line" => 1,
+        "column" => 37
+      }
+    }
+
+    [
+      %{
+        type: :function,
+        file: file,
+        line: 7,
+        column: 7
+      },
+      _
+    ] = send_request(socket, request)
+
+    assert file =~ "#{File.cwd!()}/test/support/example_protocol.ex"
   end
 
   test "signature request", %{socket: socket, auth_token: auth_token} do

--- a/test/support/example_protocol.ex
+++ b/test/support/example_protocol.ex
@@ -1,0 +1,12 @@
+defprotocol ElixirSenseExample.ExampleProtocol do
+  @spec some(t) :: any
+  def some(t)
+end
+
+defimpl ElixirSenseExample.ExampleProtocol, for: List do
+  def some(t), do: t
+end
+
+defimpl ElixirSenseExample.ExampleProtocol, for: Map do
+  def some(t), do: t
+end


### PR DESCRIPTION
Adds a new provider returning:
- behaviour implementations
- behaviour callback implementations
- protocol implementations
- protocol function implementations
- delegatees defined by defdelegate

Removes delegate support from definitions provider.
Changes definitions to return nil if not found.

Relevant discussions in https://github.com/elixir-lsp/elixir-ls/issues/132
I will follow with a PR to elixirLS when this one is merged