### PR TITLE
Update completion engine reference in docs

### DIFF
--- a/lib/elixir_sense/providers/completion/reducers/complete_engine.ex
+++ b/lib/elixir_sense/providers/completion/reducers/complete_engine.ex
@@ -11,7 +11,7 @@ defmodule ElixirSense.Providers.Completion.Reducers.CompleteEngine do
 
   @doc """
   A reducer that populates the context with the suggestions provided by
-  the `ElixirLS.Utils.CompletionEngine` module.
+  the `ElixirSense.Providers.Completion.CompletionEngine` module.
 
   The suggestions are grouped by type and saved in the context under the
   `:complete_engine_suggestions_by_type` key and can be accessed by any reducer


### PR DESCRIPTION
## Summary
- fix docs to reference `ElixirSense.Providers.Completion.CompletionEngine`

## Testing
- `mix docs` *(fails: dependency ex_doc missing)*
- `mix test` *(fails: dependency excoveralls missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849342d79b08321ba24b86f4b4ef8e8