### PR TITLE
improvement: support searching for external plugins

### DIFF
--- a/lib/elixir_sense/plugins/ecto.ex
+++ b/lib/elixir_sense/plugins/ecto.ex
@@ -7,6 +7,7 @@ defmodule ElixirSense.Plugins.Ecto do
   alias ElixirSense.Plugins.Ecto.Types
 
   use ElixirSense.Providers.Suggestion.GenericReducer
+  @behaviour ElixirSense.Plugins.Plugin
 
   @schema_funcs [:field, :belongs_to, :has_one, :has_many, :many_to_many]
 
@@ -96,6 +97,7 @@ defmodule ElixirSense.Plugins.Ecto do
   end
 
   # Adds customized snippet for `Ecto.Schema.schema/2`
+  @impl true
   def decorate(%{origin: "Ecto.Schema", name: "schema", arity: 2} = item) do
     snippet = """
     schema "$1" do

--- a/lib/elixir_sense/plugins/plugin.ex
+++ b/lib/elixir_sense/plugins/plugin.ex
@@ -1,0 +1,23 @@
+defmodule ElixirSense.Plugins.Plugin do
+  alias ElixirSense.Core.State
+  @type suggestion :: ElixirSense.Providers.Suggestion.generic()
+
+  @type acc :: %{context: term, result: list(suggestion())}
+  @type cursor_context :: %{
+          text_before: String.t(),
+          text_after: String.t(),
+          at_module_body?: boolean
+        }
+
+  @callback reduce(
+              hint :: String,
+              env :: State.Env.t(),
+              buffer_metadata :: Metadata.t(),
+              cursor_context,
+              acc
+            ) :: {:cont, acc} | {:halt, acc}
+
+  @callback decorate(suggestion) :: suggestion
+
+  @optional_callbacks decorate: 1, reduce: 5
+end

--- a/lib/elixir_sense/plugins/util.ex
+++ b/lib/elixir_sense/plugins/util.ex
@@ -7,6 +7,27 @@ defmodule ElixirSense.Plugins.Util do
   alias ElixirSense.Core.State
   alias ElixirSense.Providers.Suggestion.Matcher
 
+  @builtin_plugins [
+    ElixirSense.Plugins.Ecto
+  ]
+
+  def plugins do
+    Enum.each(@builtin_plugins, &Code.ensure_loaded/1)
+
+    :code.all_loaded()
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.filter(&is_plugin?/1)
+  end
+
+  def is_plugin?(module) do
+    behaviours =
+      module.module_info(:attributes)
+      |> Enum.filter(&(elem(&1, 0) == :behaviour))
+      |> Enum.flat_map(&elem(&1, 1))
+
+    ElixirSense.Plugins.Plugin in behaviours
+  end
+
   def match_module?(mod_str, hint) do
     hint = String.downcase(hint)
     mod_full = String.downcase(mod_str)


### PR DESCRIPTION
I've implemented an elixir sense plugin for Ash in a fork, but Ash is not even nearly as ubiquitous as Ecto, so it seemed a bit strange to PR that plugin directly to elixir_sense. With a system like this, we could actually support arbitrary elixir_sense extensions for all kinds of libraries, or even just custom ones for an individual user. The one thing I'm not sure of if what/if the performance implications of searching for modules on every auto-complete would be. It is very fast on my machine, but I'm on an m1 mac so I know that may not be representative of the average user.

Would love any constructive feedback :D

EDIT:

I didn't explain what it actually does, which is that it searches for any loaded module that implements the `ElixirSense.Plugins.Plugin` behaviour, and will call their `reduce/5` and/or `describe/1` functions, utilizing patterns set out for the Ecto plugin :) 