### PR TITLE
improvement: support external plugins

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -9,6 +9,7 @@ defmodule ElixirSense do
   alias ElixirSense.Core.Applications
   alias ElixirSense.Core.Introspection
   alias ElixirSense.Core.Metadata
+  alias ElixirSense.Core.ModuleStore
   alias ElixirSense.Core.Parser
   alias ElixirSense.Core.Source
   alias ElixirSense.Core.State
@@ -201,6 +202,7 @@ defmodule ElixirSense do
       maybe_fix_autocomple_on_cursor(buffer_file_metadata, text_before, text_after, line)
 
     env = Metadata.get_env(buffer_file_metadata, line)
+    module_store = ModuleStore.build()
 
     cursor_context = %{
       text_before: text_before,
@@ -208,7 +210,7 @@ defmodule ElixirSense do
       at_module_body?: Metadata.at_module_body?(buffer_file_metadata, env)
     }
 
-    Suggestion.find(hint, env, buffer_file_metadata, cursor_context)
+    Suggestion.find(hint, env, buffer_file_metadata, cursor_context, module_store)
   end
 
   @doc """

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -4,6 +4,8 @@ defmodule ElixirSense.Core.ModuleStore do
   """
   defstruct by_behaviour: %{}, list: []
 
+  @type t :: %__MODULE__{by_behaviour: %{optional(atom) => module}, list: list(module)}
+
   alias ElixirSense.Core.Applications
 
   def ensure_compiled(context, module_or_modules) do

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -10,11 +10,16 @@ defmodule ElixirSense.Core.ModuleStore do
 
   def build(list \\ all_loaded(), module_store \\ %__MODULE__{}) do
     Enum.reduce(list, module_store, fn module, module_store ->
-      module_store = %{module_store | list: [module | module_store.list]}
+      try do
+        module_store = %{module_store | list: [module | module_store.list]}
 
-      module.module_info(:attributes)[:behaviour]
-      |> List.wrap()
-      |> Enum.reduce(module_store, &add_behaviour(module, &1, &2))
+        module.module_info(:attributes)[:behaviour]
+        |> List.wrap()
+        |> Enum.reduce(module_store, &add_behaviour(module, &1, &2))
+      rescue
+        _ ->
+          module_store
+      end
     end)
   end
 
