### PR TITLE
allow for plugins not using the ElixirSense.Plugin `@behaviour`

### DIFF
--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -49,7 +49,7 @@ defmodule ElixirSense.Core.ModuleStore do
 
   defp is_plugin?(module) do
     module.module_info(:attributes)
-    |> Enum.flat_map(fn
+    |> Enum.any?(fn
       {:behaviour, behaviours} when is_list(behaviours) ->
         ElixirSense.Plugin in behaviours
 

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -2,9 +2,13 @@ defmodule ElixirSense.Core.ModuleStore do
   @moduledoc """
   Caches the module list and a list of modules keyed by the behaviour they implement.
   """
-  defstruct by_behaviour: %{}, list: []
+  defstruct by_behaviour: %{}, list: [], plugins: []
 
-  @type t :: %__MODULE__{by_behaviour: %{optional(atom) => module}, list: list(module)}
+  @type t :: %__MODULE__{
+          by_behaviour: %{optional(atom) => module},
+          list: list(module),
+          plugins: []
+        }
 
   alias ElixirSense.Core.Applications
 
@@ -20,6 +24,13 @@ defmodule ElixirSense.Core.ModuleStore do
       try do
         module_store = %{module_store | list: [module | module_store.list]}
 
+        module_store =
+          if is_plugin?(module) do
+            %{module_store | plugins: [module | module_store.plugins]}
+          else
+            module_store
+          end
+
         module.module_info(:attributes)
         |> Enum.flat_map(fn
           {:behaviour, behaviours} when is_list(behaviours) ->
@@ -33,6 +44,20 @@ defmodule ElixirSense.Core.ModuleStore do
         _ ->
           module_store
       end
+    end)
+  end
+
+  defp is_plugin?(module) do
+    module.module_info(:attributes)
+    |> Enum.flat_map(fn
+      {:behaviour, behaviours} when is_list(behaviours) ->
+        ElixirSense.Plugin in behaviours
+
+      {:is_elixir_sense_plugin, true} ->
+        true
+
+      _ ->
+        false
     end)
   end
 

--- a/lib/elixir_sense/core/module_store.ex
+++ b/lib/elixir_sense/core/module_store.ex
@@ -7,7 +7,7 @@ defmodule ElixirSense.Core.ModuleStore do
   @type t :: %__MODULE__{
           by_behaviour: %{optional(atom) => module},
           list: list(module),
-          plugins: []
+          plugins: list(module)
         }
 
   alias ElixirSense.Core.Applications

--- a/lib/elixir_sense/providers/suggestion.ex
+++ b/lib/elixir_sense/providers/suggestion.ex
@@ -106,9 +106,14 @@ defmodule ElixirSense.Providers.Suggestion do
   """
   @spec find(String.t(), State.Env.t(), Metadata.t(), cursor_context, ModuleStore.t(), keyword()) ::
           [suggestion()]
-  def find(hint, env, buffer_metadata, cursor_context, module_store, opts \\ []) do
-    plugins = module_store.by_behaviour[ElixirSense.Plugin] || []
-
+  def find(
+        hint,
+        env,
+        buffer_metadata,
+        cursor_context,
+        %{plugins: plugins} = module_store,
+        opts \\ []
+      ) do
     reducers =
       plugins
       |> Enum.filter(&function_exported?(&1, :reduce, 5))


### PR DESCRIPTION
So the problem with the existing implementation of plugins that live outside of ElixirSense (a problem that I created 😄 ) is that, unless you want your external hex package to have an explicit dependency on `elixir_sense`, you're going to have to do something like this:

```elixir
{:elixir_sense, ..., only: [:dev, :test]}
```

And then in your code that defines the plugin, you'll need to do something like:
```elixir
if Code.ensure_compiled?(ElixirSense.Plugin) do
  defmodule MyApp.Plugin do
  
  end
end
```
If you don't do that, then users who use your plugin *without* including `{:elixir_sense, ...}` as a dev dependency will get errors.

*BUT* then you run into the issue that if they don't include `{:elixir_sense, ...}` as a dev dependency, then the plugin won't be compiled at all, and so elixir_sense won't know about it.

This became an especially big problem when elixir_sense updated and a bunch of new ash users that were pointing at `elixir_sense` on github got that new update, but that update was not compatible with the version of `elixir_ls` that they were running. And so elixir_ls broke for all of them (and will break for any new user who follows the current getting started guide).

It is an unfortunate set of circumstances, and as far as I can tell there is really only two ways it can work and still be a good experience for end users:

1. plugins can live in `elixir_sense`. This is great for really popular things like the ecto plugin, but personally I think it stifles creativity/velocity for other people who want to experiment with these things. Maybe thats only me, for now, but eventually I think it won't be

2. plugin authors can do some hacky/annoying stuff to not have a dependency on ElixirSense, but to also not conditionally compile on its presence. Things like changing `ElixirSense.Plugin.foo(bar)` to `apply(ElixirSense.Plugin, :foo, [bar])`. Additionally, to avoid warnings on missing `@behaviour` modules, we have to make them findable without adopting the behaviour.

For an example of what this looks like for Ash (well, technically for Spark), you can see the PR that would make this work: 
https://github.com/ash-project/spark/pull/5/files

Its naturally not ideal for me to have to code the plugin this way, but this is very much preferrable to the alternative of requiring users to pin a specific version of elixir_sense, IMO.