### PR TITLE
Allow to lookup Elixir source files under configured location

### DIFF
--- a/test/elixir_sense/location_test.exs
+++ b/test/elixir_sense/location_test.exs
@@ -1,0 +1,32 @@
+defmodule ElixirSense.LocationTest do
+  use ExUnit.Case, async: false
+
+  import ElixirSense.Location
+
+  setup do
+    elixir_src = Path.join(File.cwd!(), "/test/misc/mock_elixir_src")
+    Application.put_env(:elixir_sense, :elixir_src, elixir_src)
+
+    on_exit(fn ->
+      Application.delete_env(:elixir_sense, :elixir_src)
+    end)
+  end
+
+  describe "find_mod_fun_source/3" do
+    test "returns location of a core Elixir function" do
+      assert %ElixirSense.Location{type: :function, line: 26, column: 3, file: file} =
+               find_mod_fun_source(String, :length, 1)
+
+      assert String.ends_with?(file, "/mock_elixir_src/lib/elixir/lib/string.ex")
+    end
+  end
+
+  describe "find_type_source/3" do
+    test "returns location of a core Elixir type" do
+      assert %ElixirSense.Location{type: :typespec, line: 11, column: 3, file: file} =
+               find_type_source(String, :t, 0)
+
+      assert String.ends_with?(file, "/mock_elixir_src/lib/elixir/lib/string.ex")
+    end
+  end
+end

--- a/test/misc/mock_elixir_src/lib/elixir/lib/string.ex
+++ b/test/misc/mock_elixir_src/lib/elixir/lib/string.ex
@@ -1,0 +1,35 @@
+import Kernel, except: [length: 1]
+
+defmodule String do
+  @typedoc """
+  A UTF-8 encoded binary.
+
+  The types `String.t()` and `binary()` are equivalent to analysis tools.
+  Although, for those reading the documentation, `String.t()` implies
+  it is a UTF-8 encoded binary.
+  """
+  @type t :: binary
+
+  @doc """
+  Returns the number of Unicode graphemes in a UTF-8 string.
+
+  ## Examples
+
+      iex> String.length("elixir")
+      6
+
+      iex> String.length("եոգլի")
+      5
+
+  """
+  @spec length(t) :: non_neg_integer
+  def length(string) when is_binary(string), do: length(string, 0)
+
+  defp length(gcs, acc) do
+    case :unicode_util.gc(gcs) do
+      [_ | rest] -> length(rest, acc + 1)
+      [] -> acc
+      {:error, <<_, rest::bits>>} -> length(rest, acc + 1)
+    end
+  end
+end


### PR DESCRIPTION
Greetings!

`elixir_sense` uses `mod.module_info(:compile)[:source]` in order to retrieve the source file for a module. While it works for regular Elixir files and dependencies, it fails for the Elixir sources (i.e., for the applications like `:elixir`, `:ex_unit`, `:eex` that ship with Elixir) if Elixir was built in a sandboxed environment. That happens, for example, on NixOS as it returns a path to a build location that no longer exists:

```iex
iex(1)> String.module_info(:compile)[:source]
'/build/source/lib/elixir/lib/string.ex'
```

("/build/source" refers to a location that contained Elixir source while it was being built inside a sandbox.)

Despite that, on NixOS it's easy to install the Elixir source as a package and provide the path to it as an environment variable.

<details>
<summary>Click me to get NixOS-specific info!</summary>

**flake.nix**:
```nix
{
  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; };

  outputs = inputs@{ flake-parts, ... }:
    flake-parts.lib.mkFlake { inherit inputs; } {
      systems =
        [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
      perSystem = { config, self', inputs', pkgs, system, ... }: {
        devShells.default = with pkgs;
          mkShell {
            name = "elixir_ls";

            # Define packages that will be available for our project
            buildInputs = [ elixir erlang elixir_ls ];

            ERL_AFLAGS = "-kernel shell_history enabled";

            # Define envvar $ELIXIR_SRC that points to Elixir sources, it looks like this:
            # /nix/store/cq9kb2qq08y95j2ym4by6f3jk0ix9sni-source
            ELIXIR_SRC = "${elixir.src}";
          };
      };
    };
}
```
</details>

This PR makes `ElixirSense.Location` to  look up Elixir sources under the configured location as a fallback. This will allow for code navigation to Elixir sources to work on environments like NixOS.

Sadly, I have no idea how to write tests for this, so any suggestion is appreciated. Meanwhile I tested it manually on my machine in an IEX session:

```iex
iex(1)> ElixirSense.Location.find_mod_fun_source(String, :length, 1)
nil
iex(2)> ElixirSense.Location.find_type_source(DateTime, :t, 0)
nil
iex(3)> elixir_src = System.get_env("ELIXIR_SRC")
"/nix/store/cq9kb2qq08y95j2ym4by6f3jk0ix9sni-source"
iex(4)> Application.put_env(:elixir_sense, :elixir_src, elixir_src)
:ok
iex(5)> ElixirSense.Location.find_mod_fun_source(String, :length, 1)
%ElixirSense.Location{
  type: :function,
  file: "/nix/store/cq9kb2qq08y95j2ym4by6f3jk0ix9sni-source/lib/elixir/lib/string.ex",
  line: 2017,
  column: 3
}
iex(6)> ElixirSense.Location.find_type_source(DateTime, :t, 0)
%ElixirSense.Location{
  type: :typespec,
  file: "/nix/store/cq9kb2qq08y95j2ym4by6f3jk0ix9sni-source/lib/elixir/lib/calendar/datetime.ex",
  line: 125,
  column: 3
}
```

If this PR is merged, I will open another one in https://github.com/elixir-lsp/elixir-ls that will read `$ELIXIR_SRC` at the server startup and configure `:elixir_sense` accordingly.