@@ -22,7 +27,7 @@ defmodule ElixirSense.Core.ModuleStore do
     Enum.flat_map(:code.all_loaded(), fn
       {module, _} ->
         try do
-          if :erlang.function_exported(module, :module_info, 0) do
+          if :erlang.function_exported(module, :module_info, 1) do
             [module]
           else
             []

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -24,21 +24,14 @@ defmodule ElixirSense.Core.ModuleStore do
   end
 
   defp all_loaded do
-    Enum.flat_map(:code.all_loaded(), fn
-      {module, _} ->
-        try do
-          if :erlang.function_exported(module, :module_info, 1) do
-            [module]
-          else
-            []
-          end
-        rescue
-          _ ->
-            []
-        end
-
-      _ ->
-        []
+    ElixirSense.Core.Applications.get_modules_from_applications()
+    |> Enum.filter(fn module ->
+      try do
+        :erlang.function_exported(module, :module_info, 1)
+      rescue
+        _ ->
+          false
+      end
     end)
   end
 

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -1,0 +1,35 @@
+defmodule ElixirSense.Core.ModuleStore do
+  defstruct by_behaviour: %{}, list: []
+
+  def ensure_compiled(context, module_or_modules) do
+    modules = List.wrap(module_or_modules)
+    Enum.map(modules, &Code.ensure_compiled/1)
+
+    Map.update!(context, :module_store, &build(modules, &1))
+  end
+
+  def build(list \\ all_loaded(), module_store \\ %__MODULE__{}) do
+    Enum.reduce(list, module_store, fn module, module_store ->
+      module_store = %{module_store | list: [module | module_store.list]}
+
+      module.module_info(:attributes)[:behaviour]
+      |> List.wrap()
+      |> Enum.reduce(module_store, &add_behaviour(module, &1, &2))
+    end)
+  end
+
+  defp all_loaded do
+    for {module, _} <- :code.all_loaded(), match?({:module, _}, Code.ensure_compiled(module)) do
+      module
+    end
+  end
+
+  defp add_behaviour(adopter, behaviour, module_store) do
+    new_by_behaviour =
+      module_store.by_behaviour
+      |> Map.put_new_lazy(behaviour, fn -> MapSet.new() end)
+      |> Map.update!(behaviour, &MapSet.put(&1, adopter))
+
+    %{module_store | by_behaviour: new_by_behaviour}
+  end
+end

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -19,9 +19,22 @@ defmodule ElixirSense.Core.ModuleStore do
   end
 
   defp all_loaded do
-    for {module, _} <- :code.all_loaded(), match?({:module, _}, Code.ensure_compiled(module)) do
-      module
-    end
+    Enum.flat_map(:code.all_loaded(), fn
+      {module, _} ->
+        try do
+          if :erlang.function_exported(module, :module_info, 0) do
+            [module]
+          else
+            []
+          end
+        rescue
+          _ ->
+            []
+        end
+
+      _ ->
+        []
+    end)
   end
 
   defp add_behaviour(adopter, behaviour, module_store) do

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -32,7 +32,7 @@ defmodule ElixirSense.Core.ModuleStore do
     Applications.get_modules_from_applications()
     |> Enum.filter(fn module ->
       try do
-        :erlang.function_exported(module, :module_info, 1)
+        function_exported?(module, :module_info, 1)
       rescue
         _ ->
           false

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -1,9 +1,14 @@
 defmodule ElixirSense.Core.ModuleStore do
+  @moduledoc """
+  Caches the module list and a list of modules keyed by the behaviour they implement.
+  """
   defstruct by_behaviour: %{}, list: []
+
+  alias ElixirSense.Core.Applications
 
   def ensure_compiled(context, module_or_modules) do
     modules = List.wrap(module_or_modules)
-    Enum.map(modules, &Code.ensure_compiled/1)
+    Enum.each(modules, &Code.ensure_compiled/1)
 
     Map.update!(context, :module_store, &build(modules, &1))
   end
@@ -24,7 +29,7 @@ defmodule ElixirSense.Core.ModuleStore do
   end
 
   defp all_loaded do
-    ElixirSense.Core.Applications.get_modules_from_applications()
+    Applications.get_modules_from_applications()
     |> Enum.filter(fn module ->
       try do
         :erlang.function_exported(module, :module_info, 1)

--- a/lib/elixir_sense/plugins/ecto.ex
+++ b/lib/elixir_sense/plugins/ecto.ex
@@ -14,7 +14,6 @@ defmodule ElixirSense.Plugins.Ecto do
 
   @impl true
   def setup(context) do
-    Code.ensure_compiled(Ecto.UUID)
     ModuleStore.ensure_compiled(context, Ecto.UUID)
   end
 

--- a/lib/elixir_sense/plugins/ecto.ex
+++ b/lib/elixir_sense/plugins/ecto.ex
@@ -32,9 +32,9 @@ defmodule ElixirSense.Plugins.Ecto do
     {:override, builtin_types ++ custom_types}
   end
 
-  def suggestions(hint, {Ecto.Schema, func, 1, _info}, _chain, _opts)
+  def suggestions(hint, {Ecto.Schema, func, 1, _info}, _chain, opts)
       when func in @schema_funcs do
-    {:override, Schema.find_schemas(hint)}
+    {:override, Schema.find_schemas(hint, opts.module_store)}
   end
 
   def suggestions(hint, {Ecto.Schema, func, 2, %{option: option}}, _, _)
@@ -56,7 +56,7 @@ defmodule ElixirSense.Plugins.Ecto do
     text_before = opts.cursor_context.text_before
 
     if after_in?(hint, text_before) do
-      {:add, Schema.find_schemas(hint)}
+      {:add, Schema.find_schemas(hint, opts.module_store)}
     else
       :ignore
     end
@@ -90,7 +90,12 @@ defmodule ElixirSense.Plugins.Ecto do
         text_before = opts.cursor_context.text_before
         env = opts.env
         buffer_metadata = opts.buffer_metadata
-        schemas = if after_in?(hint, text_before), do: Schema.find_schemas(hint), else: []
+
+        schemas =
+          if after_in?(hint, text_before),
+            do: Schema.find_schemas(hint, opts.module_store),
+            else: []
+
         bindings = Query.extract_bindings(text_before, info, env, buffer_metadata)
         {:add, schemas ++ Query.bindings_suggestions(hint, bindings)}
 

--- a/lib/elixir_sense/plugins/ecto/schema.ex
+++ b/lib/elixir_sense/plugins/ecto/schema.ex
@@ -436,8 +436,8 @@ defmodule ElixirSense.Plugins.Ecto.Schema do
     end
   end
 
-  def find_schemas(hint) do
-    for {module, _} <- :code.all_loaded(),
+  def find_schemas(hint, module_store) do
+    for module <- module_store.list,
         function_exported?(module, :__schema__, 1),
         mod_str = inspect(module),
         Util.match_module?(mod_str, hint) do

--- a/lib/elixir_sense/plugins/ecto/types.ex
+++ b/lib/elixir_sense/plugins/ecto/types.ex
@@ -46,11 +46,8 @@ defmodule ElixirSense.Plugins.Ecto.Types do
     end
   end
 
-  def find_custom_types(hint) do
-    _ = Code.ensure_compiled(Ecto.UUID)
-
-    for {module, _} <- :code.all_loaded(),
-        Ecto.Type in (module.module_info(:attributes)[:behaviour] || []),
+  def find_custom_types(hint, module_store) do
+    for module <- Map.get(module_store.by_behaviour, Ecto.Type, []),
         type_str = inspect(module),
         Util.match_module?(type_str, hint) do
       custom_type_to_suggestion(module, hint)

--- a/lib/elixir_sense/plugins/plugin.ex
+++ b/lib/elixir_sense/plugins/plugin.ex
@@ -3,6 +3,7 @@ defmodule ElixirSense.Plugin do
   A behaviour to implement for adding auto complete and snippets to elixir sense.
   """
 
+  alias ElixirSense.Core.Metadata
   alias ElixirSense.Core.State
   @type suggestion :: ElixirSense.Providers.Suggestion.generic()
 

--- a/lib/elixir_sense/plugins/plugin.ex
+++ b/lib/elixir_sense/plugins/plugin.ex
@@ -1,0 +1,26 @@
+defmodule ElixirSense.Plugin do
+  alias ElixirSense.Core.State
+  @type suggestion :: ElixirSense.Providers.Suggestion.generic()
+
+  @type context :: term
+  @type acc :: %{context: context(), result: list(suggestion())}
+  @type cursor_context :: %{
+          text_before: String.t(),
+          text_after: String.t(),
+          at_module_body?: boolean
+        }
+
+  @callback reduce(
+              hint :: String,
+              env :: State.Env.t(),
+              buffer_metadata :: Metadata.t(),
+              cursor_context,
+              acc
+            ) :: {:cont, acc} | {:halt, acc}
+
+  @callback setup(context()) :: context()
+
+  @callback decorate(suggestion) :: suggestion
+
+  @optional_callbacks decorate: 1, reduce: 5, setup: 1
+end

--- a/lib/elixir_sense/plugins/plugin.ex
+++ b/lib/elixir_sense/plugins/plugin.ex
@@ -1,4 +1,8 @@
 defmodule ElixirSense.Plugin do
+  @moduledoc """
+  A behaviour to implement for adding auto complete and snippets to elixir sense.
+  """
+
   alias ElixirSense.Core.State
   @type suggestion :: ElixirSense.Providers.Suggestion.generic()
 

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -103,7 +103,10 @@ defmodule ElixirSense.Providers.Suggestion do
   @spec find(String.t(), State.Env.t(), Metadata.t(), cursor_context, Metadata.module_store()) ::
           [suggestion()]
   def find(hint, env, buffer_metadata, cursor_context, module_store) do
-    plugins = Application.get_env(:elixir_sense, :plugins, [ElixirSense.Plugins.Ecto])
+    plugins =
+      Application.get_env(:elixir_sense, :plugins, [ElixirSense.Plugins.Ecto])
+      |> IO.inspect(label: "DEBUG INFO - Plugins: ")
+
     Enum.each(plugins, &Code.ensure_compiled/1)
 
     reducers =

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -106,7 +106,7 @@ defmodule ElixirSense.Providers.Suggestion do
 
     reducers =
       plugins
-      |> Enum.filter(&:erlang.function_exported(&1, :reduce, 5))
+      |> Enum.filter(&function_exported?(&1, :reduce, 5))
       |> Enum.map(fn module ->
         {module, &module.reduce/5}
       end)

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -42,6 +42,7 @@ defmodule ElixirSense.Providers.Suggestion do
   """
 
   alias ElixirSense.Core.Metadata
+  alias ElixirSense.Core.ModuleStore
   alias ElixirSense.Core.State
   alias ElixirSense.Providers.Suggestion.Reducers
 
@@ -99,7 +100,7 @@ defmodule ElixirSense.Providers.Suggestion do
   @doc """
   Finds all suggestions for a hint based on context information.
   """
-  @spec find(String.t(), State.Env.t(), Metadata.t(), cursor_context, Metadata.module_store()) ::
+  @spec find(String.t(), State.Env.t(), Metadata.t(), cursor_context, ModuleStore.t()) ::
           [suggestion()]
   def find(hint, env, buffer_metadata, cursor_context, module_store) do
     plugins = module_store.by_behaviour[ElixirSense.Plugin] || []

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -102,9 +102,7 @@ defmodule ElixirSense.Providers.Suggestion do
   @spec find(String.t(), State.Env.t(), Metadata.t(), cursor_context, Metadata.module_store()) ::
           [suggestion()]
   def find(hint, env, buffer_metadata, cursor_context, module_store) do
-    plugins = Application.get_env(:elixir_sense, :plugins, [ElixirSense.Plugins.Ecto])
-
-    Enum.each(plugins, &Code.ensure_compiled/1)
+    plugins = module_store.by_behaviour[ElixirSense.Plugin] || []
 
     reducers =
       plugins

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -114,7 +114,7 @@ defmodule ElixirSense.Providers.Suggestion do
 
     context =
       plugins
-      |> Enum.filter(&:erlang.function_exported(&1, :setup, 1))
+      |> Enum.filter(&function_exported?(&1, :setup, 1))
       |> Enum.reduce(%{module_store: module_store}, fn plugin, context ->
         plugin.setup(context)
       end)

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -132,7 +132,7 @@ defmodule ElixirSense.Providers.Suggestion do
 
     for item <- result do
       plugins
-      |> Enum.filter(&:erlang.function_exported(&1, :decorate, 1))
+      |> Enum.filter(&function_exported?(&1, :decorate, 1))
       |> Enum.reduce(item, fn module, item -> module.decorate(item) end)
     end
   end

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -104,6 +104,7 @@ defmodule ElixirSense.Providers.Suggestion do
           [suggestion()]
   def find(hint, env, buffer_metadata, cursor_context, module_store) do
     plugins = Application.get_env(:elixir_sense, :plugins, [ElixirSense.Plugins.Ecto])
+    Enum.each(plugins, &Code.ensure_compiled/1)
 
     reducers =
       plugins

--- a/lib/elixir_sense/providers/suggestion/complete.ex
+++ b/lib/elixir_sense/providers/suggestion/complete.ex
@@ -473,7 +473,7 @@ defmodule ElixirSense.Providers.Suggestion.Complete do
     for {{k, nil, nil}, _} <- env.mods_and_funs, do: Atom.to_string(k)
   end
 
-  def match_module_funs(mod, hint, include_builtin, env) do
+  defp match_module_funs(mod, hint, include_builtin, env) do
     falist =
       cond do
         env.mods_and_funs |> Map.has_key?({mod, nil, nil}) ->
@@ -736,33 +736,33 @@ defmodule ElixirSense.Providers.Suggestion.Complete do
             | ElixirSense.Providers.Suggestion.Reducers.Struct.field()
             | ElixirSense.Providers.Suggestion.Reducers.Common.attribute()
           ]
-  def to_entries(%{kind: :field, subtype: subtype, name: name, origin: origin}) do
+  defp to_entries(%{kind: :field, subtype: subtype, name: name, origin: origin}) do
     [%{type: :field, name: name, subtype: subtype, origin: origin, call?: true}]
   end
 
-  def to_entries(%{kind: :module, name: name, desc: {desc, metadata}, subtype: subtype}) do
+  defp to_entries(%{kind: :module, name: name, desc: {desc, metadata}, subtype: subtype}) do
     [%{type: :module, name: name, subtype: subtype, summary: desc, metadata: metadata}]
   end
 
-  def to_entries(%{kind: :variable, name: name}) do
+  defp to_entries(%{kind: :variable, name: name}) do
     [%{type: :variable, name: name}]
   end
 
-  def to_entries(%{kind: :attribute, name: name}) do
+  defp to_entries(%{kind: :attribute, name: name}) do
     [%{type: :attribute, name: "@" <> name}]
   end
 
-  def to_entries(%{
-        kind: :function,
-        name: name,
-        arities: arities,
-        def_arities: def_arities,
-        module: mod,
-        func_kind: func_kind,
-        docs: docs,
-        specs: specs,
-        args: args
-      }) do
+  defp to_entries(%{
+         kind: :function,
+         name: name,
+         arities: arities,
+         def_arities: def_arities,
+         module: mod,
+         func_kind: func_kind,
+         docs: docs,
+         specs: specs,
+         args: args
+       }) do
     for e <- Enum.zip([arities, docs, specs, args, def_arities]),
         {a, {doc, metadata}, spec, args, def_arity} = e do
       kind =

--- a/lib/elixir_sense/providers/suggestion/complete.ex
+++ b/lib/elixir_sense/providers/suggestion/complete.ex
@@ -473,7 +473,7 @@ defmodule ElixirSense.Providers.Suggestion.Complete do
     for {{k, nil, nil}, _} <- env.mods_and_funs, do: Atom.to_string(k)
   end
 
-  defp match_module_funs(mod, hint, include_builtin, env) do
+  def match_module_funs(mod, hint, include_builtin, env) do
     falist =
       cond do
         env.mods_and_funs |> Map.has_key?({mod, nil, nil}) ->
@@ -736,33 +736,33 @@ defmodule ElixirSense.Providers.Suggestion.Complete do
             | ElixirSense.Providers.Suggestion.Reducers.Struct.field()
             | ElixirSense.Providers.Suggestion.Reducers.Common.attribute()
           ]
-  defp to_entries(%{kind: :field, subtype: subtype, name: name, origin: origin}) do
+  def to_entries(%{kind: :field, subtype: subtype, name: name, origin: origin}) do
     [%{type: :field, name: name, subtype: subtype, origin: origin, call?: true}]
   end
 
-  defp to_entries(%{kind: :module, name: name, desc: {desc, metadata}, subtype: subtype}) do
+  def to_entries(%{kind: :module, name: name, desc: {desc, metadata}, subtype: subtype}) do
     [%{type: :module, name: name, subtype: subtype, summary: desc, metadata: metadata}]
   end
 
-  defp to_entries(%{kind: :variable, name: name}) do
+  def to_entries(%{kind: :variable, name: name}) do
     [%{type: :variable, name: name}]
   end
 
-  defp to_entries(%{kind: :attribute, name: name}) do
+  def to_entries(%{kind: :attribute, name: name}) do
     [%{type: :attribute, name: "@" <> name}]
   end
 
-  defp to_entries(%{
-         kind: :function,
-         name: name,
-         arities: arities,
-         def_arities: def_arities,
-         module: mod,
-         func_kind: func_kind,
-         docs: docs,
-         specs: specs,
-         args: args
-       }) do
+  def to_entries(%{
+        kind: :function,
+        name: name,
+        arities: arities,
+        def_arities: def_arities,
+        module: mod,
+        func_kind: func_kind,
+        docs: docs,
+        specs: specs,
+        args: args
+      }) do
     for e <- Enum.zip([arities, docs, specs, args, def_arities]),
         {a, {doc, metadata}, spec, args, def_arity} = e do
       kind =

--- a/lib/elixir_sense/providers/suggestion/generic_reducer.ex
+++ b/lib/elixir_sense/providers/suggestion/generic_reducer.ex
@@ -44,7 +44,7 @@ defmodule ElixirSense.Providers.Suggestion.GenericReducer do
         end
 
       [] ->
-        if :erlang.function_exported(reducer, :suggestions, 2) do
+        if function_exported?(reducer, :suggestions, 2) do
           reducer.suggestions(hint, opts) |> handle_suggestions(acc)
         else
           {:cont, acc}

--- a/lib/elixir_sense/providers/suggestion/generic_reducer.ex
+++ b/lib/elixir_sense/providers/suggestion/generic_reducer.ex
@@ -37,7 +37,7 @@ defmodule ElixirSense.Providers.Suggestion.GenericReducer do
 
     case Util.func_call_chain(text_before, env, buffer_metadata) do
       [func_call | _] = chain ->
-        if :erlang.function_exported(reducer, :suggestions, 4) do
+        if function_exported?(reducer, :suggestions, 4) do
           reducer.suggestions(hint, func_call, chain, opts) |> handle_suggestions(acc)
         else
           {:cont, acc}

--- a/lib/elixir_sense/providers/suggestion/generic_reducer.ex
+++ b/lib/elixir_sense/providers/suggestion/generic_reducer.ex
@@ -28,17 +28,24 @@ defmodule ElixirSense.Providers.Suggestion.GenericReducer do
   def reduce(reducer, hint, env, buffer_metadata, cursor_context, acc) do
     text_before = cursor_context.text_before
 
+    opts = %{
+      env: env,
+      buffer_metadata: buffer_metadata,
+      cursor_context: cursor_context,
+      module_store: acc.context.module_store
+    }
+
     case Util.func_call_chain(text_before, env, buffer_metadata) do
       [func_call | _] = chain ->
         if :erlang.function_exported(reducer, :suggestions, 4) do
-          reducer.suggestions(hint, func_call, chain, acc) |> handle_suggestions(acc)
+          reducer.suggestions(hint, func_call, chain, opts) |> handle_suggestions(acc)
         else
           {:cont, acc}
         end
 
       [] ->
         if :erlang.function_exported(reducer, :suggestions, 2) do
-          reducer.suggestions(hint, acc) |> handle_suggestions(acc)
+          reducer.suggestions(hint, opts) |> handle_suggestions(acc)
         else
           {:cont, acc}
         end

--- a/lib/elixir_sense/providers/suggestion/generic_reducer.ex
+++ b/lib/elixir_sense/providers/suggestion/generic_reducer.ex
@@ -30,17 +30,18 @@ defmodule ElixirSense.Providers.Suggestion.GenericReducer do
 
     case Util.func_call_chain(text_before, env, buffer_metadata) do
       [func_call | _] = chain ->
-        opts = %{
-          env: env,
-          buffer_metadata: buffer_metadata,
-          cursor_context: cursor_context,
-          module_store: acc.context.module_store
-        }
+        if :erlang.function_exported(reducer, :suggestions, 4) do
+          reducer.suggestions(hint, func_call, chain, acc) |> handle_suggestions(acc)
+        else
+          {:cont, acc}
+        end
 
-        reducer.suggestions(hint, func_call, chain, opts) |> handle_suggestions(acc)
-
-      _ ->
-        {:cont, acc}
+      [] ->
+        if :erlang.function_exported(reducer, :suggestions, 2) do
+          reducer.suggestions(hint, acc) |> handle_suggestions(acc)
+        else
+          {:cont, acc}
+        end
     end
   end
 

--- a/lib/elixir_sense/providers/suggestion/generic_reducer.ex
+++ b/lib/elixir_sense/providers/suggestion/generic_reducer.ex
@@ -33,7 +33,8 @@ defmodule ElixirSense.Providers.Suggestion.GenericReducer do
         opts = %{
           env: env,
           buffer_metadata: buffer_metadata,
-          cursor_context: cursor_context
+          cursor_context: cursor_context,
+          module_store: acc.context.module_store
         }
 
         reducer.suggestions(hint, func_call, chain, opts) |> handle_suggestions(acc)

--- a/test/elixir_sense/providers/suggestion_test.exs
+++ b/test/elixir_sense/providers/suggestion_test.exs
@@ -21,10 +21,17 @@ defmodule ElixirSense.Providers.SuggestionTest do
   }
 
   @cursor_context %{text_before: "", text_after: ""}
+  @module_store %ElixirSense.Core.ModuleStore{}
 
   test "find definition of built-in functions" do
     result =
-      Suggestion.find("ElixirSenseExample.EmptyModule.", @env, %Metadata{}, @cursor_context)
+      Suggestion.find(
+        "ElixirSenseExample.EmptyModule.",
+        @env,
+        %Metadata{},
+        @cursor_context,
+        @module_store
+      )
 
     assert result |> Enum.at(0) == %{
              args: "atom",
@@ -95,7 +102,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
                summary: "Produces a new list by " <> _,
                type: :function
              }
-           ] = Suggestion.find("List.del", @env, %Metadata{}, @cursor_context)
+           ] = Suggestion.find("List.del", @env, %Metadata{}, @cursor_context, @module_store)
   end
 
   test "return completion candidates for module with alias" do
