### PR TITLE
Use a runtime check for `Macro.classify_atom/1`

### DIFF
--- a/lib/elixir_sense/providers/completion/completion_engine.ex
+++ b/lib/elixir_sense/providers/completion/completion_engine.ex
@@ -850,19 +850,18 @@ defmodule ElixirSense.Providers.Completion.CompletionEngine do
 
   ## Helpers
 
-  # Version.match? is slow, we need to avoid it in a hot loop
-  if Version.match?(System.version(), ">= 1.14.0-dev") do
-    defp usable_as_unquoted_module?(name) do
-      # Conversion to atom is not a problem because
-      # it is only called with existing modules names.
-      # credo:disable-for-lines:7
-      Macro.classify_atom(String.to_atom(name)) in [:identifier, :unquoted] and
-        not String.starts_with?(name, "Elixir.")
-    end
-  else
-    defp usable_as_unquoted_module?(name) do
-      Code.Identifier.classify(String.to_atom(name)) != :other and
-        not String.starts_with?(name, "Elixir.")
+  defp usable_as_unquoted_module?(name) do
+    unquoted_atom_or_identifier?(String.to_atom(name)) and
+      not String.starts_with?(name, "Elixir.")
+  end
+
+  defp unquoted_atom_or_identifier?(atom) when is_atom(atom) do
+    # Macro.classify_atom/1 was introduced in 1.14.0. If it's not available,
+    # assume we're on an older version and fall back to a private API.
+    if function_exported?(Macro, :classify_atom, 1) do
+      apply(Macro, :classify_atom, [atom]) in [:identifier, :unquoted]
+    else
+      apply(Code.Identifier, :classify, [atom]) != :other
     end
   end
 


### PR DESCRIPTION
We ran into an issue in Lexical reported here: https://github.com/lexical-lsp/lexical/issues/805

Lexical is packaged by precompiling everything, usually on the lowest supported version of Elixir/OTP, and then injecting those compiled modules when launching the runtime node where user project code runs. This means that compile-time version checks could lead to an unexpected code branch at runtime, as the runtime might be a later version.

I think this would *usually* be okay, since compile-time version checks are usually there to use new APIs and fall back to ones that would still work, but in this case, a private API (`Code.Identifier.classify`) was being used that no longer exists in 1.14+.

I know this code-path is performance-sensitive, but a quick Benchee shows that `function_exported?/3` is a small fraction of the cost of `Version.match?/2`:

```
Name                              ips        average  deviation         median         99th %
using_function_exported       12.31 M      0.0812 μs ±10125.72%      0.0800 μs       0.100 μs
using_version_check            0.26 M        3.84 μs   ±605.70%        3.28 μs        7.38 μs

Comparison:
using_function_exported       12.31 M
using_version_check            0.26 M - 47.28x slower +3.76 μs
```

I've confirmed locally that this change addresses the issue linked above.