### PR TITLE
Improve Phoenix integration

### DIFF
--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -526,16 +526,6 @@ defmodule ElixirSense.Core.Source do
   def get_mod_fun([atom, fun], _binding_env) when is_atom(atom), do: {{atom, false}, fun}
   def get_mod_fun(_, _binding_env), do: nil
 
-  def get_mod([{name, _, nil} | _rest], binding_env) when is_atom(name) do
-    case Binding.expand(binding_env, {:variable, name}) do
-      {:atom, atom} ->
-        {atom, false}
-
-      _ ->
-        nil
-    end
-  end
-
   def get_mod([{:__aliases__, _, list} | _rest], binding_env) do
     get_mod(list, binding_env)
   end

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -526,6 +526,16 @@ defmodule ElixirSense.Core.Source do
   def get_mod_fun([atom, fun], _binding_env) when is_atom(atom), do: {{atom, false}, fun}
   def get_mod_fun(_, _binding_env), do: nil
 
+  def get_mod([{name, _, nil} | _rest], binding_env) do
+    case Binding.expand(binding_env, {:variable, name}) do
+      {:atom, atom} ->
+        {atom, false}
+
+      _ ->
+        nil
+    end
+  end
+
   def get_mod([{:__aliases__, _, list} | _rest], binding_env) do
     get_mod(list, binding_env)
   end

--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -526,7 +526,7 @@ defmodule ElixirSense.Core.Source do
   def get_mod_fun([atom, fun], _binding_env) when is_atom(atom), do: {{atom, false}, fun}
   def get_mod_fun(_, _binding_env), do: nil
 
-  def get_mod([{name, _, nil} | _rest], binding_env) do
+  def get_mod([{name, _, nil} | _rest], binding_env) when is_atom(name) do
     case Binding.expand(binding_env, {:variable, name}) do
       {:atom, atom} ->
         {atom, false}

--- a/lib/elixir_sense/plugins/phoenix.ex
+++ b/lib/elixir_sense/plugins/phoenix.ex
@@ -1,4 +1,6 @@
 defmodule ElixirSense.Plugins.Phoenix do
+  @moduledoc false
+
   @behaviour ElixirSense.Plugin
 
   use ElixirSense.Providers.Suggestion.GenericReducer

--- a/lib/elixir_sense/plugins/phoenix.ex
+++ b/lib/elixir_sense/plugins/phoenix.ex
@@ -28,7 +28,8 @@ defmodule ElixirSense.Plugins.Phoenix do
     @impl true
     def suggestions(hint, {Phoenix.Router, func, 1, _info}, _list, opts)
         when func in @phoenix_route_funcs do
-      {_, scope_alias} = Scope.within_scope(opts.cursor_context.text_before)
+      binding = Binding.from_env(opts.env, opts.buffer_metadata)
+      {_, scope_alias} = Scope.within_scope(opts.cursor_context.text_before, binding)
 
       case find_controllers(opts.module_store, opts.env, hint, scope_alias) do
         [] -> :ignore

