### PR TITLE
find elixir modules that require adding an alias

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -203,7 +203,7 @@ defmodule ElixirSense do
         spec: "@spec insert_at(list, integer, any) :: list", summary: "Returns a list with `value` inserted at the specified `index`."}]
   """
   @spec suggestions(String.t(), pos_integer, pos_integer) :: [Suggestion.suggestion()]
-  def suggestions(buffer, line, column) do
+  def suggestions(buffer, line, column, opts \\ []) do
     hint = Source.prefix(buffer, line, column)
     buffer_file_metadata = Parser.parse_string(buffer, true, true, line)
     {text_before, text_after} = Source.split_at(buffer, line, column)
@@ -220,7 +220,7 @@ defmodule ElixirSense do
       at_module_body?: Metadata.at_module_body?(buffer_file_metadata, env)
     }
 
-    Suggestion.find(hint, env, buffer_file_metadata, cursor_context, module_store)
+    Suggestion.find(hint, env, buffer_file_metadata, cursor_context, module_store, opts)
   end
 
   @doc """

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -202,7 +202,7 @@ defmodule ElixirSense do
         name: "insert_at", metadata: %{}, snippet: nil, visibility: :public,
         spec: "@spec insert_at(list, integer, any) :: list", summary: "Returns a list with `value` inserted at the specified `index`."}]
   """
-  @spec suggestions(String.t(), pos_integer, pos_integer) :: [Suggestion.suggestion()]
+  @spec suggestions(String.t(), pos_integer, pos_integer, keyword()) :: [Suggestion.suggestion()]
   def suggestions(buffer, line, column, opts \\ []) do
     hint = Source.prefix(buffer, line, column)
     buffer_file_metadata = Parser.parse_string(buffer, true, true, line)

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -17,7 +17,9 @@ defmodule ElixirSense.Core.Metadata do
           types: State.types_t(),
           specs: State.specs_t(),
           structs: State.structs_t(),
-          error: nil | term
+          error: nil | term,
+          first_alias_positions: map(),
+          moduledoc_positions: map()
         }
 
   defstruct source: "",
@@ -29,8 +31,8 @@ defmodule ElixirSense.Core.Metadata do
             specs: %{},
             structs: %{},
             error: nil,
-            first_alias_positions: nil,
-            moduledoc_positions: nil
+            first_alias_positions: %{},
+            moduledoc_positions: %{}
 
   @type signature_t :: %{
           name: String.t(),
@@ -77,7 +79,9 @@ defmodule ElixirSense.Core.Metadata do
         case mod_info do
           %State.ModFunInfo{positions: [{line, column}]} ->
             # Hacky :shrug
-            {line + 1, column - 10 + 2}
+            line_offset = 1
+            column_offset = -8
+            {line + line_offset, column + column_offset}
 
           _ ->
             nil

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -94,7 +94,9 @@ defmodule ElixirSense.Core.Parser do
       mods_funs_to_positions: acc.mods_funs_to_positions,
       lines_to_env: acc.lines_to_env,
       vars_info_per_scope_id: acc.vars_info_per_scope_id,
-      calls: acc.calls
+      calls: acc.calls,
+      first_alias_positions: acc.first_alias_positions,
+      moduledoc_positions: acc.moduledoc_positions
     }
   end
 

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -52,6 +52,8 @@ defmodule ElixirSense.Core.State do
           calls: calls_t,
           structs: structs_t,
           types: types_t,
+          first_alias_positions: map(),
+          moduledoc_positions: map(),
           # TODO
           binding_context: list
         }
@@ -76,7 +78,9 @@ defmodule ElixirSense.Core.State do
             calls: %{},
             structs: %{},
             types: %{},
-            binding_context: []
+            binding_context: [],
+            first_alias_positions: %{},
+            moduledoc_positions: %{}
 
   defmodule Env do
     @moduledoc """
@@ -301,6 +305,75 @@ defmodule ElixirSense.Core.State do
   def add_current_env_to_line(%__MODULE__{} = state, line) when is_integer(line) do
     env = get_current_env(state)
     %__MODULE__{state | lines_to_env: Map.put(state.lines_to_env, line, env)}
