### PR TITLE
Fix docs reference for CompletionEngine

### DIFF
--- a/lib/elixir_sense/providers/completion/reducers/complete_engine.ex
+++ b/lib/elixir_sense/providers/completion/reducers/complete_engine.ex
@@ -11,7 +11,7 @@ defmodule ElixirSense.Providers.Completion.Reducers.CompleteEngine do
 
   @doc """
   A reducer that populates the context with the suggestions provided by
-  the `ElixirLS.Utils.CompletionEngine` module.
+  the `ElixirSense.Providers.Completion.CompletionEngine` module.
 
   The suggestions are grouped by type and saved in the context under the
   `:complete_engine_suggestions_by_type` key and can be accessed by any reducer


### PR DESCRIPTION
## Summary
- update docs in CompleteEngine reducer to reference proper module

## Testing
- `mix docs` *(fails: dependency download issue)*

------
https://chatgpt.com/codex/tasks/task_e_684ff60874008321952e2fbeeffbaeaf