### PR TITLE
Introduce references tracer

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -368,7 +368,14 @@ defmodule ElixirSense do
       ...>   C.func()
       ...> end
       ...> '''
-      iex> ElixirSense.references(code, 3, 6) |> Enum.take(2)
+      ...> trace = %{
+      ...>   {ElixirSense.Providers.ReferencesTest.Modules.Callee1, :func, 0} => %{
+      ...>     callee: {ElixirSense.Providers.ReferencesTest.Modules.Callee1, :func, 0},
+      ...>     file: "test/support/modules_with_references.ex",
+      ...>     line: 36
+      ...>   }
+      ...> }
+      iex> ElixirSense.references(code, 3, 6, trace)
       [
         %{
           uri: "test/support/modules_with_references.ex",
@@ -376,18 +383,16 @@ defmodule ElixirSense do
             start: %{line: 36, column: 60},
             end: %{line: 36, column: 64}
           }
-        },
-        %{
-          uri: "test/support/modules_with_references.ex",
-          range: %{
-            start: %{line: 65, column: 16},
-            end: %{line: 65, column: 20}
-          }
         }
       ]
   """
-  @spec references(String.t(), pos_integer, pos_integer) :: [References.reference_info()]
-  def references(code, line, column) do
+  @spec references(
+          String.t(),
+          pos_integer,
+          pos_integer,
+          ElixirSense.Core.References.Tracer.call_trace_t() | nil
+        ) :: [References.reference_info()]
+  def references(code, line, column, trace \\ nil) do
     case Source.subject_with_position(code, line, column) do
       {subject, {line, col}} ->
         buffer_file_metadata = Parser.parse_string(code, true, true, line)
@@ -410,7 +415,8 @@ defmodule ElixirSense do
           env,
           vars,
           attributes,
-          buffer_file_metadata
+          buffer_file_metadata,
+          trace
         )
 
       _ ->

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -23,6 +23,16 @@ defmodule ElixirSense do
   alias ElixirSense.Providers.Signature
   alias ElixirSense.Providers.Suggestion
 
+  @type callee_t :: {module, atom, non_neg_integer}
+
+  @type call_t :: %{
+          callee: callee_t,
+          file: nil | String.t(),
+          line: nil | pos_integer,
+          column: nil | pos_integer
+        }
+  @type call_trace_t :: %{optional(callee_t) => [call_t]}
+
   @doc ~S"""
   Returns all documentation related a module or function, including types and callback information.
 
@@ -372,7 +382,8 @@ defmodule ElixirSense do
       ...>   {ElixirSense.Providers.ReferencesTest.Modules.Callee1, :func, 0} => %{
       ...>     callee: {ElixirSense.Providers.ReferencesTest.Modules.Callee1, :func, 0},
       ...>     file: "test/support/modules_with_references.ex",
-      ...>     line: 36
+      ...>     line: 36,
+      ...>     column: 60,
       ...>   }
       ...> }
       iex> ElixirSense.references(code, 3, 6, trace)
@@ -390,9 +401,9 @@ defmodule ElixirSense do
           String.t(),
           pos_integer,
           pos_integer,
-          ElixirSense.Core.References.Tracer.call_trace_t() | nil
+          call_trace_t()
         ) :: [References.reference_info()]
-  def references(code, line, column, trace \\ nil) do
+  def references(code, line, column, trace) do
     case Source.subject_with_position(code, line, column) do
       {subject, {line, col}} ->
         buffer_file_metadata = Parser.parse_string(code, true, true, line)

--- a/lib/elixir_sense/core/references_tracer.ex
+++ b/lib/elixir_sense/core/references_tracer.ex
@@ -1,0 +1,62 @@
+defmodule ElixirSense.Core.References.Tracer do
+  @moduledoc """
+  Elixir Compiler tracer that registers function calls
+  """
+  use Agent
+
+  @type callee_t :: {module, atom, non_neg_integer}
+
+  @type call_t :: %{
+          callee: callee_t,
+          file: nil | String.t(),
+          line: nil | pos_integer
+        }
+  @type call_trace_t :: %{optional(callee_t) => [call_t]}
+
+  @spec start_link(call_trace_t) :: Agent.on_start()
+  def start_link(initial \\ %{}) do
+    Agent.start_link(fn -> initial end, name: __MODULE__)
+  end
+
+  @spec get :: call_trace_t
+  def get do
+    Agent.get(__MODULE__, & &1)
+  end
+
+  @spec register_call(call_t) :: :ok
+  def register_call(%{callee: callee} = call) do
+    Agent.update(__MODULE__, fn calls ->
+      updated_calls =
+        case calls[callee] do
+          nil -> [call]
+          callee_calls -> [call | callee_calls]
+        end
+
+      calls |> Map.put(callee, updated_calls)
+    end)
+  end
+
+  def trace({:imported_function, meta, module, name, arity}, env) do
+    register_call(%{
+      callee: {module, name, arity},
+      file: env.file |> Path.relative_to_cwd(),
+      line: meta[:line]
+    })
+
+    :ok
+  end
+
+  def trace({:remote_function, meta, module, name, arity}, env) do
+    register_call(%{
+      callee: {module, name, arity},
+      file: env.file |> Path.relative_to_cwd(),
+      line: meta[:line]
+    })
+
+    :ok
+  end
+
+  def trace(_trace, _env) do
+    :ok
+  end
+end

--- a/lib/elixir_sense/providers/references.ex
+++ b/lib/elixir_sense/providers/references.ex
@@ -13,7 +13,6 @@ defmodule ElixirSense.Providers.References do
   alias ElixirSense.Core.State
   alias ElixirSense.Core.State.AttributeInfo
   alias ElixirSense.Core.State.VarInfo
-  alias Mix.Tasks.Xref
 
   @type position :: %{line: pos_integer, column: pos_integer}
 
@@ -168,29 +167,6 @@ defmodule ElixirSense.Providers.References do
     |> List.flatten()
     |> Enum.filter(caller_filter(mfa))
     |> Enum.uniq()
-  end
-
-  defp calls do
-    if Mix.Project.umbrella?() do
-      umbrella_calls()
-    else
-      Xref.calls()
-    end
-  end
-
-  def umbrella_calls do
-    build_dir = Path.expand(Mix.Project.config()[:build_path])
-    app_paths = Mix.Project.apps_paths()
-
-    app_paths
-    |> Enum.flat_map(fn {app, path} ->
-      Mix.Project.in_project(app, path, [build_path: build_dir], fn _ ->
-        Xref.calls()
-        |> Enum.map(fn call ->
-          Map.update!(call, :file, fn file -> Path.expand(file) end)
-        end)
-      end)
-    end)
   end
 
   defp expand_xref_line_calls(xref_call, buffer_arity) do

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -35,12 +35,17 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 2, 8, trace)
 
-    assert references == [
+    assert [
              %{
-               range: %{start: %{column: 14, line: 4}, end: %{column: 17, line: 4}},
+               range: range_1,
                uri: "test/support/module_with_builtin_type_shadowing.ex"
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{column: 14, line: 4}, end: %{column: 17, line: 4}}
+    end
   end
 
   test "find references with cursor over a function call", %{trace: trace} do
@@ -55,20 +60,27 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 59, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+               range: range_2
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+               range: range_3
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+      assert range_3 == %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+    end
   end
 
   test "find references with cursor over a function definition", %{trace: trace} do
@@ -87,33 +99,46 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 2, 10, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+               range: range_2
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+               range: range_3
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+      assert range_3 == %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+    end
 
     references = ElixirSense.references(buffer, 6, 10, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+               range: range_2
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+    end
   end
 
   test "find references with cursor over a function definition with default arg", %{trace: trace} do
@@ -127,16 +152,22 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 2, 10, trace)
 
-    assert references == [
+    assert [
              %{
-               range: %{end: %{column: 42, line: 3}, start: %{column: 37, line: 3}},
+               range: range_1,
                uri: "test/support/subscriber.ex"
              },
              %{
-               range: %{end: %{column: 42, line: 4}, start: %{column: 37, line: 4}},
+               range: range_2,
                uri: "test/support/subscriber.ex"
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{end: %{column: 42, line: 3}, start: %{column: 37, line: 3}}
+      assert range_2 == %{end: %{column: 42, line: 4}, start: %{column: 37, line: 4}}
+    end
   end
 
   test "find references with cursor over a function with arity 1", %{trace: trace} do
@@ -151,16 +182,22 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 59, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+               range: range_2
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+    end
   end
 
   test "find references with cursor over a function called via @attr.call", %{trace: trace} do
@@ -176,16 +213,22 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 4, 12, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+               range: range_2
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+    end
   end
 
   test "find references to function called via @attr.call", %{trace: trace} do
@@ -200,12 +243,17 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 59, trace)
 
-    assert references == [
+    assert [
              %{
-               range: %{end: %{column: 23, line: 114}, start: %{column: 13, line: 114}},
+               range: range_1,
                uri: "test/support/modules_with_references.ex"
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{end: %{column: 23, line: 114}, start: %{column: 13, line: 114}}
+    end
   end
 
   test "find references with cursor over a function with arity 1 called via pipe operator", %{
@@ -223,12 +271,17 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 4, 62, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+               range: range_1
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+    end
   end
 
   test "find references with cursor over a function with arity 1 captured", %{trace: trace} do
@@ -243,12 +296,17 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 72, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+               range: range_1
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+    end
   end
 
   test "find references with cursor over a function when caller uses pipe operator", %{
@@ -265,12 +323,17 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 59, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+               range: range_1
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 49, column: 63}, end: %{line: 49, column: 71}}
+    end
   end
 
   test "find references with cursor over a function when caller uses capture operator", %{
@@ -315,21 +378,31 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 59, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 90, column: 60}, end: %{line: 90, column: 68}}
+               range: range_1
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 90, column: 60}, end: %{line: 90, column: 68}}
+    end
 
     references = ElixirSense.references(buffer, 4, 59, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 90, column: 60}, end: %{line: 90, column: 68}}
+               range: range_1
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 90, column: 60}, end: %{line: 90, column: 68}}
+    end
   end
 
   test "find references with cursor over a function with deault argument when caller does not uses default arguments",
@@ -346,21 +419,31 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 59, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 91, column: 60}, end: %{line: 91, column: 69}}
+               range: range_1
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 91, column: 60}, end: %{line: 91, column: 69}}
+    end
 
     references = ElixirSense.references(buffer, 4, 59, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 91, column: 60}, end: %{line: 91, column: 69}}
+               range: range_1
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 91, column: 60}, end: %{line: 91, column: 69}}
+    end
   end
 
   test "find references with cursor over a module with funs with deault argument", %{trace: trace} do
@@ -375,16 +458,22 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 55, trace)
 
-    assert references == [
+    assert [
              %{
-               range: %{end: %{column: 68, line: 90}, start: %{column: 60, line: 90}},
+               range: range_1,
                uri: "test/support/modules_with_references.ex"
              },
              %{
-               range: %{end: %{column: 69, line: 91}, start: %{column: 60, line: 91}},
+               range: range_2,
                uri: "test/support/modules_with_references.ex"
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{end: %{column: 68, line: 90}, start: %{column: 60, line: 90}}
+      assert range_2 == %{end: %{column: 69, line: 91}, start: %{column: 60, line: 91}}
+    end
   end
 
   test "find references with cursor over a module with 1.2 alias syntax", %{trace: trace} do
@@ -415,20 +504,27 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 4, 8, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+               range: range_2
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+               range: range_3
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+      assert range_3 == %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+    end
   end
 
   test "find references with cursor over a function call from an imported module", %{trace: trace} do
@@ -444,20 +540,27 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 4, 6, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+               range: range_2
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+               range: range_3
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+      assert range_3 == %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+    end
   end
 
   test "find references with cursor over a function call pipe from an imported module", %{
@@ -475,16 +578,22 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 4, 12, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+               range: range_2
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+    end
   end
 
   test "find references with cursor over a function capture from an imported module", %{
@@ -502,20 +611,27 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 4, 7, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+               range: range_2
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+               range: range_3
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+      assert range_2 == %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+      assert range_3 == %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+    end
   end
 
   test "find imported references", %{trace: trace} do
@@ -548,10 +664,15 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     reference = ElixirSense.references(buffer, 3, 59, trace) |> Enum.at(1)
 
-    assert reference == %{
+    assert %{
              uri: "test/support/modules_with_references.ex",
-             range: %{start: %{line: 70, column: 9}, end: %{line: 70, column: 13}}
-           }
+             range: range_1
+           } = reference
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 70, column: 9}, end: %{line: 70, column: 13}}
+    end
   end
 
   test "find references when module with __MODULE__ special form", %{trace: trace} do
@@ -711,28 +832,37 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 53, trace)
 
-    assert references == [
+    assert [
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+               range: range_1
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+               range: range_2
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+               range: range_3
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+               range: range_4
              },
              %{
                uri: "test/support/modules_with_references.ex",
-               range: %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+               range: range_5
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{line: 36, column: 60}, end: %{line: 36, column: 64}}
+      assert range_2 == %{start: %{line: 42, column: 60}, end: %{line: 42, column: 64}}
+      assert range_3 == %{start: %{line: 65, column: 16}, end: %{line: 65, column: 20}}
+      assert range_4 == %{start: %{line: 65, column: 63}, end: %{line: 65, column: 67}}
+      assert range_5 == %{start: %{line: 65, column: 79}, end: %{line: 65, column: 83}}
+    end
   end
 
   test "find references with cursor over an erlang module", %{trace: trace} do
@@ -749,12 +879,17 @@ defmodule ElixirSense.Providers.ReferencesTest do
       ElixirSense.references(buffer, 3, 7, trace)
       |> Enum.filter(&(&1.uri =~ "modules_with_references"))
 
-    assert references == [
+    assert [
              %{
-               range: %{start: %{column: 12, line: 74}, end: %{column: 15, line: 74}},
+               range: range_1,
                uri: "test/support/modules_with_references.ex"
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{column: 12, line: 74}, end: %{column: 15, line: 74}}
+    end
   end
 
   test "find references with cursor over an erlang function call", %{trace: trace} do
@@ -769,12 +904,17 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 11, trace)
 
-    assert references == [
+    assert [
              %{
-               range: %{start: %{column: 12, line: 74}, end: %{column: 15, line: 74}},
+               range: range_1,
                uri: "test/support/modules_with_references.ex"
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{column: 12, line: 74}, end: %{column: 15, line: 74}}
+    end
   end
 
   test "find references with cursor over builtin function call", %{trace: trace} do
@@ -789,11 +929,16 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     references = ElixirSense.references(buffer, 3, 60, trace)
 
-    assert references == [
+    assert [
              %{
-               range: %{start: %{column: 60, line: 101}, end: %{column: 71, line: 101}},
+               range: range_1,
                uri: "test/support/modules_with_references.ex"
              }
-           ]
+           ] = references
+
+    if Version.match?(System.version(), ">= 1.13.0") do
+      # elixir 1.13 changed positions reurned from tracer
+      assert range_1 == %{start: %{column: 60, line: 101}, end: %{column: 71, line: 101}}
+    end
   end
 end

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -9,6 +9,7 @@ defmodule ElixirSense.Providers.ReferencesTest do
 
     Code.compile_file("./test/support/modules_with_references.ex")
     Code.compile_file("./test/support/module_with_builtin_type_shadowing.ex")
+    Code.compile_file("./test/support/subscriber.ex")
 
     trace = Tracer.get()
 

--- a/test/support/references_tracer.ex
+++ b/test/support/references_tracer.ex
@@ -4,26 +4,17 @@ defmodule ElixirSense.Core.References.Tracer do
   """
   use Agent
 
-  @type callee_t :: {module, atom, non_neg_integer}
-
-  @type call_t :: %{
-          callee: callee_t,
-          file: nil | String.t(),
-          line: nil | pos_integer
-        }
-  @type call_trace_t :: %{optional(callee_t) => [call_t]}
-
-  @spec start_link(call_trace_t) :: Agent.on_start()
+  @spec start_link(ElixirSense.call_trace_t()) :: Agent.on_start()
   def start_link(initial \\ %{}) do
     Agent.start_link(fn -> initial end, name: __MODULE__)
   end
 
-  @spec get :: call_trace_t
+  @spec get :: ElixirSense.call_trace_t()
   def get do
     Agent.get(__MODULE__, & &1)
   end
 
-  @spec register_call(call_t) :: :ok
+  @spec register_call(ElixirSense.call_t()) :: :ok
   def register_call(%{callee: callee} = call) do
     Agent.update(__MODULE__, fn calls ->
       updated_calls =
@@ -36,21 +27,13 @@ defmodule ElixirSense.Core.References.Tracer do
     end)
   end
 
-  def trace({:imported_function, meta, module, name, arity}, env) do
+  def trace({kind, meta, module, name, arity}, env)
+      when kind in [:imported_function, :imported_macro, :remote_function, :remote_macro] do
     register_call(%{
       callee: {module, name, arity},
       file: env.file |> Path.relative_to_cwd(),
-      line: meta[:line]
-    })
-
-    :ok
-  end
-
-  def trace({:remote_function, meta, module, name, arity}, env) do
-    register_call(%{
-      callee: {module, name, arity},
-      file: env.file |> Path.relative_to_cwd(),
-      line: meta[:line]
+      line: meta[:line],
+      column: meta[:column]
     })
 
     :ok


### PR DESCRIPTION
Supersedes https://github.com/elixir-lsp/elixir_sense/pull/80

I ended up using a tracer process only in tests. The assumption here is that the client will run it's own tracer and provide trace data to elixir_sense