--- a/lib/elixir_sense/plugins/phoenix.ex
+++ b/lib/elixir_sense/plugins/phoenix.ex
@@ -1,0 +1,100 @@
+defmodule ElixirSense.Plugins.Phoenix do
+  @behaviour ElixirSense.Plugin
+
+  use ElixirSense.Providers.Suggestion.GenericReducer
+
+  alias ElixirSense.Core.Source
+  alias ElixirSense.Core.Binding
+  alias ElixirSense.Core.Introspection
+  alias ElixirSense.Core.ModuleStore
+  alias ElixirSense.Plugins.Phoenix.Scope
+  alias ElixirSense.Plugins.Util
+  alias ElixirSense.Providers.Suggestion.Matcher
+
+  @phoenix_route_funcs ~w(
+    get put patch trace
+    delete head options
+    forward connect post
+  )a
+
+  @impl true
+  def setup(context) do
+    ModuleStore.ensure_compiled(context, Phoenix.Router)
+  end
+
+  @impl true
+  def suggestions(hint, {Phoenix.Router, func, 1, _info}, _list, opts)
+      when func in @phoenix_route_funcs do
+    {_, scope_alias} = Scope.within_scope(opts.cursor_context.text_before)
+
+    case find_controllers(opts.module_store, opts.env, hint, scope_alias) do
+      [] -> :ignore
+      controllers -> {:override, controllers}
+    end
+  end
+
+  def suggestions(
+        hint,
+        {Phoenix.Router, func, 2, %{params: [_path, module]}},
+        _list,
+        opts
+      )
+      when func in @phoenix_route_funcs do
+    binding_env = Binding.from_env(opts.env, opts.buffer_metadata)
+    {_, scope_alias} = Scope.within_scope(opts.cursor_context.text_before)
+    {module, _} = Source.get_mod([module], binding_env)
+
+    module = Module.safe_concat(scope_alias, module)
+
+    suggestions =
+      for {export, {2, :function}} when export not in ~w(action call)a <-
+            Introspection.get_exports(module),
+          name = inspect(export),
+          Matcher.match?(name, hint) do
+        %{
+          type: :generic,
+          kind: :function,
+          label: name,
+          insert_text: Util.trim_leading_for_insertion(hint, name),
+          detail: "Phoenix action"
+        }
+      end
+
+    {:override, suggestions}
+  end
+
+  @impl true
+  def suggestions(_hint, _func_call, _list, _opts) do
+    :ignore
+  end
+
+  defp find_controllers(module_store, env, hint, scope_alias) do
+    [prefix | _] =
+      env.module
+      |> inspect()
+      |> String.split(".")
+
+    for module <- module_store.list,
+        mod_str = inspect(module),
+        Util.match_module?(mod_str, prefix),
+        mod_str =~ "Controller",
+        Util.match_module?(mod_str, hint) do
+      {doc, _} = Introspection.get_module_docs_summary(module)
+
+      %{
+        type: :generic,
+        kind: :class,
+        label: mod_str,
+        insert_text: skip_scope_alias(scope_alias, mod_str),
+        detail: "Phoenix controller",
+        documentation: doc
+      }
+    end
+    |> Enum.sort_by(& &1.label)
+  end
+
+  defp skip_scope_alias(nil, insert_text), do: insert_text
+
+  defp skip_scope_alias(scope_alias, insert_text),
+    do: String.replace_prefix(insert_text, "#{inspect(scope_alias)}.", "")
+end

--- a/lib/elixir_sense/plugins/phoenix/scope.ex
+++ b/lib/elixir_sense/plugins/phoenix/scope.ex
@@ -92,6 +92,16 @@ defmodule ElixirSense.Plugins.Phoenix.Scope do
     get_mod(scope_alias, binding_env)
   end
 
+  defp get_mod({name, _, nil}, binding_env) when is_atom(name) do
+    case Binding.expand(binding_env, {:variable, name}) do
+      {:atom, atom} ->
+        atom
+
+      _ ->
+        nil
+    end
+  end
+
   defp get_mod(scope_alias, binding_env) do
     with {mod, _} <- Source.get_mod([scope_alias], binding_env) do
       mod

--- a/lib/elixir_sense/plugins/phoenix/scope.ex
+++ b/lib/elixir_sense/plugins/phoenix/scope.ex
@@ -42,8 +42,7 @@ defmodule ElixirSense.Plugins.Phoenix.Scope do
        do: module
 
   # scope path: "/", alias: ExampleWeb do ... end
-  defp get_scope_alias([{:scope, _, [scope_params]}], binding_env, module)
-       when is_list(scope_params) do
+  defp get_scope_alias([{:scope, _, [scope_params]}], binding_env, module) do
     scope_alias = Keyword.get(scope_params, :alias)
     scope_alias = get_mod(scope_alias, binding_env)
     safe_concat(module, scope_alias)

--- a/lib/elixir_sense/plugins/phoenix/scope.ex
+++ b/lib/elixir_sense/plugins/phoenix/scope.ex
@@ -88,10 +88,13 @@ defmodule ElixirSense.Plugins.Phoenix.Scope do
     safe_concat([module, scope_alias, get_scope_alias(tail, binding_env)])
   end
 
+  defp get_mod({:__aliases__, _, [scope_alias]}, binding_env) do
+    get_mod(scope_alias, binding_env)
+  end
+
   defp get_mod(scope_alias, binding_env) do
