### PR TITLE
Implement type inferences from guard expressions

### DIFF
--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1477,6 +1477,106 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
            ] = state |> get_line_vars(4)
   end
 
+  describe "infer vars type information from guards" do
+    defp var_with_guards(guard) do
+      """
+      defmodule MyModule do
+        def func(x) when #{guard} do
+          x
+        end
+      end
+      """
+      |> string_to_state()
+      |> get_line_vars(3)
+      |> hd()
+    end
+
+    test "number guards" do
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("is_number(x)")
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("is_float(x)")
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("is_integer(x)")
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("round(x)")
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("trunc(x)")
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("div(x)")
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("rem(x)")
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("abs(x)")
+    end
+
+    test "binary guards" do
+      assert %VarInfo{name: :x, type: :binary} = var_with_guards("is_binary(x)")
+      assert %VarInfo{name: :x, type: :binary} = var_with_guards(~s/binary_part(x, 0, 1) == "a"/)
+    end
+
+    test "bitstring guards" do
+      assert %VarInfo{name: :x, type: :bitstring} = var_with_guards("is_bitstring(x)")
+      assert %VarInfo{name: :x, type: :bitstring} = var_with_guards("bit_size(x) == 1")
+      assert %VarInfo{name: :x, type: :bitstring} = var_with_guards("byte_size(x) == 1")
+    end
+
+    test "list guards" do
+      assert %VarInfo{name: :x, type: :list} = var_with_guards("is_list(x)")
+      assert %VarInfo{name: :x, type: :list} = var_with_guards("hd(x) == 1")
+      assert %VarInfo{name: :x, type: :list} = var_with_guards("tl(x) == 1")
+      assert %VarInfo{name: :x, type: :list} = var_with_guards("length(x) == 1")
+    end
+
+    test "tuple guards" do
+      assert %VarInfo{name: :x, type: :tuple} = var_with_guards("is_tuple(x)")
+      assert %VarInfo{name: :x, type: :tuple} = var_with_guards("tuple_size(x) == 1")
+      assert %VarInfo{name: :x, type: :tuple} = var_with_guards("elem(x, 0) == 1")
+    end
+
+    test "atom guards" do
+      assert %VarInfo{name: :x, type: :atom} = var_with_guards("is_atom(x)")
+    end
+
+    test "boolean guards" do
+      assert %VarInfo{name: :x, type: :boolean} = var_with_guards("is_boolean(x)")
+    end
+
+    test "map guards" do
+      assert %VarInfo{name: :x, type: {:map, [], nil}} = var_with_guards("is_map(x)")
+
+      assert %VarInfo{name: :x, type: {:map, [a: nil], nil}} =
+               var_with_guards("is_map_key(x, :a)")
+
+      assert %VarInfo{name: :x, type: {:map, [{"a", nil}], nil}} =
+               var_with_guards(~s/is_map_key(x, "a")/)
+    end
+
+    test "struct guards" do
+      assert %VarInfo{name: :x, type: :struct} = var_with_guards("is_struct(x)")
+
+      assert %VarInfo{name: :x, type: {:struct, [], {:atom, URI}, nil}} =
+               var_with_guards("is_struct(x, URI)")
+
+      assert %VarInfo{name: :x, type: {:struct, [], {:atom, URI}, nil}} =
+               """
+               defmodule MyModule do
+                 alias URI, as: MyURI
+
+                 def func(x) when is_struct(x, MyURI) do
+                   x
+                 end
+               end
+               """
+               |> string_to_state()
+               |> get_line_vars(5)
+               |> hd()
+    end
+
+    test "and combination predicate guards can be merge" do
+      assert %VarInfo{name: :x, type: :number} = var_with_guards("is_number(x) and x >= 1")
+
+      assert %VarInfo{name: :x, type: {:map, [a: nil, b: nil], nil}} =
+               var_with_guards("is_map_key(x, :a) and is_map_key(x, :b)")
+    end
+
+    test "or combination predicate guards can not be used" do
+      assert %VarInfo{name: :x, type: nil} = var_with_guards("is_number(x) or is_atom(x)")
+    end
+  end
+
   test "aliases" do
     state =
       """


### PR DESCRIPTION
Potential improvements for future:
1. Better handle `and` operator in guards: current implementation picks one and discards the other
2. Better handle `or` operator in guards: current implementation discards both sides. We can represent them as union types. In real use cases, this should happen rarely, so I'll leave it like this for now

Closes #204