### PR TITLE
Include handling for group metadata in introspection.ex

### DIFF
--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -447,7 +447,9 @@ defmodule ElixirSense.Core.Introspection do
     "**Delegates to**\n#{inspect(m)}.#{f}/#{a}"
   end
 
-  defp get_metadata_entry_md({_, _}), do: nil
+  defp get_metadata_entry_md({key, value}) do
+    "**#{key}**\n#{value}"
+  end
 
   # no types inside a function
   def get_type_docs_md(_, _, {_f, _a}) do

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -419,6 +419,10 @@ defmodule ElixirSense.Core.Introspection do
     "**Since**\n#{text}"
   end
 
+  defp get_metadata_entry_md({:group, text}) do
+    "**Group** - #{text}"
+  end
+
   defp get_metadata_entry_md({:guard, true}) do
     "**Guard**"
   end

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -447,6 +447,8 @@ defmodule ElixirSense.Core.Introspection do
     "**Delegates to**\n#{inspect(m)}.#{f}/#{a}"
   end
 
+  defp get_metadata_entry_md({_, _}), do: nil
+
   # no types inside a function
   def get_type_docs_md(_, _, {_f, _a}) do
     []

--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -420,7 +420,7 @@ defmodule ElixirSense.Core.Introspection do
   end
 
   defp get_metadata_entry_md({:group, text}) do
-    "**Group** - #{text}"
+    "**Group**\n#{text}"
   end
 
   defp get_metadata_entry_md({:guard, true}) do


### PR DESCRIPTION
In some case, `NormalizedCode.getDocs()` would return results that include `:group` in the results. Since there was no matching `get_metadata_entry_md` for group, it would fail. This PR adds the appropriate match as well as a nonmatching path.