### PR TITLE
Use Elixir-provided list of module attributes.

### DIFF
--- a/lib/elixir_sense/core/builtin_attributes.ex
+++ b/lib/elixir_sense/core/builtin_attributes.ex
@@ -1,34 +1,7 @@
 defmodule ElixirSense.Core.BuiltinAttributes do
   @moduledoc false
-  @list ~w(
-    optional_callbacks
-    behaviour
-    impl
-    derive
-    enforce_keys
-    struct
-    compile
-    deprecated
-    dialyzer
-    file
-    external_resource
-    on_load
-    on_definition
-    vsn
-    after_compile
-    after_verify
-    before_compile
-    fallback_to_any
-    type
-    typep
-    opaque
-    spec
-    callback
-    macrocallback
-    typedoc
-    doc
-    moduledoc
-  )a
+
+  @list Map.keys(Module.reserved_attributes())
 
   def all, do: @list
 end


### PR DESCRIPTION
Hello! Love the work y'all have done on this :) Wanting to try helping out, so I figured I'd start with a small PR. 

Converts `ElixirSense.Core.BuiltInAttributes` to use `Module.reserved_attributes`, which is the official Elixir list of built-in attributes.