+  end
+
+  def add_moduledoc_positions(
+        %__MODULE__{} = state,
+        [line: line, column: column],
+        [{:moduledoc, _meta, [here_doc]}],
+        line
+      )
+      when is_integer(line) and is_binary(here_doc) do
+    module_name = module_name(state)
+
+    line_to_insert_alias =
+      here_doc |> String.split("\n") |> Enum.count() |> then(fn count -> line + count + 1 end)
+
+    %__MODULE__{
+      state
+      | moduledoc_positions:
+          Map.put(state.moduledoc_positions, module_name, {line_to_insert_alias, column})
+    }
+  end
+
+  def add_moduledoc_positions(
+        %__MODULE__{} = state,
+        [line: line, column: column],
+        [{:moduledoc, _meta, [params]}],
+        line
+      )
+      when is_integer(line) and is_boolean(params) do
+    module_name = module_name(state)
+
+    line_to_insert_alias = line + 1
+
+    %__MODULE__{
+      state
+      | moduledoc_positions:
+          Map.put(state.moduledoc_positions, module_name, {line_to_insert_alias, column})
+    }
+  end
+
+  def add_moduledoc_positions(state, _, _, _), do: state
+
+  def add_first_alias_positions(%__MODULE__{} = state, line, column)
+      when is_integer(line) and is_integer(column) do
+    current_scope = hd(hd(state.scopes))
+
+    is_module? = is_atom(current_scope)
+
+    if is_module? do
+      module_name = module_name(state)
+
+      %__MODULE__{
+        state
+        | first_alias_positions:
+            Map.put_new(state.first_alias_positions, module_name, {line, column})
+      }
+    else
+      state
+    end
+  end
+
+  defp module_name(state) do
+    hd(state.scopes)
+    |> Enum.reverse()
+    |> then(fn
+      [Elixir | rest] -> rest
+      rest -> rest
+    end)
+    |> Enum.filter(&is_atom/1)
+    |> Module.concat()
   end
 
   def add_call_to_line(%__MODULE__{} = state, {mod, func, arity}, {line, _column} = position) do

--- a/lib/elixir_sense/core/state.ex
+++ b/lib/elixir_sense/core/state.ex
@@ -316,8 +316,8 @@ defmodule ElixirSense.Core.State do
       when is_integer(line) and is_binary(here_doc) do
     module_name = module_name(state)
 
-    line_to_insert_alias =
-      here_doc |> String.split("\n") |> Enum.count() |> then(fn count -> line + count + 1 end)
+    new_line_count = here_doc |> String.split("\n") |> Enum.count()
+    line_to_insert_alias = new_line_count + line + 1
 
     %__MODULE__{
       state
@@ -368,13 +368,13 @@ defmodule ElixirSense.Core.State do
   defp module_name(state) do
     hd(state.scopes)
     |> Enum.reverse()
-    |> then(fn
-      [Elixir | rest] -> rest
-      rest -> rest
-    end)
+    |> after_elixir_prefix()
     |> Enum.filter(&is_atom/1)
     |> Module.concat()
   end
+
+  defp after_elixir_prefix([Elixir | rest]), do: rest
+  defp after_elixir_prefix(rest), do: rest
 
   def add_call_to_line(%__MODULE__{} = state, {mod, func, arity}, {line, _column} = position) do
     call = %CallInfo{mod: mod, func: func, arity: arity, position: position}

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -104,7 +104,7 @@ defmodule ElixirSense.Providers.Suggestion do
   @doc """
   Finds all suggestions for a hint based on context information.
   """
-  @spec find(String.t(), State.Env.t(), Metadata.t(), cursor_context, ModuleStore.t()) ::
+  @spec find(String.t(), State.Env.t(), Metadata.t(), cursor_context, ModuleStore.t(), keyword()) ::
           [suggestion()]
   def find(hint, env, buffer_metadata, cursor_context, module_store, opts \\ []) do
     plugins = module_store.by_behaviour[ElixirSense.Plugin] || []

--- a/lib/elixir_sense/providers/suggestion/complete.ex
+++ b/lib/elixir_sense/providers/suggestion/complete.ex
@@ -88,7 +88,7 @@ defmodule ElixirSense.Providers.Suggestion.Complete do
               behaviours: []
   end
 
-  @spec complete(String.t(), Env.t(), list(keyword())) ::
+  @spec complete(String.t(), Env.t(), keyword()) ::
           [
             ElixirSense.Providers.Suggestion.Reducers.Common.func()
             | ElixirSense.Providers.Suggestion.Reducers.Common.mod()

--- a/lib/elixir_sense/providers/suggestion/complete.ex
+++ b/lib/elixir_sense/providers/suggestion/complete.ex
@@ -560,9 +560,10 @@ defmodule ElixirSense.Providers.Suggestion.Complete do
       subtype = Introspection.get_module_subtype(module)
       result = %{kind: :module, type: :elixir, name: name, desc: {desc, meta}, subtype: subtype}
 
-      cond do
-        required_alias? -> Map.put(result, :required_alias, module)
-        true -> result
+      if required_alias? do
+        Map.put(result, :required_alias, module)
+      else
+        result
       end
     end)
   end

--- a/lib/elixir_sense/providers/suggestion/reducers/common.ex
+++ b/lib/elixir_sense/providers/suggestion/reducers/common.ex
@@ -61,24 +61,7 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Common do
   def populate(hint, env, buffer_metadata, context, acc, opts \\ []) do
     text_before = context.text_before
 
-    %Metadata{
-      structs: structs,
-      mods_funs_to_positions: mods_and_funs,
-      specs: metadata_specs,
-      types: metadata_types
-    } = buffer_metadata
-
-    suggestions =
-      find_mods_funcs(
-        hint,
-        env,
-        mods_and_funs,
-        metadata_specs,
-        metadata_types,
-        structs,
-        text_before,
-        opts
-      )
+    suggestions = find_mods_funcs(hint, env, buffer_metadata, text_before, opts)
 
     suggestions_by_type = Enum.group_by(suggestions, & &1.type)
 
@@ -156,10 +139,12 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Common do
            scope: scope,
            behaviours: behaviours
          },