-    case scope_alias do
-      {:__aliases__, _, [scope_alias]} -> scope_alias
-      _ -> Source.get_mod([scope_alias], binding_env)
+    with {mod, _} <- Source.get_mod([scope_alias], binding_env) do
+      mod
     end
   end
 end

--- a/lib/elixir_sense/plugins/phoenix/scope.ex
+++ b/lib/elixir_sense/plugins/phoenix/scope.ex
@@ -1,4 +1,6 @@
 defmodule ElixirSense.Plugins.Phoenix.Scope do
+  @moduledoc false
+
   alias ElixirSense.Core.Source
   alias ElixirSense.Core.Binding
 

--- a/lib/elixir_sense/plugins/phoenix/scope.ex
+++ b/lib/elixir_sense/plugins/phoenix/scope.ex
@@ -21,8 +21,7 @@ defmodule ElixirSense.Plugins.Phoenix.Scope do
       path
       |> Enum.filter(&match?({:scope, _, _}, &1))
       |> Enum.map(fn {:scope, meta, params} ->
-        # drop `do` block from params
-        params = Enum.filter(params, &(not match?([{:do, _} | _], &1)))
+        params = Enum.reject(params, &match?([{:do, _} | _], &1))
         {:scope, meta, params}
       end)
 
@@ -90,11 +89,8 @@ defmodule ElixirSense.Plugins.Phoenix.Scope do
 
   defp get_mod(scope_alias, binding_env) do
     case scope_alias do
-      {:__aliases__, _, [scope_alias]} ->
-        scope_alias
-
-      _ ->
-        Source.get_mod([scope_alias], binding_env)
+      {:__aliases__, _, [scope_alias]} -> scope_alias
+      _ -> Source.get_mod([scope_alias], binding_env)
     end
   end
 end

--- a/lib/elixir_sense/plugins/phoenix/scope.ex
+++ b/lib/elixir_sense/plugins/phoenix/scope.ex
@@ -1,0 +1,100 @@
+defmodule ElixirSense.Plugins.Phoenix.Scope do
+  alias ElixirSense.Core.Source
+  alias ElixirSense.Core.Binding
+
+  import Module, only: [safe_concat: 2, safe_concat: 1]
+
+  def within_scope(buffer, binding_env \\ %Binding{}) do
+    {:ok, ast} = Code.Fragment.container_cursor_to_quoted(buffer)
+
+    with {true, scopes_ast} <- get_scopes(ast),
+         scopes_ast = Enum.reverse(scopes_ast),
+         scope_alias <- get_scope_alias(scopes_ast, binding_env) do
+      {true, scope_alias}
+    end
+  end
+
+  defp get_scopes(ast) do
+    path = Macro.path(ast, &match?({:__cursor__, _, _}, &1))
+
+    scopes =
+      path
+      |> Enum.filter(&match?({:scope, _, _}, &1))
+      |> Enum.map(fn {:scope, meta, params} ->
+        # drop `do` block from params
+        params = Enum.filter(params, &(not match?([{:do, _} | _], &1)))
+        {:scope, meta, params}
+      end)
+
+    case scopes do
+      [] -> {false, nil}
+      scopes -> {true, scopes}
+    end
+  end
+
+  defp get_scope_alias(scopes_ast, binding_env, module \\ nil)
+
+  # is this possible? scope do ... end
+  defp get_scope_alias([{:scope, _, []}], _binding_env, module), do: module
+
+  # scope "/" do ... end
+  defp get_scope_alias([{:scope, _, [scope_params]}], _binding_env, module)
+       when not is_list(scope_params),
+       do: module
+
+  # scope path: "/", alias: ExampleWeb do ... end
+  defp get_scope_alias([{:scope, _, [scope_params]}], binding_env, module)
+       when is_list(scope_params) do
+    scope_alias = Keyword.get(scope_params, :alias)
+    scope_alias = get_mod(scope_alias, binding_env)
+    safe_concat(module, scope_alias)
+  end
+
+  # scope "/", alias: ExampleWeb do ... end
+  defp get_scope_alias(
+         [{:scope, _, [_scope_path, scope_params]}],
+         binding_env,
+         module
+       )
+       when is_list(scope_params) do
+    scope_alias = Keyword.get(scope_params, :alias)
+    scope_alias = get_mod(scope_alias, binding_env)
+    safe_concat(module, scope_alias)
+  end
+
+  # scope "/", ExampleWeb do ... end
+  defp get_scope_alias(
+         [{:scope, _, [_scope_path, scope_alias]}],
+         binding_env,
+         module
+       ) do
+    scope_alias = get_mod(scope_alias, binding_env)
+    safe_concat(module, scope_alias)
+  end
+
+  # scope "/", ExampleWeb, host: "api." do ... end
+  defp get_scope_alias(
+         [{:scope, _, [_scope_path, scope_alias, _scope_params]}],
+         binding_env,
+         module
+       ) do
+    scope_alias = get_mod(scope_alias, binding_env)
+    safe_concat(module, scope_alias)
+  end
+
+  # recurse
+  defp get_scope_alias([head | tail], binding_env, module) do
+    scope_alias = get_scope_alias([head], binding_env, module)
+    safe_concat([module, scope_alias, get_scope_alias(tail, binding_env)])
+  end
+
+  defp get_mod(scope_alias, binding_env) do
+    case scope_alias do
+      {:__aliases__, _, [scope_alias]} ->
+        scope_alias
+
+      _ ->
+        Source.get_mod([scope_alias], binding_env)
+    end
+  end
+end

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -14,6 +14,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert nil == ElixirSense.definition("__MODULE__", 1, 1)
   end
 
