### PR TITLE
don't replace string interpolation

### DIFF
--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -170,7 +170,7 @@ defmodule ElixirSense.Core.Source do
       |> split_lines
       |> Enum.map_join("\n", fn line ->
         # this is a naive comment strip - it will not honour # in strings, chars etc
-        Regex.replace(~r/[^<]\#[^{].*$/, line, "")
+        Regex.replace(~r/[^<]\#(?!\{).*$/, line, "")
       end)
 
     case walk_text(code, acc, &find_subject/5) do

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -170,7 +170,7 @@ defmodule ElixirSense.Core.Source do
       |> split_lines
       |> Enum.map_join("\n", fn line ->
         # this is a naive comment strip - it will not honour # in strings, chars etc
-        Regex.replace(~r/[^<]\#.*$/, line, "")
+        Regex.replace(~r/[^<]\#[^{].*$/, line, "")
       end)
 
     case walk_text(code, acc, &find_subject/5) do

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -917,12 +917,15 @@ defmodule ElixirSense.Core.SourceTest do
 
           :ets. # for performance.
             match(:ac_tab, {{:loaded, :"$1"}, :_})
+
+          "String \#{inspect("Interpolation")}"
         end
       end
       """
 
       assert subject(code, 4, 10) == ":ets.match"
       assert subject(code, 7, 7) == ":ets.match"
+      assert subject(code, 9, 18) == "inspect"
     end
   end
 


### PR DESCRIPTION
Get documentation when hovering the functions inside string interpolation.
related issue https://github.com/elixir-lsp/vscode-elixir-ls/issues/185

<img width="409" alt="image" src="https://user-images.githubusercontent.com/6327995/152599107-784bc769-21c7-408a-a0e1-a523fccd150b.png">