### PR TITLE
Update ModuleStore type

### DIFF
--- a/lib/elixir_sense/providers/plugins/module_store.ex
+++ b/lib/elixir_sense/providers/plugins/module_store.ex
@@ -1,11 +1,11 @@
 defmodule ElixirSense.Providers.Plugins.ModuleStore do
   @moduledoc """
-  Caches the module list and a list of modules keyed by the behaviour they implement.
+  Caches the module list and a set of modules keyed by the behaviour they implement.
   """
   defstruct by_behaviour: %{}, list: [], plugins: []
 
   @type t :: %__MODULE__{
-          by_behaviour: %{optional(atom) => module},
+          by_behaviour: %{optional(atom) => MapSet.t(module)},
           list: list(module),
           plugins: list(module)
         }


### PR DESCRIPTION
## Summary
- document that ModuleStore caches modules in sets by behaviour
- type by_behaviour as `%{optional(atom) => MapSet.t(module)}`

## Testing
- `mix deps.get` *(fails: Unknown package bunt in lockfile)*
- `mix test` *(fails: dependencies missing)*


------
https://chatgpt.com/codex/tasks/task_e_6848bcb46ecc8321b1bae923c827017b