### PR TITLE
Fix variable references

### DIFF
--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -815,6 +815,10 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_block_keyword(ast, state)
   end
 
+  defp pre({:->, meta, [[{:when, _, [_var, guards]} = lhs], rhs]}, state) do
+    pre_clause({:->, meta, [guards, rhs]}, state, lhs)
+  end
+
   defp pre({:->, meta, [[lhs], rhs]}, state) do
     pre_clause({:->, meta, [:_, rhs]}, state, lhs)
   end

--- a/lib/elixir_sense/core/metadata_builder.ex
+++ b/lib/elixir_sense/core/metadata_builder.ex
@@ -207,6 +207,11 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   defp pre_func({type, _, _} = ast, state, %{line: line, col: col}, name, params, options \\ [])
        when is_atom(name) do
+    vars =
+      state
+      |> find_vars(params)
+      |> merge_same_name_vars()
+
     state
     |> new_named_func(name, length(params || []))
     |> add_func_to_index(name, params || [], {line, col}, type, options)
@@ -214,7 +219,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> new_import_scope
     |> new_require_scope
     |> new_func_vars_scope
-    |> add_vars(find_vars(state, params), true)
+    |> add_vars(vars, true)
     |> add_current_env_to_line(line)
     |> result(ast)
   end
@@ -256,6 +261,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
       end
 
     state
+    |> maybe_move_vars_to_outer_scope
     |> remove_vars_scope
     |> result(ast)
   end
@@ -292,17 +298,23 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> remove_alias_scope
     |> remove_import_scope
     |> remove_require_scope
+    |> maybe_move_vars_to_outer_scope
     |> remove_vars_scope
     |> result(ast)
   end
 
   defp pre_clause({_clause, [line: line, column: _column], _} = ast, state, lhs) do
+    vars =
+      state
+      |> find_vars(lhs, Enum.at(state.binding_context, 0))
+      |> merge_same_name_vars()
+
     state
     |> new_alias_scope
     |> new_import_scope
     |> new_require_scope
     |> new_vars_scope
-    |> add_vars(find_vars(state, lhs, Enum.at(state.binding_context, 0)), true)
+    |> add_vars(vars, true)
     |> add_current_env_to_line(line)
     |> result(ast)
   end
@@ -312,6 +324,7 @@ defmodule ElixirSense.Core.MetadataBuilder do
     |> remove_alias_scope
     |> remove_import_scope
     |> remove_require_scope
+    |> maybe_move_vars_to_outer_scope
     |> remove_vars_scope
     |> result(ast)
   end
@@ -474,8 +487,15 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_func(ast_without_params, state, %{line: line, col: column}, name, params, options)
   end
 