@@ -123,12 +130,19 @@ defmodule ElixirSense.Providers.SuggestionTest do
                "MyList.del",
                %{@env | aliases: [{MyList, List}]},
                %Metadata{},
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
   end
 
   test "return completion candidates for functions from import" do
-    assert Suggestion.find("say", %{@env | imports: [MyModule]}, %Metadata{}, @cursor_context) ==
+    assert Suggestion.find(
+             "say",
+             %{@env | imports: [MyModule]},
+             %Metadata{},
+             @cursor_context,
+             @module_store
+           ) ==
              [
                %{
                  args: "",
@@ -154,7 +168,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
         "module_",
         @env,
         %Metadata{},
-        @cursor_context
+        @cursor_context,
+        @module_store
       )
       |> Enum.filter(fn item -> item.type in [:function] end)
 
@@ -163,7 +178,7 @@ defmodule ElixirSense.Providers.SuggestionTest do
 
   test "empty hint should not return built-in functions" do
     suggestions_names =
-      Suggestion.find("", @env, %Metadata{}, @cursor_context)
+      Suggestion.find("", @env, %Metadata{}, @cursor_context, @module_store)
       |> Enum.filter(&Map.has_key?(&1, :name))
       |> Enum.map(& &1.name)
 
@@ -191,7 +206,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                "ElixirSenseExample.FunctionsWithTheSameName.all",
                @env,
                %Metadata{},
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
   end
 
@@ -216,7 +232,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                "ElixirSenseExample.FunctionsWithTheSameName.conca",
                @env,
                %Metadata{},
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
   end
 
@@ -230,7 +247,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                "%ElixirSense.Providers.SuggestionTest.MyStr",
                @env_func,
                %Metadata{},
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
   end
 
@@ -240,7 +258,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                "f = &Enum.al",
                @env_func,
                %Metadata{},
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
   end
 
@@ -250,7 +269,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                "x.Foo.get_by",
                @env_func,
                %Metadata{},
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
   end
 
@@ -269,7 +289,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                    }
                  }
                },
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
 
     assert [%{type: :module, name: "SomeModule"} | _] =
