### PR TITLE
Fix plugin reduce typespec

### DIFF
--- a/lib/elixir_sense/providers/plugins/plugin.ex
+++ b/lib/elixir_sense/providers/plugins/plugin.ex
@@ -12,7 +12,7 @@ defmodule ElixirSense.Providers.Plugin do
         }
 
   @callback reduce(
-              hint :: String,
+              hint :: String.t(),
               env :: State.Env.t(),
               buffer_metadata :: Metadata.t(),
               cursor_context,


### PR DESCRIPTION
## Summary
- use `String.t()` instead of `String` for the `hint` parameter

## Testing
- `mix compile --no-deps-check`

------
https://chatgpt.com/codex/tasks/task_e_684ff614084883219e53a7abb299e373