### PR TITLE
Remove duplicate warn log assertion

### DIFF
--- a/test/elixir_sense/log_test.exs
+++ b/test/elixir_sense/log_test.exs
@@ -33,7 +33,6 @@ defmodule ElixirSense.LogTest do
 
     test "warn emits no output" do
       assert capture_log(fn -> warn("hello") end) == ""
-      assert capture_log(fn -> warn("hello") end) == ""
     end
 
     test "error emits no output" do


### PR DESCRIPTION
## Summary
- clean up duplicate assertion in log tests

## Testing
- `mix test` *(fails: Could not install Hex metadata)*

------
https://chatgpt.com/codex/tasks/task_e_684ff60f83c083219c51ce9ce58f5255