### PR TITLE
Fix typo in compiler comment

### DIFF
--- a/lib/elixir_sense/core/compiler.ex
+++ b/lib/elixir_sense/core/compiler.ex
@@ -1768,7 +1768,7 @@ defmodule ElixirSense.Core.Compiler do
           state = State.new_func_vars_scope(state)
 
           # elixir dispatches callbacks by raw dispatch and eval_forms
-          # instead we expand a bock with require and possibly expand macros
+          # instead we expand a block with require and possibly expand macros
           # we do not attempt to exec function callbacks
           args =
             case attribute do


### PR DESCRIPTION
## Summary
- correct 'bock' to 'block'

## Testing
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6848bbeddd4483218b6988af0512b62c