### PR TITLE
Fix for getting the typespec of `any()`

### DIFF
--- a/lib/elixir_sense/core/type_info.ex
+++ b/lib/elixir_sense/core/type_info.ex
@@ -113,6 +113,7 @@ defmodule ElixirSense.Core.TypeInfo do
             case ti do
               %{spec: ast} -> spec_ast_to_string(ast)
               %{signature: signature} -> signature
+              %{doc: doc} -> doc
               nil -> "#{type}"
             end
       }

--- a/lib/elixir_sense/core/type_info.ex
+++ b/lib/elixir_sense/core/type_info.ex
@@ -113,8 +113,7 @@ defmodule ElixirSense.Core.TypeInfo do
             case ti do
               %{spec: ast} -> spec_ast_to_string(ast)
               %{signature: signature} -> signature
-              %{doc: doc} -> doc
-              nil -> "#{type}"
+              _ -> "#{type}"
             end
       }
     end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ElixirSense.Mixfile do
   def project do
     [
       app: :elixir_sense,
-      version: "2.0.0",
+      version: "2.0.1",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ElixirSense.Mixfile do
   def project do
     [
       app: :elixir_sense,
-      version: "2.0.1",
+      version: "2.0.0",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/elixir_sense/core/type_info_test.exs
+++ b/test/elixir_sense/core/type_info_test.exs
@@ -368,4 +368,12 @@ defmodule ElixirSense.Core.TypeInfoTest do
   test "fun_with_remote_opaque" do
     assert [] = TypeInfo.extract_param_options(Local, :fun_with_remote_opaque, 0)
   end
+
+  test "builtin_type_documentation" do
+    assert [%{name: "any", params: [], spec: "@type any"}] =
+             TypeInfo.get_signatures(nil, :any, nil)
+
+    assert [%{name: "pid", params: [], spec: "@type pid"}] =
+             TypeInfo.get_signatures(nil, :pid, nil)
+  end
 end


### PR DESCRIPTION
Hi there!

Every time when I was creating a typespec with `any()` in some part of it, the lang server would error out with the following message:

```
LSP :: Error from the Language Server: an exception was raised:
    ** (CaseClauseError) no case clause matching: %{doc: "The top type, the set of all terms", params: []}
        (elixir_sense 2.0.0) lib/elixir_sense/core/type_info.ex:113: anonymous fn/3 in ElixirSense.Core.TypeInfo.get_signatures/3
        (elixir 1.12.0) lib/enum.ex:2356: Enum."-reduce/3-lists^foldl/2-0-"/3
        (elixir_sense 2.0.0) lib/elixir_sense/core/type_info.ex:106: ElixirSense.Core.TypeInfo.get_signatures/3
        (elixir_sense 2.0.0) lib/elixir_sense/providers/signature.ex:55: ElixirSense.Providers.Signature.find_signatures/5
        (elixir_sense 2.0.0) lib/elixir_sense/providers/signature.ex:42: ElixirSense.Providers.Signature.find/3
        (language_server 0.7.0) lib/language_server/providers/signature_help.ex:8: ElixirLS.LanguageServer.Providers.SignatureHelp.signature/3
        (language_server 0.7.0) lib/language_server/server.ex:779: anonymous fn/3 in ElixirLS.LanguageServer.Server.handle_request_async/2 (Server End Error)
```

Seemed easy enough; I tracked down the function where the clause was blowing up and added a clause to handle the information coming back from `any`.

I'm running Elixir 1.12.0, Erlang 24.0.1

This seems to have fixed the issue. I'm not particularly familiar with this project; I wouldn't be surprised if there's a better way to fix this problem. :)