+  @tag requires_elixir_1_14: true
   test "find module definition inside Phoenix's scope" do
     _define_existing_atom = ExampleWeb
 

--- a/test/elixir_sense/definition_test.exs
+++ b/test/elixir_sense/definition_test.exs
@@ -14,6 +14,26 @@ defmodule ElixirSense.Providers.DefinitionTest do
     assert nil == ElixirSense.definition("__MODULE__", 1, 1)
   end
 
+  test "find module definition inside Phoenix's scope" do
+    _define_existing_atom = ExampleWeb
+
+    buffer = """
+    defmodule ExampleWeb.Router do
+      import Phoenix.Router
+
+      scope "/", ExampleWeb do
+        get "/", PageController, :home
+      end
+    end
+    """
+
+    %Location{type: :module, file: file, line: line, column: column} =
+      ElixirSense.definition(buffer, 5, 15)
+
+    assert file =~ "elixir_sense/test/support/plugins/phoenix/page_controller.ex"
+    assert read_line(file, {line, column}) =~ "ExampleWeb.PageController"
+  end
+
   test "find definition of aliased modules in `use`" do
     buffer = """
     defmodule MyModule do
@@ -443,7 +463,7 @@ defmodule ElixirSense.Providers.DefinitionTest do
 
     defmodule B do
       @behaviour A
-      
+
       def abc, do: :ok
     end
 

--- a/test/elixir_sense/plugins/phoenix/scope_test.exs
+++ b/test/elixir_sense/plugins/phoenix/scope_test.exs
@@ -1,5 +1,6 @@
 defmodule ElixirSense.Plugins.Phoenix.ScopeTest do
   use ExUnit.Case
+  alias ElixirSense.Core.Binding
   alias ElixirSense.Plugins.Phoenix.Scope
 
   @moduletag requires_elixir_1_14: true
@@ -42,6 +43,68 @@ defmodule ElixirSense.Plugins.Phoenix.ScopeTest do
       """
 
       assert {true, ExampleWeb.Admin} = Scope.within_scope(buffer)