-         mods_and_funs,
-         metadata_specs,
-         metadata_types,
-         structs,
+         %Metadata{
+           structs: structs,
+           mods_funs_to_positions: mods_and_funs,
+           specs: metadata_specs,
+           types: metadata_types
+         },
          text_before,
          opts
        ) do

--- a/lib/elixir_sense/providers/suggestion/reducers/common.ex
+++ b/lib/elixir_sense/providers/suggestion/reducers/common.ex
@@ -58,7 +58,7 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Common do
     * Variable fields
 
   """
-  def populate(hint, env, buffer_metadata, context, acc) do
+  def populate(hint, env, buffer_metadata, context, acc, opts \\ []) do
     text_before = context.text_before
 
     %Metadata{
@@ -76,7 +76,8 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Common do
         metadata_specs,
         metadata_types,
         structs,
-        text_before
+        text_before,
+        opts
       )
 
     suggestions_by_type = Enum.group_by(suggestions, & &1.type)
@@ -159,7 +160,8 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Common do
          metadata_specs,
          metadata_types,
          structs,
-         text_before
+         text_before,
+         opts
        ) do
     env = %Complete.Env{
       aliases: aliases,
@@ -194,6 +196,6 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Common do
         hint
       end
 
-    Complete.complete(hint, env)
+    Complete.complete(hint, env, opts)
   end
 end

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -26,6 +26,37 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
            ) =~ "def function_arity_zero"
   end
 
+  test "moduledoc heredoc version" do
+    state =
+      """
+      defmodule Outer do
+        @moduledoc \"\"\"
+        This is the here doc version
+        \"\"\"
+        defmodule Inner do
+          @moduledoc \"\"\"
+          This is the Inner modules moduledoc
+          \"\"\"
+        end
+      end
+      """
+      |> string_to_state
+
+    assert %{Outer => {5, 3}, Outer.Inner => {9, 5}} = state.moduledoc_positions
+  end
+
+  test "moduledoc boolean version" do
+    state =
+      """
+      defmodule Outer do
+        @moduledoc false
+      end
+      """
+      |> string_to_state
+
+    assert %{Outer => {3, 3}} = state.moduledoc_positions
+  end
+
   test "module attributes" do
     state =
       """
@@ -3380,6 +3411,22 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
                type: :def
              }
            } = state.mods_funs_to_positions
+  end
+
+  test "first_alias_positions" do
+    state =
+      """
+      defmodule OuterMod do
+        alias Foo.Bar
+        alias Foo1.Bar1
+        defmodule InnerMod do
+          alias Baz.Quz
+        end
+      end
+      """
+      |> string_to_state
+
+    assert %{OuterMod => {2, 3}, OuterMod.InnerMod => {5, 5}} = state.first_alias_positions
   end
 
   test "use" do

--- a/test/elixir_sense/providers/suggestion/complete_test.exs
+++ b/test/elixir_sense/providers/suggestion/complete_test.exs
@@ -24,8 +24,8 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
   alias ElixirSense.Providers.Suggestion.Complete.Env
   alias ElixirSense.Core.State.{ModFunInfo, SpecInfo, VarInfo, AttributeInfo}
 
-  def expand(expr, env \\ %Env{}) do
-    ElixirSense.Providers.Suggestion.Complete.do_expand(expr, env)
+  def expand(expr, env \\ %Env{}, opts \\ []) do
+    ElixirSense.Providers.Suggestion.Complete.do_expand(expr, env, opts)
   end
 
   test "erlang module completion" do
@@ -282,6 +282,29 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
                  }
                ]
              })
+  end
+
+  test "find elixir modules that require alias" do
+    assert [
+             %{metadata: %{}, name: "Chars", required_alias: String.Chars},
+             %{metadata: %{}, name: "Chars", required_alias: List.Chars},
+             %{
+               metadata: %{},
+               name: "CallerWithAliasesAndImports",
+               required_alias:
+                 ElixirSense.Providers.ReferencesTest.Modules.CallerWithAliasesAndImports
+             }
+           ] = expand('Char', %Env{}, required_alias: true)
+  end
+
+  test "does not suggest required_alias when alias already exists" do
+    env = %Env{
+      aliases: [{MyChars, String.Chars}]
+    }
+
+    results = expand('Char', env, required_alias: true)
+
+    refute Enum.find(results, fn expansion -> expansion[:required_alias] == String.Chars end)
   end
 
   test "elixir submodule no completion" do


### PR DESCRIPTION
Basic code to find modules that require adding an alias. Sort of related to [elixir-ls issue](https://github.com/elixir-lsp/elixir-ls/issues/161)
~Marking it draft due to some known test failures that I would like to get some suggestions on how to handle them.~