@@ -281,7 +302,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                    {SomeModule, nil, nil} => %ElixirSense.Core.State.ModFunInfo{type: :defmodule}
                  }
                },
-               @cursor_context
+               @cursor_context,
+               @module_store
              )
   end
 
@@ -298,7 +320,8 @@ defmodule ElixirSense.Providers.SuggestionTest do
                    {SomeModule, nil, nil} => %ElixirSense.Core.State.ModFunInfo{type: :defmodule}
                  }
                },
-               %{text_before: "%SomeModule{st", text_after: ""}
+               %{text_before: "%SomeModule{st", text_after: ""},
+               @module_store
              )
   end
 end


### PR DESCRIPTION
This is a new PR based on this: https://github.com/elixir-lsp/elixir_sense/pull/139

Unfortunately, I don't think we can automatically find all extensions that are loaded since likely those extensions will be defined by your dependencies, and so some explicit configuration is needed. I went the simplest route possible here, and just expected `config :elixir_sense, :plugins`, which is actually a bit problematic because you get a warning about using that app in config w/o including it in deps.

I'm open to ideas on how to actually do the configuration.

Because we can't do it via automatically finding them, the `module_store` is technically unnecessary to make this work since I just used an explicit list. However, it seems like an optimization we wanted anyway, so I've left it in here.