### PR TITLE
Allowed logging of errors to be quieted.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,6 @@
+import  Config
+
+config :elixir_sense,
+  logging_enabled: true
+
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+import Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,2 @@
+import Config
+config :elixir_sense, logging_enabled: false

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,1 @@
+import Config

--- a/lib/elixir_sense/core/ast.ex
+++ b/lib/elixir_sense/core/ast.ex
@@ -5,6 +5,7 @@ defmodule ElixirSense.Core.Ast do
 
   alias ElixirSense.Core.Introspection
   alias ElixirSense.Core.State
+  import ElixirSense.Log
 
   @empty_env_info %{
     requires: [],
@@ -72,7 +73,7 @@ defmodule ElixirSense.Core.Ast do
     env_info
   catch
     {:expand_error, _} ->
-      IO.puts(:stderr, "Info: ignoring recursive macro")
+      info(:stderr, "ignoring recursive macro", label: "Info")
       @empty_env_info
   end
 

--- a/lib/elixir_sense/core/ast.ex
+++ b/lib/elixir_sense/core/ast.ex
@@ -73,7 +73,7 @@ defmodule ElixirSense.Core.Ast do
     env_info
   catch
     {:expand_error, _} ->
-      info(:stderr, "ignoring recursive macro", label: "Info")
+      info("ignoring recursive macro")
       @empty_env_info
   end
 

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -57,8 +57,11 @@ defmodule ElixirSense.Core.MetadataBuilder do
       rescue
         exception ->
           warn(
-            "#{inspect(exception.__struct__)} during metadata build: #{Exception.message(exception)}",
-            __STACKTRACE__
+            Exception.format(
+              :error,
+              "#{inspect(exception.__struct__)} during metadata build: #{Exception.message(exception)}",
+              __STACKTRACE__
+            )
           )
 
           {nil, state}

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -4,6 +4,8 @@ defmodule ElixirSense.Core.MetadataBuilder do
   """
 
   import ElixirSense.Core.State
+  import ElixirSense.Log
+
   alias ElixirSense.Core.Ast
   alias ElixirSense.Core.BuiltinFunctions
   alias ElixirSense.Core.Introspection
@@ -54,7 +56,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
         fun.(ast, state)
       rescue
         exception ->
-          IO.warn(
+          warn(
             "#{inspect(exception.__struct__)} during metadata build: #{Exception.message(exception)}",
             __STACKTRACE__
           )

--- a/lib/elixir_sense/log.ex
+++ b/lib/elixir_sense/log.ex
@@ -2,67 +2,39 @@ defmodule ElixirSense.Log do
   @moduledoc """
   A simple logger for the project that allows it to be muted via application config
   """
+  require Logger
 
-  def info(message) do
-    info(:stdio, message, [])
+  def enabled? do
+    Application.get_env(:elixir_sense, :logging_enabled, true)
   end
 
-  def info(message, opts) when is_binary(message) and is_list(opts) do
-    info(:stdio, message, opts)
-  end
+  defmacro info(message) do
+    quote do
+      require Logger
 
-  def info(device, message) when is_atom(device) and is_binary(message) do
-    info(device, message, [])
-  end
-
-  def info(device, message, opts) do
-    log(device, message, Keyword.put_new(opts, :label, "info"))
-  end
-
-  def warn(message, stacktrace_info \\ nil) when is_binary(message) do
-    opts =
-      if is_nil(stacktrace_info) do
-        [logger_fn: fn _device, message -> IO.warn(message) end]
-      else
-        [logger_fn: fn _device, message -> IO.warn(message, stacktrace_info) end]
+      if ElixirSense.Log.enabled?() do
+        Logger.info(unquote(message))
       end
-
-    log(:stdio, message, opts)
-  end
-
-  def error(message) when is_binary(message) do
-    error(:stderr, message, [])
-  end
-
-  def error(message, opts) when is_binary(message) and is_list(opts) do
-    error(:stderr, message, opts)
-  end
-
-  def error(device, message) when is_atom(device) and is_binary(message) do
-    error(device, message, [])
-  end
-
-  def error(device, message, opts) do
-    log(device, message, Keyword.put_new(opts, :label, "error"))
-  end
-
-  def log(device \\ :stdio, message, opts \\ []) do
-    if Application.get_env(:elixir_sense, :logging_enabled, true) do
-      logger = Keyword.get(opts, :logger_fn, &IO.puts/2)
-      message = maybe_append_label(message, opts)
-      logger.(device, message)
     end
-
-    :ok
   end
 
-  defp maybe_append_label(message, opts) do
-    case Keyword.get(opts, :label) do
-      label_text when is_binary(label_text) ->
-        label_text <> ": " <> message
+  defmacro warn(message) do
+    quote do
+      require Logger
 
-      _ ->
-        message
+      if ElixirSense.Log.enabled?() do
+        Logger.warning(unquote(message))
+      end
+    end
+  end
+
+  defmacro error(message) when is_binary(message) do
+    quote do
+      require Logger
+
+      if ElixirSense.Log.enabled?() do
+        Logger.error(unquote(message))
+      end
     end
   end
 end

--- a/lib/elixir_sense/log.ex
+++ b/lib/elixir_sense/log.ex
@@ -1,0 +1,68 @@
+defmodule ElixirSense.Log do
+  @moduledoc """
+  A simple logger for the project that allows it to be muted via application config
+  """
+
+  def info(message) do
+    info(:stdio, message, [])
+  end
+
+  def info(message, opts) when is_binary(message) and is_list(opts) do
+    info(:stdio, message, opts)
+  end
+
+  def info(device, message) when is_atom(device) and is_binary(message) do
+    info(device, message, [])
+  end
+
+  def info(device, message, opts) do
+    log(device, message, Keyword.put_new(opts, :label, "info"))
+  end
+
+  def warn(message, stacktrace_info \\ nil) when is_binary(message) do
+    opts =
+      if is_nil(stacktrace_info) do
+        [logger_fn: fn _device, message -> IO.warn(message) end]
+      else
+        [logger_fn: fn _device, message -> IO.warn(message, stacktrace_info) end]
+      end
+
+    log(:stdio, message, opts)
+  end
+
+  def error(message) when is_binary(message) do
+    error(:stderr, message, [])
+  end
+
+  def error(message, opts) when is_binary(message) and is_list(opts) do
+    error(:stderr, message, opts)
+  end
+
+  def error(device, message) when is_atom(device) and is_binary(message) do
+    error(device, message, [])
+  end
+
+  def error(device, message, opts) do
+    log(device, message, Keyword.put_new(opts, :label, "error"))
+  end
+
+  def log(device \\ :stdio, message, opts \\ []) do
+    if Application.get_env(:elixir_sense, :logging_enabled, true) do
+      logger = Keyword.get(opts, :logger_fn, &IO.puts/2)
+      message = maybe_append_label(message, opts)
+      logger.(device, message)
+    end
+
+    :ok
+  end
+
+  defp maybe_append_label(message, opts) do
+    case Keyword.get(opts, :label) do
+      label_text when is_binary(label_text) ->
+        label_text <> ": " <> message
+
+      _ ->
+        message
+    end
+  end
+end

--- a/test/elixir_sense/log_test.exs
+++ b/test/elixir_sense/log_test.exs
@@ -1,0 +1,79 @@
+defmodule ElixirSense.LogTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+  import ElixirSense.Log
+
+  def with_logging_disabled(_) do
+    orig_value = Application.get_env(:elixir_sense, :logging_enabled)
+    Application.put_env(:elixir_sense, :logging_enabled, false)
+    on_exit(fn -> Application.put_env(:elixir_sense, :logging_enabled, orig_value) end)
+    :ok
+  end
+
+  describe "log messages" do
+    test "an info message has an info label by default" do
+      assert capture_io(fn -> info("good morning") end) == "info: good morning\n"
+    end
+
+    test "info supports adding a label" do
+      assert capture_io(fn -> info("good morning", label: "heya") end) == "heya: good morning\n"
+    end
+
+    test "info suppoerts changing the device" do
+      assert capture_io(:stderr, fn -> info(:stderr, "good morning") end)
+
+      assert capture_io(:stderr, fn -> info(:stderr, "good morning", label: "e") end) ==
+               "e: good morning\n"
+    end
+
+    test "an error message has an error label by default" do
+      assert capture_io(:stderr, fn -> error("good morning") end) == "error: good morning\n"
+    end
+
+    test "error supports adding a label" do
+      assert capture_io(:stderr, fn -> error("good morning", label: "heya") end) ==
+               "heya: good morning\n"
+    end
+
+    test "error suppoerts changing the device" do
+      assert capture_io(fn -> error(:stdio, "good morning") end)
+
+      assert capture_io(fn -> error(:stdio, "good morning", label: "e") end) ==
+               "e: good morning\n"
+    end
+
+    test "warn emits a stack trace by default" do
+      this_unit_test_path = Path.relative_to_cwd(__ENV__.file)
+      message = capture_io(:stderr, fn -> warn("did I do that?") end)
+
+      assert String.contains?(message, "did I do that?")
+      assert String.contains?(message, "warning: ")
+      assert String.contains?(message, "lib/elixir_sense/log.ex")
+      assert String.contains?(message, this_unit_test_path)
+    end
+
+    test "warn allows you to override the stack trace" do
+      message =
+        capture_io(:stderr, fn -> warn("finger wagging", line: 3, col: 8, file: "broken.ex") end)
+
+      assert String.contains?(message, "broken.ex:3")
+    end
+  end
+
+  describe "with logging disabled" do
+    setup [:with_logging_disabled]
+
+    test "info emits no output" do
+      assert capture_io(fn -> info("hello") end) == ""
+    end
+
+    test "warn emits no output" do
+      assert capture_io(fn -> warn("hello") end) == ""
+      assert capture_io(:stderr, fn -> warn("hello") end) == ""
+    end
+
+    test "error emits no output" do
+      assert capture_io(:stderr, fn -> error("hello") end) == ""
+    end
+  end
+end

--- a/test/elixir_sense/log_test.exs
+++ b/test/elixir_sense/log_test.exs
@@ -13,12 +13,14 @@ defmodule ElixirSense.LogTest do
   describe "log messages" do
     test "an info message has an info label by default" do
       message = assert capture_log(fn -> info("good morning") end)
-      assert message =~ "[info] good morning\n"
+      assert message =~ "[info] "
+      assert message =~ "good morning\n"
     end
 
     test "an error message has an error label by default" do
       message = assert capture_log(fn -> error("good morning") end)
-      assert message =~ "[error] good morning\n"
+      assert message =~ "[error] "
+      assert message =~ "good morning\n"
     end
   end
 

--- a/test/elixir_sense/log_test.exs
+++ b/test/elixir_sense/log_test.exs
@@ -1,6 +1,6 @@
 defmodule ElixirSense.LogTest do
   use ExUnit.Case
-  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
   import ElixirSense.Log
 
   def with_logging_disabled(_) do
@@ -12,51 +12,13 @@ defmodule ElixirSense.LogTest do
 
   describe "log messages" do
     test "an info message has an info label by default" do
-      assert capture_io(fn -> info("good morning") end) == "info: good morning\n"
-    end
-
-    test "info supports adding a label" do
-      assert capture_io(fn -> info("good morning", label: "heya") end) == "heya: good morning\n"
-    end
-
-    test "info suppoerts changing the device" do
-      assert capture_io(:stderr, fn -> info(:stderr, "good morning") end)
-
-      assert capture_io(:stderr, fn -> info(:stderr, "good morning", label: "e") end) ==
-               "e: good morning\n"
+      message = assert capture_log(fn -> info("good morning") end)
+      assert message =~ "[info] good morning\n"
     end
 
     test "an error message has an error label by default" do
-      assert capture_io(:stderr, fn -> error("good morning") end) == "error: good morning\n"
-    end
-
-    test "error supports adding a label" do
-      assert capture_io(:stderr, fn -> error("good morning", label: "heya") end) ==
-               "heya: good morning\n"
-    end
-
-    test "error suppoerts changing the device" do
-      assert capture_io(fn -> error(:stdio, "good morning") end)
-
-      assert capture_io(fn -> error(:stdio, "good morning", label: "e") end) ==
-               "e: good morning\n"
-    end
-
-    test "warn emits a stack trace by default" do
-      this_unit_test_path = Path.relative_to_cwd(__ENV__.file)
-      message = capture_io(:stderr, fn -> warn("did I do that?") end)
-
-      assert String.contains?(message, "did I do that?")
-      assert String.contains?(message, "warning: ")
-      assert String.contains?(message, "lib/elixir_sense/log.ex")
-      assert String.contains?(message, this_unit_test_path)
-    end
-
-    test "warn allows you to override the stack trace" do
-      message =
-        capture_io(:stderr, fn -> warn("finger wagging", line: 3, col: 8, file: "broken.ex") end)
-
-      assert String.contains?(message, "broken.ex:3")
+      message = assert capture_log(fn -> error("good morning") end)
+      assert message =~ "[error] good morning\n"
     end
   end
 
@@ -64,16 +26,16 @@ defmodule ElixirSense.LogTest do
     setup [:with_logging_disabled]
 
     test "info emits no output" do
-      assert capture_io(fn -> info("hello") end) == ""
+      assert capture_log(fn -> info("hello") end) == ""
     end
 
     test "warn emits no output" do
-      assert capture_io(fn -> warn("hello") end) == ""
-      assert capture_io(:stderr, fn -> warn("hello") end) == ""
+      assert capture_log(fn -> warn("hello") end) == ""
+      assert capture_log(fn -> warn("hello") end) == ""
     end
 
     test "error emits no output" do
-      assert capture_io(:stderr, fn -> error("hello") end) == ""
+      assert capture_log(fn -> error("hello") end) == ""
     end
   end
 end


### PR DESCRIPTION
While using elixir-ls, frequently, the code that's sent to the LSP server (and then to elixir_sense) isn't always syntactically accurate, and sometimes elixir_sense will fail and spam the logs. After enough of these spammy logs, emacs throws the error into a mini-buffer to alert the user to some problem, which is not particularly helpful.

Emitting an error message in these circumstances is dubious, since there's nothing truly wrong, but I can understand that it might be helpful for other uses of elixir_ls. To that end, I consolidated the logging functions into a module and gated them with an application variable so that other apps can enable or disable logging at their discretion.