### PR TITLE
Add inference when using dependency injection via module attribute

### DIFF
--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -38,9 +38,25 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
           IO.puts @inner_attr
         end
         IO.puts ""
+        @otherattribute Application.get_env(:elixir_sense, :some_attribute, InnerModule)
       end
       """
       |> string_to_state
+
+    assert get_line_attributes(state, 10) == [
+             %ElixirSense.Core.State.AttributeInfo{
+               name: :myattribute,
+               positions: [{2, 3}, {3, 11}],
+               type: {:atom, String}
+             },
+             %AttributeInfo{
+               name: :otherattribute,
+               positions: [{10, 3}],
+               type:
+                 {:call, {:atom, Application}, :get_env,
+                  [atom: :elixir_sense, atom: :some_attribute, atom: MyModule.InnerModule]}
+             }
+           ]
 
     assert get_line_attributes(state, 3) == [
              %AttributeInfo{


### PR DESCRIPTION
Implements https://github.com/elixir-lsp/elixir-ls/issues/541

This PR adds basic inference when doing dependency injection using module attributes that calls into `Application.compile_env/3`, `Application.compile_env!/2`, `Application.get_env/3``and `Application.fetch_env!/2`. It works by calling the function and returning the resulting module as the expression type