### PR TITLE
Fix moduledoc syntax

### DIFF
--- a/lib/elixir_sense/providers/completion/reducer.ex
+++ b/lib/elixir_sense/providers/completion/reducer.ex
@@ -1,7 +1,7 @@
 defmodule ElixirSense.Providers.Completion.Reducer do
-  @moduledoc !"""
-             Provides common functions for reducers.
-             """
+  @moduledoc """
+  Provides common functions for reducers.
+  """
 
   def put_context(acc, key, value) do
     updated_context = Map.put(acc.context, key, value)


### PR DESCRIPTION
## Summary
- clean up invalid moduledoc syntax in reducer

## Testing
- `mix compile --force --no-deps-check`
- `mix test --no-deps-check` *(fails: could not find application file: excoveralls.app)*

------
https://chatgpt.com/codex/tasks/task_e_684ff61720b48321b08c3e8b216c3d6b