### PR TITLE
Fix duplicate alias in definition locator

### DIFF
--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -10,7 +10,6 @@ defmodule ElixirSense.Providers.Definition.Locator do
   alias ElixirSense.Core.Introspection
   alias ElixirSense.Core.Metadata
   alias ElixirSense.Core.State
-  alias ElixirSense.Core.State.ModFunInfo
   alias ElixirSense.Core.Source
   alias ElixirSense.Core.SurroundContext
   alias ElixirSense.Providers.Location


### PR DESCRIPTION
## Summary
- remove unused alias in definition locator

## Testing
- `mix deps.get` *(fails: `mix` not found)*
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff5f722fc8321b1d381d1e634647a