### PR TITLE
Fix tests for Elixir 1.15 and OTP 26

### DIFF
--- a/lib/elixir_sense/core/introspection.ex
+++ b/lib/elixir_sense/core/introspection.ex
@@ -374,6 +374,7 @@ defmodule ElixirSense.Core.Introspection do
   def get_metadata_md(metadata) do
     text =
       metadata
+      |> Enum.sort()
       |> Enum.map(&get_metadata_entry_md/1)
       |> Enum.reject(&is_nil/1)
       |> Enum.join("\n")

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule ElixirSense.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
+      prune_code_paths: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.html": :test],
       dialyzer: [
@@ -38,6 +39,8 @@ defmodule ElixirSense.Mixfile do
 
   defp deps do
     [
+      # TODO: Remove when excoveralls depends on fixed ssl_verify_fun
+      {:ssl_verify_fun, "~> 1.1", manager: :rebar3, only: :test, override: true},
       {:excoveralls, "~> 0.10", only: :test},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:credo, "~> 1.0", only: [:dev], runtime: false},

--- a/test/elixir_sense/core/parser_test.exs
+++ b/test/elixir_sense/core/parser_test.exs
@@ -395,6 +395,7 @@ defmodule ElixirSense.Core.ParserTest do
            } = parse_string(source, true, true, 6)
   end
 
+  @tag only_this: true
   test "parse_string with literal strings in sigils" do
     source = ~S'''
     defmodule MyMod do
@@ -410,13 +411,15 @@ defmodule ElixirSense.Core.ParserTest do
     assert %ElixirSense.Core.Metadata{
              lines_to_env: %{
                5 => %ElixirSense.Core.State.Env{
-                 vars: [
-                   %ElixirSense.Core.State.VarInfo{name: :x},
-                   %ElixirSense.Core.State.VarInfo{name: :y}
-                 ]
+                 vars: vars
                }
              }
            } = parse_string(source, true, true, 5)
+
+    assert [
+             %ElixirSense.Core.State.VarInfo{name: :x},
+             %ElixirSense.Core.State.VarInfo{name: :y}
+           ] = Enum.sort(vars)
   end
 
   test "parse struct" do

--- a/test/elixir_sense/providers/suggestion/complete_test.exs
+++ b/test/elixir_sense/providers/suggestion/complete_test.exs
@@ -51,9 +51,9 @@ defmodule ElixirSense.Providers.Suggestion.CompleteTest do
   end
 
   test "erlang module multiple values completion" do
-    list = expand(':user')
-    assert list |> Enum.find(&(&1.name == ":user"))
-    assert list |> Enum.find(&(&1.name == ":user_drv"))
+    list = expand(':logger')
+    assert list |> Enum.find(&(&1.name == ":logger"))
+    assert list |> Enum.find(&(&1.name == ":logger_proxy"))
   end
 
   test "erlang root completion" do


### PR DESCRIPTION
Elixir 1.15 prunes "unused" code paths by default, which lets the tests fail. Settings `prune_code_paths: false` for tests avoids that.

OTP 26 changed the Map behaviour when converting them to lists (there isn't a stable sorting anymore). This PR fixes the affected tests.
It also removed some modules used for autocompletion tests. I switched them to the `:logger` module.

There is also a problem with `ssl_verify_fun` (see https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27) which is used by excoveralls. The explicit dependency to `:ssl_verify_fun` can be removed as soon as the PR is merged and a new version is released.