### PR TITLE
Update module docs for clarity

### DIFF
--- a/lib/elixir_sense.ex
+++ b/lib/elixir_sense.ex
@@ -1,9 +1,10 @@
 defmodule ElixirSense do
   @moduledoc """
-  ElxirSense is a Elixir library that implements useful features for any editor/tool that needs
-  to introspect context-aware information about Elixir source code.
+  ElixirSense is an Elixir library that implements useful features for any editor
+  or tool that needs to introspect context-aware information about Elixir source code.
 
-  This module provides the basic functionality for context-aware code completion, docs, signature info and more.
+  This module provides basic functionality for context-aware code completion,
+  docs, signature info, and more.
   """
 
   alias ElixirSense.Core.Applications


### PR DESCRIPTION
## Summary
- fix typo in module docs of `ElixirSense`

## Testing
- `mix format lib/elixir_sense.ex`
- `mix test` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6848bbf140d08321949c0b3d4ea8aac4