-  defp pre({def_name, meta, [{:when, _, [head | _]}, body]}, state) when def_name in @defs do
-    pre({def_name, meta, [head, body]}, state)
+  # function head with guards
+  defp pre(
+         {def_name, meta,
+          [{:when, _, [{name, [line: line, column: column] = meta2, params}, guards]}, body]},
+         state
+       )
+       when def_name in @defs do
+    ast_without_params = {def_name, meta, [{name, add_no_call(meta2), []}, guards, body]}
+    pre_func(ast_without_params, state, %{line: line, col: column}, name, params)
   end
 
   defp pre(
@@ -803,55 +823,37 @@ defmodule ElixirSense.Core.MetadataBuilder do
     pre_clause({:->, meta, [:_, rhs]}, state, lhs)
   end
 
-  defp pre({atom, [line: line, column: _column] = meta, [lhs, rhs]}, state)
+  defp pre({atom, [line: _line, column: _column] = meta, [lhs, rhs]}, state)
        when atom in [:=, :<-] do
-    match_context_r = get_binding_type(state, rhs)
-
-    match_context_r =
-      if atom == :<- and match?([:for | _], state.binding_context) do
-        {:for_expression, match_context_r}
-      else
-        match_context_r
-      end
-
-    vars_l = find_vars(state, lhs, match_context_r)
-
-    vars =
-      case rhs do
-        {:=, _, [nested_lhs, _nested_rhs]} ->
-          match_context_l = get_binding_type(state, lhs)
-          nested_vars = find_vars(state, nested_lhs, match_context_l)
-
-          vars_l ++ nested_vars
-
-        _ ->
-          vars_l
-      end
-
-    state
-    |> add_vars(vars, true)
-    |> add_current_env_to_line(line)
-    |> result({:=, meta, [:_, rhs]})
+    result(state, {atom, meta, [lhs, rhs]})
   end
 
   defp pre({var_or_call, [line: line, column: column], nil} = ast, state)
        when is_atom(var_or_call) and var_or_call != :__MODULE__ do
     if Enum.any?(get_current_vars(state), &(&1.name == var_or_call)) do
-      state
-      |> add_vars(find_vars(state, ast), false)
+      vars =
+        state
+        |> find_vars(ast)
+        |> merge_same_name_vars()
+
+      add_vars(state, vars, false)
     else
       # pre Elixir 1.4 local call syntax
       # TODO remove on Elixir 2.0
-      state
-      |> add_call_to_line({nil, var_or_call, 0}, {line, column})
-      |> add_current_env_to_line(line)
+      add_call_to_line(state, {nil, var_or_call, 0}, {line, column})
     end
+    |> add_current_env_to_line(line)
     |> result(ast)
   end
 
   defp pre({:when, meta, [lhs, rhs]}, state) do
+    vars =
+      state
+      |> find_vars(lhs)
+      |> merge_same_name_vars()
+
     state
-    |> add_vars(find_vars(state, lhs), true)
+    |> add_vars(vars, true)
     |> result({:when, meta, [:_, rhs]})
   end
 
@@ -1223,6 +1225,14 @@ defmodule ElixirSense.Core.MetadataBuilder do
     post_func(ast, state)
   end
 
+  defp post(
+         {def_name, [line: _line, column: _column], [{name, _, _params}, _guards, _]} = ast,
+         state
+       )
+       when def_name in @defs and is_atom(name) do
+    post_func(ast, state)
+  end
+
   defp post({def_name, _, _} = ast, state) when def_name in @defs do
     {ast, state}
   end
@@ -1252,6 +1262,44 @@ defmodule ElixirSense.Core.MetadataBuilder do
 
   defp post({:->, [line: _line, column: _column], [_lhs, _rhs]} = ast, state) do
     post_clause(ast, state)
+  end
+
+  defp post({atom, [line: line, column: _column], [lhs, rhs]} = ast, state)
+       when atom in [:=, :<-] do
+    match_context_r = get_binding_type(state, rhs)
+
+    match_context_r =
+      if atom == :<- and match?([:for | _], state.binding_context) do
+        {:for_expression, match_context_r}
+      else
+        match_context_r
+      end
+
+    vars_l = find_vars(state, lhs, match_context_r)
+
+    vars =
+      case rhs do
+        {:=, _, [nested_lhs, _nested_rhs]} ->
+          match_context_l = get_binding_type(state, lhs)
+          nested_vars = find_vars(state, nested_lhs, match_context_l)
+
+          vars_l ++ nested_vars
+
+        _ ->
+          vars_l
+      end
+      |> merge_same_name_vars()
+
+    # Variables and calls were added for the left side of the assignment in `pre` call, but without
+    # the context of an assignment. Thus, they have to be removed here. On their place there will
+    # be added new variables having types merged with types of corresponding deleted variables.
+    remove_positions = Enum.flat_map(vars, fn %VarInfo{positions: positions} -> positions end)
+
+    state
+    |> remove_calls(remove_positions)
+    |> merge_new_vars(vars, remove_positions)
+    |> add_current_env_to_line(line)
+    |> result(ast)
   end
 
   # String literal

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -395,7 +395,7 @@ defmodule ElixirSense.Core.Source do
   end
 
   defp find_subject(grapheme, rest, line, col, %{pos_found: false, line: line, col: col} = acc) do
-    find_subject(grapheme, rest, line, col, %{acc | pos_found: true})
+    find_subject(grapheme, rest, line, col, %{acc | pos: {line, col - 1}, pos_found: true})
   end
 
   defp find_subject("." = grapheme, rest, _line, _col, %{pos_found: false} = acc) do

--- a/lib/elixir_sense/providers/references.ex
+++ b/lib/elixir_sense/providers/references.ex
@@ -27,6 +27,8 @@ defmodule ElixirSense.Providers.References do
   @spec find(
           String.t(),
           non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
           State.Env.t(),
           [VarInfo.t()],
           [AttributeInfo.t()],
@@ -35,6 +37,8 @@ defmodule ElixirSense.Providers.References do
         ) :: [ElixirSense.Providers.References.reference_info()]
   def find(
         subject,
+        line,
+        column,
         arity,
         %State.Env{
           imports: imports,
@@ -51,7 +55,10 @@ defmodule ElixirSense.Providers.References do
         },
         trace
       ) do
-    var_info = vars |> Enum.find(fn %VarInfo{name: name} -> to_string(name) == subject end)
+    var_info =
+      Enum.find(vars, fn %VarInfo{name: name, positions: positions} ->
+        to_string(name) == subject and {line, column} in positions
+      end)
 
     attribute_info =
       case subject do

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -161,7 +161,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       def main, do: my_func("a", "b")
-      #               ^ 
+      #               ^
       def my_func, do: "not this one"
       def my_func(a, b), do: a <> b
     end
@@ -408,7 +408,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert ElixirSense.definition(buffer, 6, 13) == %Location{
              type: :variable,
              file: nil,
-             line: 3,
+             line: 5,
              column: 5
            }
 
@@ -424,7 +424,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       def func do
-        var1 = 
+        var1 =
           1
       end
     end
@@ -514,6 +514,156 @@ defmodule ElixirSense.Providers.DefinitionTest do
              type: :variable,
              file: nil,
              line: 5,
+             column: 5
+           }
+  end
+
+  test "find definition for a redefined variable" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(var) do
+        var = 1 + var
+
+        var
+      end
+    end
+    """
+
+    # `var` defined in the function header
+    assert ElixirSense.definition(buffer, 3, 15) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 14
+           }
+
+    # `var` redefined in the function body
+    assert ElixirSense.definition(buffer, 5, 5) == %Location{
+             type: :variable,
+             file: nil,
+             line: 3,
+             column: 5
+           }
+  end
+
+  test "find definition of a variable in a guard" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(var) when is_atom(var) do
+        var
+      end
+    end
+    """
+
+    assert ElixirSense.definition(buffer, 2, 32) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 14
+           }
+
+    assert ElixirSense.definition(buffer, 3, 5) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 14
+           }
+  end
+
+  test "find definition of variables when variable is a function parameter" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun([h | t]) do
+        sum = h + my_fun(t)
+
+        if h > sum do
+          h + sum
+        else
+          h = my_fun(t) + sum
+          h
+        end
+      end
+    end
+    """
+
+    # `h` from the function header
+    assert ElixirSense.definition(buffer, 3, 11) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 15
+           }
+
+    assert ElixirSense.definition(buffer, 6, 7) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 15
+           }
+
+    # `h` from the if-else scope
+    assert ElixirSense.definition(buffer, 9, 7) == %Location{
+             type: :variable,
+             file: nil,
+             line: 8,
+             column: 7
+           }
+
+    # `t`
+    assert ElixirSense.definition(buffer, 8, 18) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 19
+           }
+
+    # `sum`
+    assert ElixirSense.definition(buffer, 8, 23) == %Location{
+             type: :variable,
+             file: nil,
+             line: 3,
+             column: 5
+           }
+  end
+
+  test "find definition of variables from the scope of an anonymous function" do
+    buffer = """
+    defmodule MyModule do
+      def my_fun(x, y) do
+        x = Enum.map(x, fn x -> x + y end)
+      end
+    end
+    """
+
+    # `x` from the `my_fun` function header
+    assert ElixirSense.definition(buffer, 3, 18) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 14
+           }
+
+    # `y` from the `my_fun` function header
+    assert ElixirSense.definition(buffer, 3, 33) == %Location{
+             type: :variable,
+             file: nil,
+             line: 2,
+             column: 17
+           }
+
+    # `x` from the anonymous function
+    assert ElixirSense.definition(buffer, 3, 29) == %Location{
+             type: :variable,
+             file: nil,
+             line: 3,
+             column: 24
+           }
+
+    # redefined `x`
+    assert ElixirSense.definition(buffer, 3, 5) == %Location{
+             type: :variable,
+             file: nil,
+             line: 3,
              column: 5
            }
   end

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -550,7 +550,11 @@ defmodule ElixirSense.Providers.DefinitionTest do
     buffer = """
     defmodule MyModule do
       def my_fun(var) when is_atom(var) do
