### PR TITLE
Struct field typespecs

### DIFF
--- a/lib/elixir_sense/core/type_info.ex
+++ b/lib/elixir_sense/core/type_info.ex
@@ -700,7 +700,7 @@ defmodule ElixirSense.Core.TypeInfo do
     end
     |> Enum.map(fn arg ->
       case arg do
-        {:"::", _, [left, right]} -> left
+        {:"::", _, [left, _right]} -> left
         other -> other
       end
       |> Macro.to_string()

--- a/lib/elixir_sense/providers/suggestion/reducers/struct.ex
+++ b/lib/elixir_sense/providers/suggestion/reducers/struct.ex
@@ -194,4 +194,6 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Struct do
   defp get_fields_from_struct_spec({:"::", _, [_, {:%, _meta1, [_mod, {:%{}, _meta2, fields}]}]}) do
     Map.new(fields)
   end
+
+  defp get_fields_from_struct_spec(_), do: %{}
 end

--- a/lib/elixir_sense/providers/suggestion/reducers/struct.ex
+++ b/lib/elixir_sense/providers/suggestion/reducers/struct.ex
@@ -8,12 +8,16 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Struct do
   alias ElixirSense.Core.State
   alias ElixirSense.Providers.Suggestion.Matcher
 
+  alias ElixirSense.Core.Normalized.Typespec
+  alias ElixirSense.Core.TypeInfo
+
   @type field :: %{
           type: :field,
           subtype: :struct_field | :map_key,
           name: String.t(),
           origin: String.t() | nil,
-          call?: boolean
+          call?: boolean,
+          type_spec: String.t() | nil
         }
 
   @doc """
@@ -76,13 +80,13 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Struct do
 
         type = Binding.expand(env, {:struct, [], type, var})
 
-        result = get_fields(type, hint, fields_so_far)
+        result = get_fields(env, type, hint, fields_so_far)
         {result, if(fields_so_far == [], do: :maybe_struct_update)}
 
       {:map, fields_so_far, var} ->
         var = Binding.expand(env, var)
 
-        result = get_fields(var, hint, fields_so_far)
+        result = get_fields(env, var, hint, fields_so_far)
         {result, if(fields_so_far == [], do: :maybe_struct_update)}
 
       _ ->
@@ -90,29 +94,104 @@ defmodule ElixirSense.Providers.Suggestion.Reducers.Struct do
     end
   end
 
-  defp get_fields({:map, fields, _}, hint, fields_so_far) do
-    expand_map_field_access(fields, hint, :map, fields_so_far)
+  defp get_fields(env, {:map, fields, _}, hint, fields_so_far) do
+    expand_map_field_access(env, fields, hint, :map, fields_so_far)
   end
 
-  defp get_fields({:struct, fields, type, _}, hint, fields_so_far) do
-    expand_map_field_access(fields, hint, {:struct, type}, fields_so_far)
+  defp get_fields(env, {:struct, fields, type, _}, hint, fields_so_far) do
+    expand_map_field_access(env, fields, hint, {:struct, type}, fields_so_far)
   end
 
-  defp get_fields(_, _hint, _fields_so_far), do: []
+  defp get_fields(_, _, _hint, _fields_so_far), do: []
 
-  defp expand_map_field_access(fields, hint, type, fields_so_far) do
-    {subtype, origin} =
+  defp expand_map_field_access(env, fields, hint, type, fields_so_far) do
+    {subtype, origin, types} =
       case type do
-        {:struct, mod} -> {:struct_field, if(mod, do: inspect(mod))}
-        :map -> {:map_key, nil}
+        {:struct, mod} ->
+          types = get_field_types(env, mod, true)
+
+          {:struct_field, if(mod, do: inspect(mod)), types}
+
+        :map ->
+          {:map_key, nil, %{}}
       end
 
     for {key, _value} when is_atom(key) <- fields,
         key not in fields_so_far,
-        key = Atom.to_string(key),
-        Matcher.match?(key, hint) do
-      %{type: :field, name: key, subtype: subtype, origin: origin, call?: false}
+        key_str = Atom.to_string(key),
+        Matcher.match?(key_str, hint) do
+      spec =
+        case types[key] do
+          nil ->
+            case key do
+              :__struct__ -> origin || "atom()"
+              :__exception__ -> "true"
+              _ -> nil
+            end
+
+          some ->
+            Macro.to_string(some)
+        end
+
+      %{
+        type: :field,
+        name: key_str,
+        subtype: subtype,
+        origin: origin,
+        call?: false,
+        type_spec: spec
+      }
     end
     |> Enum.sort_by(& &1.name)
+  end
+
+  def get_field_types(env, mod, include_private) do
+    case get_field_types_from_metadata(env, mod, include_private) do
+      nil -> get_field_types_from_introspection(mod, include_private)
+      res -> res
+    end
+  end
+
+  defguardp type_is_public(kind, include_private) when kind == :type or include_private
+
+  defp get_field_types_from_metadata(
+         %{types: types},
+         mod,
+         include_private
+       ) do
+    case types[{mod, :t, 0}] do
+      %State.TypeInfo{specs: [type_spec], kind: kind}
+      when type_is_public(kind, include_private) ->
+        case Code.string_to_quoted(type_spec) do
+          {:ok, {:@, _, [{_kind, _, [spec]}]}} ->
+            spec
+            |> get_fields_from_struct_spec()
+
+          _ ->
+            nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp get_field_types_from_introspection(nil, _include_private), do: %{}
+
+  defp get_field_types_from_introspection(mod, include_private) do
+    # assume struct typespec is t()
+    case TypeInfo.get_type_spec(mod, :t, 0) do
+      {kind, spec} when type_is_public(kind, include_private) ->
+        spec
+        |> Typespec.type_to_quoted()
+        |> get_fields_from_struct_spec()
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp get_fields_from_struct_spec({:"::", _, [_, {:%, _meta1, [_mod, {:%{}, _meta2, fields}]}]}) do
+    Map.new(fields)
   end
 end

--- a/test/elixir_sense/providers/suggestion/complete_test.exs
+++ b/test/elixir_sense/providers/suggestion/complete_test.exs
@@ -458,26 +458,145 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
     }
 
     assert expand('map.f', env) ==
-             [%{name: "foo", subtype: :map_key, type: :field, origin: nil, call?: true}]
+             [
+               %{
+                 name: "foo",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
+             ]
 
     assert [_ | _] = expand('map.b', env)
 
     assert expand('map.bar_', env) ==
              [
-               %{name: "bar_1", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "bar_2", subtype: :map_key, type: :field, origin: nil, call?: true}
+               %{
+                 name: "bar_1",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "bar_2",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
              ]
 
     assert expand('map.c', env) == []
 
     assert expand('map.', env) ==
              [
-               %{name: "bar_1", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "bar_2", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "foo", subtype: :map_key, type: :field, origin: nil, call?: true}
+               %{
+                 name: "bar_1",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "bar_2",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "foo",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
              ]
 
-    assert expand('map.foo', env) == []
+    assert expand('map.foo', env) == [
+             %{
+               call?: true,
+               name: "foo",
+               origin: nil,
+               subtype: :map_key,
+               type: :field,
+               type_spec: nil
+             }
+           ]
+  end
+
+  test "struct key completion is supported" do
+    env = %Env{
+      types: %{
+        {MyStruct, :t, 0} => %ElixirSense.Core.State.TypeInfo{
+          name: :t,
+          args: [[]],
+          specs: ["@type t :: %MyStruct{some: integer}"],
+          kind: :type
+        }
+      },
+      structs: %{
+        MyStruct => %ElixirSense.Core.State.StructInfo{type: :defstruct, fields: [some: 1]}
+      },
+      vars: [
+        %VarInfo{
+          name: :struct,
+          type: {:struct, [], {:atom, DateTime}, nil}
+        },
+        %VarInfo{
+          name: :other,
+          type: {:call, {:atom, DateTime}, :utc_now, []}
+        },
+        %VarInfo{
+          name: :from_metadata,
+          type: {:struct, [], {:atom, MyStruct}, nil}
+        }
+      ]
+    }
+
+    assert expand('struct.h', env) ==
+             [
+               %{
+                 call?: true,
+                 name: "hour",
+                 origin: "DateTime",
+                 subtype: :struct_field,
+                 type: :field,
+                 type_spec: "Calendar.hour()"
+               }
+             ]
+
+    assert expand('other.d', env) ==
+             [
+               %{
+                 call?: true,
+                 name: "day",
+                 origin: "DateTime",
+                 subtype: :struct_field,
+                 type: :field,
+                 type_spec: "Calendar.day()"
+               }
+             ]
+
+    assert expand('from_metadata.s', env) ==
+             [
+               %{
+                 call?: true,
+                 name: "some",
+                 origin: "MyStruct",
+                 subtype: :struct_field,
+                 type: :field,
+                 type_spec: "integer"
+               }
+             ]
   end
 
   test "map atom key completion is supported on attributes" do
@@ -491,26 +610,79 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
     }
 
     assert expand('@map.f', env) ==
-             [%{name: "foo", subtype: :map_key, type: :field, origin: nil, call?: true}]
+             [
+               %{
+                 name: "foo",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
+             ]
 
     assert [_ | _] = expand('@map.b', env)
 
     assert expand('@map.bar_', env) ==
              [
-               %{name: "bar_1", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "bar_2", subtype: :map_key, type: :field, origin: nil, call?: true}
+               %{
+                 name: "bar_1",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "bar_2",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
              ]
 
     assert expand('@map.c', env) == []
 
     assert expand('@map.', env) ==
              [
-               %{name: "bar_1", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "bar_2", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "foo", subtype: :map_key, type: :field, origin: nil, call?: true}
+               %{
+                 name: "bar_1",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "bar_2",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "foo",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
              ]
 
-    assert expand('@map.foo', env) == []
+    assert expand('@map.foo', env) == [
+             %{
+               call?: true,
+               name: "foo",
+               origin: nil,
+               subtype: :map_key,
+               type: :field,
+               type_spec: nil
+             }
+           ]
   end
 
   test "nested map atom key completion is supported" do
@@ -540,34 +712,119 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
     }
 
     assert expand('map.nested.deeply.f', env) ==
-             [%{name: "foo", subtype: :map_key, type: :field, origin: nil, call?: true}]
+             [
+               %{
+                 name: "foo",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
+             ]
 
     assert [_ | _] = expand('map.nested.deeply.b', env)
 
     assert expand('map.nested.deeply.bar_', env) ==
              [
-               %{name: "bar_1", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "bar_2", subtype: :map_key, type: :field, origin: nil, call?: true}
+               %{
+                 name: "bar_1",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "bar_2",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
              ]
 
     assert expand('map.nested.deeply.', env) ==
              [
-               %{name: "bar_1", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "bar_2", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "foo", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "mod", subtype: :map_key, type: :field, origin: nil, call?: true},
-               %{name: "num", subtype: :map_key, type: :field, origin: nil, call?: true}
+               %{
+                 name: "bar_1",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "bar_2",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "foo",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "mod",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               },
+               %{
+                 name: "num",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
              ]
 
     assert [_ | _] = expand('map.nested.deeply.mod.print', env)
 
     assert expand('map.nested', env) ==
-             [%{name: "nested", subtype: :map_key, type: :field, origin: nil, call?: true}]
+             [
+               %{
+                 name: "nested",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
+             ]
 
     assert expand('map.nested.deeply', env) ==
-             [%{name: "deeply", subtype: :map_key, type: :field, origin: nil, call?: true}]
+             [
+               %{
+                 name: "deeply",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
+             ]
 
-    assert expand('map.nested.deeply.foo', env) == []
+    assert expand('map.nested.deeply.foo', env) == [
+             %{
+               call?: true,
+               name: "foo",
+               origin: nil,
+               subtype: :map_key,
+               type: :field,
+               type_spec: nil
+             }
+           ]
 
     assert expand('map.nested.deeply.c', env) == []
     assert expand('map.a.b.c.f', env) == []
@@ -1224,7 +1481,8 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                }
              ]
 
@@ -1235,12 +1493,22 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                }
              ]
 
     assert expand('struct.some_map.', env) ==
-             [%{name: "asdf", subtype: :map_key, type: :field, origin: nil, call?: true}]
+             [
+               %{
+                 name: "asdf",
+                 subtype: :map_key,
+                 type: :field,
+                 origin: nil,
+                 call?: true,
+                 type_spec: nil
+               }
+             ]
 
     assert expand('struct.str.', env) ==
              [
@@ -1249,42 +1517,48 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                },
                %{
                  name: "a_mod",
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                },
                %{
                  name: "my_val",
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                },
                %{
                  name: "some_map",
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                },
                %{
                  name: "str",
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                },
                %{
                  name: "unknown_str",
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                }
              ]
 
@@ -1295,7 +1569,8 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
                  subtype: :struct_field,
                  type: :field,
                  origin: "ElixirSense.Providers.Suggestion.CompleteTest.MyStruct",
-                 call?: true
+                 call?: true,
+                 type_spec: nil
                }
              ]
 
@@ -1306,9 +1581,17 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
                  name: "__struct__",
                  origin: nil,
                  subtype: :struct_field,
-                 type: :field
+                 type: :field,
+                 type_spec: nil
                },
-               %{call?: true, name: "abc", origin: nil, subtype: :struct_field, type: :field}
+               %{
+                 call?: true,
+                 name: "abc",
+                 origin: nil,
+                 subtype: :struct_field,
+                 type: :field,
+                 type_spec: nil
+               }
              ]
   end
 

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -1925,27 +1925,27 @@ defmodule ElixirSense.SuggestionsTest do
   test "suggestion for struct fields" do
     buffer = """
     defmodule Mod do
-      %IO.Stream{}
+      %ElixirSenseExample.IO.Stream{}
       %ArgumentError{}
     end
     """
 
     list =
-      ElixirSense.suggestions(buffer, 2, 14)
+      ElixirSense.suggestions(buffer, 2, 33)
       |> Enum.filter(&(&1.type in [:field]))
 
     assert list == [
              %{
                name: "__struct__",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
-               type_spec: "IO.Stream"
+               type_spec: "ElixirSenseExample.IO.Stream"
              },
              %{
                name: "device",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -1953,7 +1953,7 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "line_or_bytes",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -1961,7 +1961,7 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "raw",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -2004,7 +2004,7 @@ defmodule ElixirSense.SuggestionsTest do
   test "suggestion for aliased struct fields" do
     buffer = """
     defmodule Mod do
-      alias IO.Stream
+      alias ElixirSenseExample.IO.Stream
       %Stream{
     end
     """
@@ -2016,15 +2016,15 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{
                name: "__struct__",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
-               type_spec: "IO.Stream"
+               type_spec: "ElixirSenseExample.IO.Stream"
              },
              %{
                name: "device",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -2032,7 +2032,7 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "line_or_bytes",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -2040,7 +2040,7 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "raw",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -2091,7 +2091,7 @@ defmodule ElixirSense.SuggestionsTest do
   test "suggestion for aliased struct fields atom module" do
     buffer = """
     defmodule Mod do
-      alias IO.Stream
+      alias ElixirSenseExample.IO.Stream
       %:"Elixir.Stream"{
     end
     """
@@ -2103,15 +2103,15 @@ defmodule ElixirSense.SuggestionsTest do
     assert list == [
              %{
                name: "__struct__",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
-               type_spec: "IO.Stream"
+               type_spec: "ElixirSenseExample.IO.Stream"
              },
              %{
                name: "device",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -2119,7 +2119,7 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "line_or_bytes",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,
@@ -2127,7 +2127,7 @@ defmodule ElixirSense.SuggestionsTest do
              },
              %{
                name: "raw",
-               origin: "IO.Stream",
+               origin: "ElixirSenseExample.IO.Stream",
                type: :field,
                call?: false,
                subtype: :struct_field,

--- a/test/elixir_sense/suggestions_test.exs
+++ b/test/elixir_sense/suggestions_test.exs
@@ -1940,28 +1940,32 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "IO.Stream"
              },
              %{
                name: "device",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "IO.device()"
              },
              %{
                name: "line_or_bytes",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: ":line | non_neg_integer()"
              },
              %{
                name: "raw",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "boolean()"
              }
            ]
 
@@ -1975,21 +1979,24 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "ArgumentError",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "true"
              },
              %{
                name: "__struct__",
                origin: "ArgumentError",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "ArgumentError"
              },
              %{
                name: "message",
                origin: "ArgumentError",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
   end
@@ -2012,28 +2019,32 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "IO.Stream"
              },
              %{
                name: "device",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "IO.device()"
              },
              %{
                name: "line_or_bytes",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: ":line | non_neg_integer()"
              },
              %{
                name: "raw",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "boolean()"
              }
            ]
   end
@@ -2056,7 +2067,8 @@ defmodule ElixirSense.SuggestionsTest do
                origin: nil,
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "atom()"
              }
            ]
 
@@ -2070,7 +2082,8 @@ defmodule ElixirSense.SuggestionsTest do
                origin: nil,
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "atom()"
              }
            ]
   end
@@ -2093,28 +2106,32 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "IO.Stream"
              },
              %{
                name: "device",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "IO.device()"
              },
              %{
                name: "line_or_bytes",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: ":line | non_neg_integer()"
              },
              %{
                name: "raw",
                origin: "IO.Stream",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "boolean()"
              }
            ]
   end
@@ -2144,21 +2161,24 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "MyServer"
              },
              %{
                name: "field_1",
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              },
              %{
                name: "field_2",
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
 
@@ -2170,14 +2190,16 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "MyServer"
              },
              %{
                name: "field_1",
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
   end
@@ -2207,21 +2229,24 @@ defmodule ElixirSense.SuggestionsTest do
                origin: ":my_server",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: ":my_server"
              },
              %{
                name: "field_1",
                origin: ":my_server",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              },
              %{
                name: "field_2",
                origin: ":my_server",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
 
@@ -2233,14 +2258,16 @@ defmodule ElixirSense.SuggestionsTest do
                origin: ":my_server",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: ":my_server"
              },
              %{
                name: "field_1",
                origin: ":my_server",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
   end
@@ -2270,14 +2297,16 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "MyServer"
              },
              %{
                name: "field_1",
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
   end
@@ -2304,14 +2333,16 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: "MyServer"
              },
              %{
                name: "field_1",
                origin: "MyServer",
                type: :field,
                call?: false,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
   end
@@ -2341,14 +2372,16 @@ defmodule ElixirSense.SuggestionsTest do
                origin: "MyServer",
                type: :field,
                call?: true,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              },
              %{
                name: "field_2",
                origin: "MyServer",
                type: :field,
                call?: true,
-               subtype: :struct_field
+               subtype: :struct_field,
+               type_spec: nil
              }
            ]
   end
@@ -2368,8 +2401,22 @@ defmodule ElixirSense.SuggestionsTest do
       |> Enum.filter(&(&1.type in [:field]))
 
     assert list == [
-             %{name: "key_1", origin: nil, type: :field, call?: true, subtype: :map_key},
-             %{name: "key_2", origin: nil, type: :field, call?: true, subtype: :map_key}
+             %{
+               name: "key_1",
+               origin: nil,
+               type: :field,
+               call?: true,
+               subtype: :map_key,
+               type_spec: nil
+             },
+             %{
+               name: "key_2",
+               origin: nil,
+               type: :field,
+               call?: true,
+               subtype: :map_key,
+               type_spec: nil
+             }
            ]
   end
 
@@ -2388,8 +2435,22 @@ defmodule ElixirSense.SuggestionsTest do
       |> Enum.filter(&(&1.type in [:field]))
 
     assert list == [
-             %{name: "key_1", origin: nil, type: :field, call?: true, subtype: :map_key},
-             %{name: "key_2", origin: nil, type: :field, call?: true, subtype: :map_key}
+             %{
+               name: "key_1",
+               origin: nil,
+               type: :field,
+               call?: true,
+               subtype: :map_key,
+               type_spec: nil
+             },
+             %{
+               name: "key_2",
+               origin: nil,
+               type: :field,
+               call?: true,
+               subtype: :map_key,
+               type_spec: nil
+             }
            ]
   end
 
@@ -2465,7 +2526,8 @@ defmodule ElixirSense.SuggestionsTest do
                name: "field_1",
                origin: "MyServer",
                subtype: :struct_field,
-               type: :field
+               type: :field,
+               type_spec: nil
              }
            ]
   end
@@ -2492,7 +2554,8 @@ defmodule ElixirSense.SuggestionsTest do
                name: "field_1",
                origin: "MyServer",
                subtype: :struct_field,
-               type: :field
+               type: :field,
+               type_spec: nil
              }
            ]
   end
@@ -2519,7 +2582,8 @@ defmodule ElixirSense.SuggestionsTest do
                name: "field_1",
                origin: "MyServer",
                subtype: :struct_field,
-               type: :field
+               type: :field,
+               type_spec: nil
              }
            ]
   end
@@ -2536,7 +2600,14 @@ defmodule ElixirSense.SuggestionsTest do
     list = ElixirSense.suggestions(buffer, 3, 22)
 
     assert list == [
-             %{call?: false, name: "field_1", origin: nil, subtype: :struct_field, type: :field}
+             %{
+               call?: false,
+               name: "field_1",
+               origin: nil,
+               subtype: :struct_field,
+               type: :field,
+               type_spec: nil
+             }
            ]
   end
 
@@ -2551,7 +2622,14 @@ defmodule ElixirSense.SuggestionsTest do
     list = ElixirSense.suggestions(buffer, 3, 9)
 
     assert list == [
-             %{call?: false, name: "hour", origin: "Time", subtype: :struct_field, type: :field}
+             %{
+               call?: false,
+               name: "hour",
+               origin: "Time",
+               subtype: :struct_field,
+               type: :field,
+               type_spec: "Calendar.hour()"
+             }
            ]
   end
 
@@ -2567,7 +2645,14 @@ defmodule ElixirSense.SuggestionsTest do
     list = ElixirSense.suggestions(buffer, 3, 22)
 
     assert list == [
-             %{call?: false, name: "field_1", origin: nil, subtype: :map_key, type: :field}
+             %{
+               call?: false,
+               name: "field_1",
+               origin: nil,
+               subtype: :map_key,
+               type: :field,
+               type_spec: nil
+             }
            ]
   end
 
@@ -2583,7 +2668,14 @@ defmodule ElixirSense.SuggestionsTest do
     list = ElixirSense.suggestions(buffer, 3, 22)
 
     assert list == [
-             %{call?: false, name: "field_1", origin: nil, subtype: :map_key, type: :field}
+             %{
+               call?: false,
+               name: "field_1",
+               origin: nil,
+               subtype: :map_key,
+               type: :field,
+               type_spec: nil
+             }
            ]
   end
 

--- a/test/support/stuct_with_typespec.ex
+++ b/test/support/stuct_with_typespec.ex
@@ -1,0 +1,13 @@
+defmodule ElixirSenseExample.IO.Stream do
+  defstruct [
+    :device,
+    :line_or_bytes,
+    :raw
+  ]
+
+  @type t() :: %ElixirSenseExample.IO.Stream{
+          device: IO.device(),
+          line_or_bytes: :line | non_neg_integer(),
+          raw: boolean()
+        }
+end


### PR DESCRIPTION
This PR adds struct property typespecs in completions when struct module defines a type `t()`