### PR TITLE
Fix duplicated assertion

### DIFF
--- a/test/elixir_sense/log_test.exs
+++ b/test/elixir_sense/log_test.exs
@@ -33,7 +33,6 @@ defmodule ElixirSense.LogTest do
 
     test "warn emits no output" do
       assert capture_log(fn -> warn("hello") end) == ""
-      assert capture_log(fn -> warn("hello") end) == ""
     end
 
     test "error emits no output" do


### PR DESCRIPTION
## Summary
- remove duplicate assertion in log_test.exs

## Testing
- `mix test` *(fails: dependency excoveralls not available)*

------
https://chatgpt.com/codex/tasks/task_e_6849341ed6ac8321aacff6b3fbc08724