### PR TITLE
[Proposal] Updated ElixirSense.Core.Normalized.Tokenizer.tokenize/1 for Elixir 1.13.0-dev compatibility

### DIFF
--- a/lib/elixir_sense/core/normalized/tokenizer.ex
+++ b/lib/elixir_sense/core/normalized/tokenizer.ex
@@ -17,13 +17,21 @@ defmodule ElixirSense.Core.Normalized.Tokenizer do
       {:ok, tokens} ->
         Enum.reverse(tokens)
 
-      # Elixir >= 1.13
-      # {:ok, warnings, tokens}
+      # [WIP] Elixir 1.13-dev
       {:ok, _, tokens} ->
+        Enum.reverse(tokens)
+
+      # [WIP] Elixir 1.13-dev
+      {:ok, _line, _column, _warning, tokens} ->
         Enum.reverse(tokens)
 
       {:error, {_line, _column, _error_prefix, _token}, _rest, sofar} ->
         sofar
+
+      # [WIP] Elixir 1.13-dev
+      {:error, _, _, _, _} ->
+        []
+
     end
   end
 end

--- a/lib/elixir_sense/core/normalized/tokenizer.ex
+++ b/lib/elixir_sense/core/normalized/tokenizer.ex
@@ -17,6 +17,11 @@ defmodule ElixirSense.Core.Normalized.Tokenizer do
       {:ok, tokens} ->
         Enum.reverse(tokens)
 
+      # Elixir >= 1.13
+      # {:ok, warnings, tokens}
+      {:ok, _, tokens} ->
+        Enum.reverse(tokens)
+
       {:error, {_line, _column, _error_prefix, _token}, _rest, sofar} ->
         sofar
     end


### PR DESCRIPTION
Hi,
maybe the _Elixir 'dev'_ version is not supported but with _Elixir 1.13.0-dev_ is impossible to  use any [elixir-ls](https://github.com/elixir-lsp/elixir-ls) based packages such as [vscode-elixir-ls](https://github.com/elixir-lsp/vscode-elixir-ls).

The change proposed concerns only a small addition when `elixir_tokenizer.tokenize` is called because now the return tuple is in the form `{:ok, warnings, result}`.

Some project test will failed but (I think) most for formatting issues.

I tried the updated package in the vscode extension with excellent results: now it is again usable!

Enrico


 
