### PR TITLE
Fix typo in compiler comment

### DIFF
--- a/lib/elixir_sense/core/compiler/state.ex
+++ b/lib/elixir_sense/core/compiler/state.ex
@@ -153,7 +153,7 @@ defmodule ElixirSense.Core.Compiler.State do
           nil
 
         {protocol, for_list} ->
-          # check wether we are in implementation or implementation child module
+          # check whether we are in implementation or implementation child module
           if Enum.any?(for_list, fn for -> macro_env.module == Module.concat(protocol, for) end) do
             {protocol, for_list}
           end


### PR DESCRIPTION
## Summary
- fix spelling mistake in compiler state comment

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bca06ed48321bbccf32d74e2a5f6