### PR TITLE
fix: include new plugin behaviour in detection list

### DIFF
--- a/lib/elixir_sense/providers/plugins/module_store.ex
+++ b/lib/elixir_sense/providers/plugins/module_store.ex
@@ -51,7 +51,8 @@ defmodule ElixirSense.Providers.Plugins.ModuleStore do
     module.module_info(:attributes)
     |> Enum.any?(fn
       {:behaviour, behaviours} when is_list(behaviours) ->
-        ElixirSense.Plugin in behaviours or ElixirLS.LanguageServer.Plugin in behaviours
+        ElixirSense.Plugin in behaviours or ElixirLS.LanguageServer.Plugin in behaviours or
+          ElixirSense.Providers.Plugin in behaviours
 
       {:is_elixir_sense_plugin, true} ->
         true

--- a/lib/elixir_sense/providers/plugins/module_store.ex
+++ b/lib/elixir_sense/providers/plugins/module_store.ex
@@ -54,11 +54,11 @@ defmodule ElixirSense.Providers.Plugins.ModuleStore do
         ElixirSense.Plugin in behaviours or ElixirLS.LanguageServer.Plugin in behaviours or
           ElixirSense.Providers.Plugin in behaviours
 
-      {:is_elixir_sense_plugin, true} ->
-        true
+      {:is_elixir_sense_plugin, value} ->
+        true in List.wrap(value)
 
-      {:is_elixir_ls_plugin, true} ->
-        true
+      {:is_elixir_ls_plugin, value} ->
+        true in List.wrap(value)
 
       _ ->
         false


### PR DESCRIPTION
The plugin module was renamed from `ElixirSense.Plugin` to `ElixirLS.LanguageServer.Plugin`, to `ElixirSense.Providers.Plugin` (both renames broke spark's plugin, not a big deal but if you can try not to rename those modules w/o letting me know so I can get ahead of it w/ a release of spark, that would be great.)

However, the new behaviour module is not in the list used to detect a plugin, so I have to use a behaviour that doesn't exist.

Additionally, module attributes from `.module_info` that are persisted appear (or can appear) as lists, and so we need to update the way we check for those flags.

This stuff has a lot of cruft, and I fully understand if we need to change it in the future, and I'm happy to participate in whatever changes we want to make. I know that there are likely changes coming to language servers soon, my only request is that I'm given a chance to justify the plugin logic's existence. It truly is a huge quality of life improvement for Ash users :)