### PR TITLE
Add support for finding references to private functions

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -409,6 +409,7 @@ defmodule ElixirSense do
           vars,
           attributes,
           buffer_file_metadata.mods_funs_to_positions,
+          buffer_file_metadata.calls,
           buffer_file_metadata.types
         )
 

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -408,9 +408,7 @@ defmodule ElixirSense do
           env,
           vars,
           attributes,
-          buffer_file_metadata.mods_funs_to_positions,
-          buffer_file_metadata.calls,
-          buffer_file_metadata.types
+          buffer_file_metadata
         )
 
       _ ->

--- a/lib/elixir_sense/providers/references.ex
+++ b/lib/elixir_sense/providers/references.ex
@@ -12,7 +12,6 @@ defmodule ElixirSense.Providers.References do
   alias ElixirSense.Core.Source
   alias ElixirSense.Core.State
   alias ElixirSense.Core.State.AttributeInfo
-  alias ElixirSense.Core.State.CallInfo
   alias ElixirSense.Core.State.VarInfo
   alias Mix.Tasks.Xref
 
@@ -34,9 +33,7 @@ defmodule ElixirSense.Providers.References do
           State.Env.t(),
           [VarInfo.t()],
           [AttributeInfo.t()],
-          State.mods_funs_to_positions_t(),
-          [CallInfo.t()],
-          State.types_t()
+          Metadata.t()
         ) :: [ElixirSense.Providers.References.reference_info()]
   def find(
         subject,
@@ -49,9 +46,11 @@ defmodule ElixirSense.Providers.References do
         },
         vars,
         attributes,
-        modules_funs,
-        calls,
-        metadata_types
+        %Metadata{
+          mods_funs_to_positions: modules_funs,
+          calls: calls,
+          types: metadata_types
+        }
       ) do
     var_info = vars |> Enum.find(fn %VarInfo{name: name} -> to_string(name) == subject end)
 

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -613,6 +613,58 @@ defmodule ElixirSense.Providers.ReferencesTest do
            ]
   end
 
+  test "find references of private functions from definition" do
+    buffer = """
+    defmodule MyModule do
+      def calls_private do
+        private_fun()
+      end
+
+      defp also_calls_private do
+        private_fun()
+      end
+
+      defp private_fun do
+        #     ^
+        :ok
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 10, 15)
+
+    assert references == [
+             %{uri: nil, range: %{start: %{line: 3, column: 5}, end: %{line: 3, column: 16}}},
+             %{uri: nil, range: %{start: %{line: 7, column: 5}, end: %{line: 7, column: 16}}}
+           ]
+  end
+
+  test "find references of private functions from invocation" do
+    buffer = """
+    defmodule MyModule do
+      def calls_private do
+        private_fun()
+        #     ^
+      end
+
+      defp also_calls_private do
+        private_fun()
+      end
+
+      defp private_fun do
+        :ok
+      end
+    end
+    """
+
+    references = ElixirSense.references(buffer, 3, 15)
+
+    assert references == [
+             %{uri: nil, range: %{start: %{line: 3, column: 5}, end: %{line: 3, column: 16}}},
+             %{uri: nil, range: %{start: %{line: 8, column: 5}, end: %{line: 8, column: 16}}}
+           ]
+  end
+
   test "find references with cursor over a module" do
     buffer = """
     defmodule Caller do


### PR DESCRIPTION
> _Does exactly what it says on the tin_

Currently, trying to retrieve references for a private function returns no results. I frequently want to do this inside large files, and so made this change such that finding references to a private function returns a list of results.

The implementation is largely inspired by the functionality for finding references to variables and attributes.