### PR TITLE
fix: handle case where guard does not produce variable, but a . expr

### DIFF
--- a/lib/elixir_sense/core/guard.ex
+++ b/lib/elixir_sense/core/guard.ex
@@ -45,9 +45,15 @@ defmodule ElixirSense.Core.Guard do
         {guard_predicate, _, params} = node, acc ->
           case guard_predicate_type(guard_predicate, params, state) do
             {type, binding} ->
-              {var, _, nil} = binding
-              # If we found the predicate type, we can prematurely exit traversing the subtree
-              {[], [{var, type} | acc]}
+              case binding do
+                # If we found the predicate type, we can prematurely exit traversing the subtree
+                {var, _, nil} ->
+                  {[], [{var, type} | acc]}
+
+                _ ->
+                  {node, acc}
+
+              end
 
             nil ->
               {node, acc}
@@ -61,7 +67,7 @@ defmodule ElixirSense.Core.Guard do
   end
 
   defp guard_predicate_type(p, params, _)
-       when p in [:is_number, :is_float, :is_integer, :round, :trunc, :div, :rem, :abs],
+       when p in [:is_number, :is_float, :is_integer, :round, :trunc, :div, :rem, :abs, :floor, :ceil],
        do: {:number, hd(params)}
 
   defp guard_predicate_type(p, params, _) when p in [:is_binary, :binary_part],

--- a/test/elixir_sense/core/metadata_builder_test.exs
+++ b/test/elixir_sense/core/metadata_builder_test.exs
@@ -1018,7 +1018,7 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
           &1,
           abc,
           cde = 1,
-          record_env()  
+          record_env()
         ]
         record_env()
         """
@@ -1213,6 +1213,22 @@ defmodule ElixirSense.Core.MetadataBuilderTest do
       assert [
                %VarInfo{name: :abc, positions: [{2, 11}, {3, 10}]}
              ] = state |> get_line_vars(3)
+    end
+
+    test "guards referencing `map.field` don't have match errors" do
+      logs =
+        ExUnit.CaptureLog.capture_log(fn ->
+          """
+          defmodule My do
+            def foo(abc) when is_atom(abc.foo) do
+              record_env()
+            end
+          end
+          """
+          |> string_to_state
+        end)
+
+      refute String.contains?(logs, "MatchError")
     end
   end
 


### PR DESCRIPTION
This is a simple fix but may not be the fully correct answer. This essentially discards information in the form of:

```elixir
def fun(map) when is_atom(map.foo)
```

From what I can tell, it used to be the case that eventually a root node in guard AST would always resolve to a variable, but now it can resolve to `var.value`.

What I'm not sure of is whether or not this `var.value` can be used for something or if it should just be discarded as I'm discarding it.