### PR TITLE
Fix autocomplete for many_to_many associations

### DIFF
--- a/lib/elixir_sense/plugins/ecto/query.ex
+++ b/lib/elixir_sense/plugins/ecto/query.ex
@@ -166,7 +166,12 @@ defmodule ElixirSense.Plugins.Ecto.Query do
     associations = find_field_relations(field, origin)
 
     relations =
-      Enum.map_join(associations, ", ", fn assoc ->
+      Enum.map_join(associations, ", ", fn
+        %{related: related, related_key: related_key} ->
+          "`#{inspect(related)} (#{inspect(related_key)})`"
+        %{related: related} ->
+          # Ecto.Association.ManyToMany does not define :related_key
+          "`#{inspect(related)}`"
         "`#{inspect(assoc.related)} (#{inspect(Map.get(assoc, :related_key))})`"
       end)
 

--- a/lib/elixir_sense/plugins/ecto/query.ex
+++ b/lib/elixir_sense/plugins/ecto/query.ex
@@ -167,7 +167,7 @@ defmodule ElixirSense.Plugins.Ecto.Query do
 
     relations =
       Enum.map_join(associations, ", ", fn assoc ->
-        "`#{inspect(assoc.related)} (#{inspect(assoc.related_key)})`"
+        "`#{inspect(assoc.related)} (#{inspect(Map.get(assoc, :related_key))})`"
       end)
 
     related_info = if relations == "", do: "", else: "* **Related:** #{relations}"

--- a/lib/elixir_sense/plugins/ecto/query.ex
+++ b/lib/elixir_sense/plugins/ecto/query.ex
@@ -172,7 +172,6 @@ defmodule ElixirSense.Plugins.Ecto.Query do
         %{related: related} ->
           # Ecto.Association.ManyToMany does not define :related_key
           "`#{inspect(related)}`"
-        "`#{inspect(assoc.related)} (#{inspect(Map.get(assoc, :related_key))})`"
       end)
 
     related_info = if relations == "", do: "", else: "* **Related:** #{relations}"

--- a/lib/elixir_sense/plugins/ecto/query.ex
+++ b/lib/elixir_sense/plugins/ecto/query.ex
@@ -169,6 +169,7 @@ defmodule ElixirSense.Plugins.Ecto.Query do
       Enum.map_join(associations, ", ", fn
         %{related: related, related_key: related_key} ->
           "`#{inspect(related)} (#{inspect(related_key)})`"
+
         %{related: related} ->
           # Ecto.Association.ManyToMany does not define :related_key
           "`#{inspect(related)}`"

--- a/test/elixir_sense/plugins/ecto_test.exs
+++ b/test/elixir_sense/plugins/ecto_test.exs
@@ -443,7 +443,8 @@ defmodule ElixirSense.Plugins.EctoTest do
                  kind: :field,
                  type: :generic
                },
-               %{label: ":comments"}
+               %{label: ":comments"},
+               %{label: ":tags"}
              ] = suggestions(buffer, cursor)
 
       assert doc == "Fake User schema."
@@ -580,6 +581,22 @@ defmodule ElixirSense.Plugins.EctoTest do
       [cursor] = cursors(buffer)
 
       assert [%{detail: "(from clause) Ecto.Query"} | _] = suggestions(buffer, cursor)
+    end
+
+    test "succeeds when using schema with many_to_many assoc" do
+      buffer = """
+      import Ecto.Query
+      alias ElixirSense.Plugins.Ecto.FakeSchemas.Post
+
+      def query() do
+        from p in Post, se
+          #               ^
+      end
+      """
+
+      [cursor] = cursors(buffer)
+
+      assert [%{label: "select"}, %{label: "select_merge"}] = suggestions(buffer, cursor)
     end
   end
 

--- a/test/elixir_sense/plugins/ecto_test.exs
+++ b/test/elixir_sense/plugins/ecto_test.exs
@@ -146,6 +146,7 @@ defmodule ElixirSense.Plugins.EctoTest do
       Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.Comment)
       Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.Post)
       Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.User)
+      Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.Tag)
       :ok
     end
 
@@ -161,6 +162,7 @@ defmodule ElixirSense.Plugins.EctoTest do
       [
         %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Comment"},
         %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Post"},
+        %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Tag"},
         %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.User"}
       ] = suggestions(buffer, cursor)
     end
@@ -455,6 +457,7 @@ defmodule ElixirSense.Plugins.EctoTest do
       Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.Comment)
       Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.Post)
       Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.User)
+      Code.ensure_loaded(ElixirSense.Plugins.Ecto.FakeSchemas.Tag)
 
       buffer = """
       import Ecto.Query
@@ -472,6 +475,7 @@ defmodule ElixirSense.Plugins.EctoTest do
       assert [
                %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Comment"},
                %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Post"},
+               %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Tag"},
                %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.User"}
                | _
              ] = suggestions(buffer, cursor_1)
@@ -479,6 +483,7 @@ defmodule ElixirSense.Plugins.EctoTest do
       assert [
                %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Comment"},
                %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Post"},
+               %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.Tag"},
                %{label: "ElixirSense.Plugins.Ecto.FakeSchemas.User"}
                | _
              ] = suggestions(buffer, cursor_2)

--- a/test/support/plugins/ecto/fake_schemas.ex
+++ b/test/support/plugins/ecto/fake_schemas.ex
@@ -43,7 +43,7 @@ defmodule ElixirSense.Plugins.Ecto.FakeSchemas.Post do
   alias ElixirSense.Plugins.Ecto.FakeSchemas.Comment
 
   def __schema__(:fields), do: [:id, :title, :text, :date, :user_id]
-  def __schema__(:associations), do: [:user, :comments]
+  def __schema__(:associations), do: [:user, :comments, :tags]
   def __schema__(:type, :id), do: :id
   def __schema__(:type, :user_id), do: :id
   def __schema__(:type, :title), do: :string
@@ -55,4 +55,23 @@ defmodule ElixirSense.Plugins.Ecto.FakeSchemas.Post do
 
   def __schema__(:association, :comments),
     do: %{related: Comment, related_key: :post_id, owner: __MODULE__, owner_key: :id}
+
+  def __schema__(:association, :tags),
+    do: %{related: Tag, owner: __MODULE__, owner_key: :id}
+end
+
+defmodule ElixirSense.Plugins.Ecto.FakeSchemas.Tag do
+  @moduledoc """
+  Fake Tag schema.
+  """
+
+  alias ElixirSense.Plugins.Ecto.FakeSchemas.Post
+
+  def __schema__(:fields), do: [:id, :name]
+  def __schema__(:associations), do: [:posts]
+  def __schema__(:type, :id), do: :id
+  def __schema__(:type, :name), do: :string
+
+  def __schema__(:association, :posts),
+    do: %{related: Post, owner: __MODULE__, owner_key: :id}
 end


### PR DESCRIPTION
Using ElixirLS with VS Code, I noticed that schemas with a many_to_many relationship weren't getting autocompletions as I composed ecto queries.

The output was complaining about the `%ManyToMany{}` struct not having a `:related_key`, and I traced it back to here. I've confirmed that this change does fix the issue and allows you to get autocompletions for schemas with `many_to_many` relationships.