### PR TITLE
Find definition to respect function arity

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -111,6 +111,8 @@ defmodule ElixirSense do
 
         Definition.find(
           subject,
+          line,
+          column,
           env,
           buffer_file_metadata.mods_funs_to_positions,
           calls,

--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -112,7 +112,6 @@ defmodule ElixirSense do
         Definition.find(
           subject,
           line,
-          column,
           env,
           buffer_file_metadata.mods_funs_to_positions,
           calls,

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -21,7 +21,6 @@ defmodule ElixirSense.Providers.Definition do
   @spec find(
           String.t(),
           pos_integer,
-          pos_integer,
           State.Env.t(),
           State.mods_funs_to_positions_t(),
           list(State.CallInfo.t()),
@@ -30,7 +29,6 @@ defmodule ElixirSense.Providers.Definition do
   def find(
         subject,
         line,
-        column,
         %State.Env{
           aliases: aliases,
           module: module,

--- a/lib/elixir_sense/providers/definition.ex
+++ b/lib/elixir_sense/providers/definition.ex
@@ -210,7 +210,6 @@ defmodule ElixirSense.Providers.Definition do
       {mod, fun, true} ->
         fn_definition = find_fn_definition(mod, fun, line, mods_funs_to_positions, calls)
 
-        # TODO: Figure out why tests fail when I remove the mods_funs_to_positions thing below
         case fn_definition || mods_funs_to_positions[{mod, fun, nil}] ||
                metadata_types[{mod, fun, nil}] do
           nil ->

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -161,15 +161,13 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       def main, do: my_func("a", "b")
-      def main2, do: my_func("a", "b")
-      def main3, do: my_func()
       #               ^ 
       def my_func, do: "not this one"
       def my_func(a, b), do: a <> b
     end
     """
 
-    assert %Location{type: :function, file: nil, line: 7, column: 7} =
+    assert %Location{type: :function, file: nil, line: 5, column: 7} =
              ElixirSense.definition(buffer, 2, 18)
   end
 

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -157,6 +157,34 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert read_line(file, {line, column}) =~ "ElixirSenseExample.Macros.go"
   end
 
+  test "find definition for the correct arity of function - on fn call" do
+    buffer = """
+    defmodule MyModule do
+      def main, do: my_func("a", "b")
+      def main2, do: my_func("a", "b")
+      def main3, do: my_func()
+      #               ^ 
+      def my_func, do: "not this one"
+      def my_func(a, b), do: a <> b
+    end
+    """
+
+    assert %Location{type: :function, file: nil, line: 7, column: 7} =
+             ElixirSense.definition(buffer, 2, 18)
+  end
+
+  test "find definition for the correct arity of function - on fn definition" do
+    buffer = """
+    defmodule MyModule do
+      def my_func, do: "not this one"
+      def my_func(a, b), do: a <> b
+    end
+    """
+
+    assert %Location{type: :function, file: nil, line: 3, column: 7} =
+             ElixirSense.definition(buffer, 3, 9)
+  end
+
   test "find definition of delegated functions" do
     buffer = """
     defmodule MyModule do


### PR DESCRIPTION
Previously find definition did not respect the arity of functions - it would just take you to the first matching function header.

This PR aims to make it respect the arity of functions when going to the definition