+    end
+
+    test "can expand module attributes" do
+      buffer = """
+      defmodule ExampleWeb.Router do
+        import Phoenix.Router
+        @web_prefix ExampleWweb
+
+        scope "/", @web_prefix do
+          get "/",
+      """
+
+      binding = %Binding{
+        structs: %{},
+        variables: [],
+        attributes: [
+          %ElixirSense.Core.State.AttributeInfo{
+            name: :web_prefix,
+            positions: [{4, 5}],
+            type: {:atom, ExampleWeb}
+          }
+        ],
+        current_module: ExampleWeb.Router,
+        imports: [{Kernel, []}, {Phoenix.Router, []}],
+        specs: %{},
+        types: %{},
+        mods_funs: %{}
+      }
+
+      assert {true, ExampleWeb} = Scope.within_scope(buffer, binding)
+    end
+
+    test "can expand variables" do
+      buffer = """
+      defmodule ExampleWeb.Router do
+        import Phoenix.Router
+        web_prefix = ExampleWweb
+
+        scope "/", web_prefix do
+          get "/",
+      """
+
+      binding = %Binding{
+        structs: %{},
+        variables: [
+          %ElixirSense.Core.State.VarInfo{
+            name: :web_prefix,
+            positions: [{5, 5}],
+            scope_id: 2,
+            is_definition: true,
+            type: {:atom, ExampleWeb}
+          }
+        ],
+        attributes: [],
+        current_module: ExampleWeb.Router,
+        imports: [{Kernel, []}, {Phoenix.Router, []}],
+        specs: %{},
+        types: %{},
+        mods_funs: %{}
+      }
+
+      assert {true, ExampleWeb} = Scope.within_scope(buffer, binding)
     end
 
     test "returns false" do

--- a/test/elixir_sense/plugins/phoenix/scope_test.exs
+++ b/test/elixir_sense/plugins/phoenix/scope_test.exs
@@ -2,6 +2,7 @@ defmodule ElixirSense.Plugins.Phoenix.ScopeTest do
   use ExUnit.Case
   alias ElixirSense.Plugins.Phoenix.Scope
 
+  @moduletag requires_elixir_1_14: true
   describe "within_scope/1" do
     test "returns true and nil alias" do
       buffer = """

--- a/test/elixir_sense/plugins/phoenix/scope_test.exs
+++ b/test/elixir_sense/plugins/phoenix/scope_test.exs
@@ -1,0 +1,52 @@
+defmodule ElixirSense.Plugins.Phoenix.ScopeTest do
+  use ExUnit.Case
+  alias ElixirSense.Plugins.Phoenix.Scope
+
+  describe "within_scope/1" do
+    test "returns true and nil alias" do
+      buffer = """
+        scope "/" do
+          get "/",
+      """
+
+      assert {true, nil} = Scope.within_scope(buffer)
+    end
+
+    test "returns true and alias when passing alias as option" do
+      buffer = """
+        scope "/", alias: ExampleWeb do
+          get "/",
+      """
+
+      assert {true, ExampleWeb} = Scope.within_scope(buffer)
+    end
+
+    test "returns true and alias when passing alias as second parameter" do
+      buffer = """
+        scope "/", ExampleWeb do
+          get "/",
+      """
+
+      assert {true, ExampleWeb} = Scope.within_scope(buffer)
+    end
+
+    test "returns true and alias when nested within other scopes" do
+      _define_existing_atom = ExampleWeb.Admin
+      _define_existing_atom = Admin
+
+      buffer = """
+        scope "/", ExampleWeb do
+          scope "/admin", Admin do
+            get "/",
+      """
+
+      assert {true, ExampleWeb.Admin} = Scope.within_scope(buffer)
+    end
+
+    test "returns false" do
+      buffer = "get \"\\\" ,"
+
+      assert {false, nil} = Scope.within_scope(buffer)
+    end
+  end
+end

--- a/test/elixir_sense/plugins/phoenix_test.exs
+++ b/test/elixir_sense/plugins/phoenix_test.exs
@@ -2,6 +2,7 @@ defmodule ElixirSense.Plugins.PhoenixTest do
   use ExUnit.Case
   import TestHelper
 
+  @moduletag requires_elixir_1_14: true
   describe "suggestions/4" do
     test "overrides with controllers for phoenix_route_funcs, when in the second parameter" do
       buffer = """