-        var
+        case var do
+          var when var > 0 -> var
+        end
+
+        Enum.map([1, 2], fn x when x > 0 -> x end)
       end
     end
     """
@@ -562,11 +566,18 @@ defmodule ElixirSense.Providers.DefinitionTest do
              column: 14
            }
 
-    assert ElixirSense.definition(buffer, 3, 5) == %Location{
+    assert ElixirSense.definition(buffer, 4, 16) == %Location{
              type: :variable,
              file: nil,
-             line: 2,
-             column: 14
+             line: 4,
+             column: 7
+           }
+
+    assert ElixirSense.definition(buffer, 7, 32) == %Location{
+             type: :variable,
+             file: nil,
+             line: 7,
+             column: 25
            }
   end
 

--- a/test/elixir_sense/references_test.exs
+++ b/test/elixir_sense/references_test.exs
@@ -793,20 +793,47 @@ defmodule ElixirSense.Providers.ReferencesTest do
     buffer = """
     defmodule MyModule do
       def my_fun(var) when is_atom(var) do
-        var
+        case var do
+          var when var > 0 -> var
+        end
+
+        Enum.map([1, 2], fn x when x > 0 -> x end)
       end
     end
     """
 
+    # `var` defined in the function header
     expected_references = [
       %{uri: nil, range: %{start: %{line: 2, column: 14}, end: %{line: 2, column: 17}}},
       %{uri: nil, range: %{start: %{line: 2, column: 32}, end: %{line: 2, column: 35}}},
-      %{uri: nil, range: %{start: %{line: 3, column: 5}, end: %{line: 3, column: 8}}}
+      %{uri: nil, range: %{start: %{line: 3, column: 10}, end: %{line: 3, column: 13}}}
     ]
 
     assert ElixirSense.references(buffer, 2, 14, trace) == expected_references
     assert ElixirSense.references(buffer, 2, 32, trace) == expected_references
-    assert ElixirSense.references(buffer, 3, 5, trace) == expected_references
+    assert ElixirSense.references(buffer, 3, 10, trace) == expected_references
+
+    # `var` defined in the case clause
+    expected_references = [
+      %{uri: nil, range: %{start: %{line: 4, column: 7}, end: %{line: 4, column: 10}}},
+      %{uri: nil, range: %{start: %{line: 4, column: 16}, end: %{line: 4, column: 19}}},
+      %{uri: nil, range: %{start: %{line: 4, column: 27}, end: %{line: 4, column: 30}}}
+    ]
+
+    assert ElixirSense.references(buffer, 4, 7, trace) == expected_references
+    assert ElixirSense.references(buffer, 4, 16, trace) == expected_references
+    assert ElixirSense.references(buffer, 4, 27, trace) == expected_references
+
+    # `x`
+    expected_references = [
+      %{uri: nil, range: %{start: %{line: 7, column: 25}, end: %{line: 7, column: 26}}},
+      %{uri: nil, range: %{start: %{line: 7, column: 32}, end: %{line: 7, column: 33}}},
+      %{uri: nil, range: %{start: %{line: 7, column: 41}, end: %{line: 7, column: 42}}}
+    ]
+
+    assert ElixirSense.references(buffer, 7, 25, trace) == expected_references
+    assert ElixirSense.references(buffer, 7, 32, trace) == expected_references
+    assert ElixirSense.references(buffer, 7, 41, trace) == expected_references
   end
 
   test "find references for variable in inner scopes", %{trace: trace} do

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -1295,10 +1295,7 @@ defmodule ElixirSense.SuggestionsTest do
 
     assert_received {:result, list}
 
-    assert list == [
-             %{name: "arg", type: :variable},
-             %{name: "my", type: :variable}
-           ]
+    assert list == [%{name: "arg", type: :variable}]
   end
 
   test "lists params in fn's not finished" do


### PR DESCRIPTION
I've made an attempt to fix the reference provider ([Issue #124](https://github.com/elixir-lsp/elixir_sense/issues/124)). I've described part of the changes below since they needed to be applied in several places.  After that, the provider should cover many cases that are handled incorrectly in the current implementation. 

---

### 1. A new scope for a function
`State.new_func_vars_scope` had a different behavior than `State.new_vars_scope` - the first one didn't increase the scope counter what I've changed. Previously all variables from all function headers were in the same scope. Now, it is changed and every function creates two new scopes:
- one for the function header
- one for the function body (to avoid handling `do ... end` differently for the functions; this part was already there)

### 2. Preserving variables when leaving a scope
I created a new function `State.maybe_move_vars_to_outer_scope`. It is called in these three places:
- `MetadataBuilder.post_scope_keyword` - after processing `:for`, `:fn` and `:with` keywords
- `MetadataBuilder.post_block_keyword` - after processing `:do`, `:else`, `:rescue`, `:catch` and `:after` keywords
- `MetadataBuilder.post_clause` - after processing `->`

so whenever a scope is deleted and it may be needed to move part of the variables to the outer scope to extract all the references later. The function takes all variables in the scope we are deleting, filters out the ones that were defined inside the scope, and puts the rest of them into the outer scope.

### 3. Vars info per scope id
Calculating `vars_info_per_scope_id` field in the `State` struct needed to be changed to keep all variables that are not only defined, but also available in the particular scope. Thus, it was needed to consider all outer scopes during the update of  `vars_info_per_scope_id` field.

### 4. Redefining variables
Variables defined in different scopes must be treated as different ones. E.g.
```elixir
def my_func do
  x = 1
  if x  == 1 do
     x = 2
  end
  x # here x is still equal to 1
end
```

To make it more consistent I decided to extend the above to treat every reassignment as creating a new variable. E.g.

```elixir
def my_func(x) do
  x = 1 + x # variables in this line are treated as different ones
  x # definition of this variable is in the line right above
end
```

Also, if we consider renaming based on references, we may obtain a tool more powerful than using just regex. 

This required differentiating between variables with the same names so in many places variables started to be differentiated by their positions. This propagated to `ElixirSense.Providers.References.find` and `ElixirSense.Providers.Definition.find` functions - finding proper definitions and references required checking the position of the variable as well. That led to extending the parameters of these functions by a line and a column.

### 5. Assignments
Since we can have many variables with the same name, I rely on their order in `vars` and `scope_vars` fields in the `State` struct. The variables are "reduced" by merging the ones with the same name until getting one with `is_definition: true`. Then, the next occurrence of a variable with the same name will be treated as a separate variable. Reduction is done from the newest to the oldest occurrences of variables. However, in the case of the assignments (`:=` and `:<-`), we want to add a new definition of the variable **after** processing the statement. Let's consider an example:

```elixir
def my_func(x) do
  x = 1 + x
end
```

We don't want to treat the first `x` in the second line as the definition of the second `x` in that line. Thus, I moved processing the left side of assignments to the `post` function.

### 6. Guards
Previously guards were omitted in the AST traversal so variables in them were not tracked. I've changed that.

---

### TODO
The pin operator (`^`) is not taken into consideration so variables can be wrongly marked as definitions. E.g.
```elixir
def my_fun(a, b) do
  case a do
    ^b -> b
  end
end
```
variable `b` will be treated as redefined in the case clause, but in fact, it is the same unchanged variable as the one defined in the function header. I suggest fixing it in a follow-up PR.

---

I'm ready to work more on that in case I omitted or broke something, so I'm waiting for the feedback.