### PR TITLE
fix: ensure modules are compiled when indexing modules

### DIFF
--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -34,7 +34,8 @@ defmodule ElixirSense.Core.ModuleStore do
     Applications.get_modules_from_applications()
     |> Enum.filter(fn module ->
       try do
-        function_exported?(module, :module_info, 1)
+        Code.ensure_compiled(module)
+        function_exported?(module, :module_info, 0)
       rescue
         _ ->
           false

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -34,7 +34,7 @@ defmodule ElixirSense.Core.ModuleStore do
     Applications.get_modules_from_applications()
     |> Enum.filter(fn module ->
       try do
-        Code.ensure_compiled(module)
+        _ = Code.ensure_compiled(module)
         function_exported?(module, :module_info, 0)
       rescue
         _ ->


### PR DESCRIPTION
I'm noticing flakiness in plugin finding logic when we build our module store but don't ensure that the modules are compiled. I'm not sure what kind of overhead this will add, but by using `Code.ensure_compiled` instead of `Code.ensure_compiled!` this should at least not incur any deadlocks, and if we call it on all relevant modules iteratively, by the time we're done all deadlock modules should have been resolved.