--- a/test/elixir_sense/plugins/phoenix_test.exs
+++ b/test/elixir_sense/plugins/phoenix_test.exs
@@ -1,0 +1,129 @@
+defmodule ElixirSense.Plugins.PhoenixTest do
+  use ExUnit.Case
+  import TestHelper
+
+  describe "suggestions/4" do
+    test "overrides with controllers for phoenix_route_funcs, when in the second parameter" do
+      buffer = """
+      defmodule ExampleWeb.Router do
+        import Phoenix.Router
+
+        get "/", P
+        #         ^
+      end
+      """
+
+      [cursor] = cursors(buffer)
+
+      result = suggestions(buffer, cursor)
+
+      assert [
+               %{
+                 type: :generic,
+                 kind: :class,
+                 label: "ExampleWeb.PageController",
+                 insert_text: "ExampleWeb.PageController",
+                 detail: "Phoenix controller"
+               }
+             ] = result
+    end
+
+    test "do not prepend alias defined within Phoenix `scope` functions" do
+      _define_existing_atom = ExampleWeb
+
+      buffer = """
+        defmodule ExampleWeb.Router do
+          import Phoenix.Router
+
+          scope "/", ExampleWeb do
+            get "/", P
+            #         ^
+          end
+        end
+      """
+
+      [cursor] = cursors(buffer)
+
+      result = suggestions(buffer, cursor)
+
+      assert [
+               %{
+                 type: :generic,
+                 kind: :class,
+                 label: "ExampleWeb.PageController",
+                 insert_text: "PageController",
+                 detail: "Phoenix controller"
+               }
+             ] = result
+    end
+
+    test "overrides with action suggestions for phoenix_route_funcs, when in the third parameter" do
+      buffer = """
+      defmodule ExampleWeb.Router do
+        import Phoenix.Router
+
+        get "/", ExampleWeb.PageController, :
+        #                                    ^
+      end
+      """
+
+      [cursor] = cursors(buffer)
+
+      result = suggestions(buffer, cursor)
+
+      assert [
+               %{
+                 detail: "Phoenix action",
+                 insert_text: "home",
+                 kind: :function,
+                 label: ":home",
+                 type: :generic
+               }
+             ] = result
+    end
+
+    test "overrides with action suggestions even when inside scope" do
+      buffer = """
+      defmodule ExampleWeb.Router do
+        import Phoenix.Router
+
+        scope "/", ExampleWeb do
+          get "/", PageController, :
+          #                         ^
+        end
+      end
+      """
+
+      [cursor] = cursors(buffer)
+
+      result = suggestions(buffer, cursor)
+
+      assert [
+               %{
+                 detail: "Phoenix action",
+                 insert_text: "home",
+                 kind: :function,
+                 label: ":home",
+                 type: :generic
+               }
+             ] = result
+    end
+
+    test "ignores for non-phoenix_route_funcs" do
+      buffer = """
+      defmodule ExampleWeb.Router do
+        import Phoenix.Router
+
+        something_else "/", P
+        #                    ^
+      end
+      """
+
+      [cursor] = cursors(buffer)
+
+      result = suggestions(buffer, cursor)
+
+      refute Enum.find(result, &(&1[:detail] == "Phoenix controller"))
+    end
+  end
+end

--- a/test/support/plugins/phoenix/page_controller.ex
+++ b/test/support/plugins/phoenix/page_controller.ex
@@ -1,0 +1,10 @@
+defmodule ExampleWeb.PageController do
+  def call(_conn, _params) do
+  end
+
+  def action(_conn, _params) do
+  end
+
+  def home(_conn, _params) do
+  end
+end

--- a/test/support/plugins/phoenix/router.ex
+++ b/test/support/plugins/phoenix/router.ex
@@ -1,0 +1,4 @@
+defmodule Phoenix.Router do
+  def get(_route, _plug, _plut_opts, _opts \\ []) do
+  end
+end


### PR DESCRIPTION
## Description
This PR has two features:
1. Enable Go To Definition when inside a Phoenix `scope`;
2. Override Auto Complete for the controller argument if the function is one of the predefined ones from Phoenix.Route;
3. Override Auto Complete for the action argument if the function is one of the predefined ones from Phoenix.Route.

The PR is in draft, anything can be discussed. I though this could be a valuable contribution given the widespread usage of Phoenix.

## TODO

- [x] Feature Gate this behind Elixir >1.14 – it uses `Macro.path/2`
- [x] Expand scope alias when they're defined with module attributes or variables

