### PR TITLE
Do not crash references when call has nil line

### DIFF
--- a/lib/elixir_sense/providers/references.ex
+++ b/lib/elixir_sense/providers/references.ex
@@ -177,8 +177,10 @@ defmodule ElixirSense.Providers.References do
   defp build_location(call) do
     %{callee: {_, func, _}} = call
 
+    line = call.line || 1
+
     {start_column, end_column} =
-      if call.column != nil do
+      if call.line != nil and call.column != nil do
         func_length = func |> to_string() |> String.length()
         {call.column, call.column + func_length}
       else
@@ -188,8 +190,8 @@ defmodule ElixirSense.Providers.References do
     %{
       uri: call.file,
       range: %{
-        start: %{line: call.line, column: start_column},
-        end: %{line: call.line, column: end_column}
+        start: %{line: line, column: start_column},
+        end: %{line: line, column: end_column}
       }
     }
   end

--- a/test/support/references_tracer.ex
+++ b/test/support/references_tracer.ex
@@ -28,9 +28,21 @@ defmodule ElixirSense.Core.References.Tracer do
   end
 
   def trace({kind, meta, module, name, arity}, env)
-      when kind in [:imported_function, :imported_macro, :remote_function, :remote_macro] do
+      when kind in [:remote_function, :remote_macro] do
     register_call(%{
       callee: {module, name, arity},
+      file: env.file |> Path.relative_to_cwd(),
+      line: meta[:line],
+      column: meta[:column]
+    })
+
+    :ok
+  end
+
+  def trace({kind, meta, name, arity}, env)
+      when kind in [:local_function, :local_macro] do
+    register_call(%{
+      callee: {env.module, name, arity},
       file: env.file |> Path.relative_to_cwd(),
       line: meta[:line],
       column: meta[:column]


### PR DESCRIPTION
remove imported_call tracking, add missing local_call tracing in test

Partial fix for https://github.com/elixir-lsp/elixir-ls/issues/842