### PR TITLE
Fix type spec for signature

### DIFF
--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -46,7 +46,7 @@ defmodule ElixirSense.Core.Metadata do
             moduledoc_positions: %{}
 
   @type signature_t :: %{
-          optional(:active_param) => :non_neg_integer,
+          optional(:active_param) => non_neg_integer(),
           name: String.t(),
           params: [String.t()],
           spec: String.t(),


### PR DESCRIPTION
## Summary
- use `non_neg_integer()` rather than atom `:non_neg_integer` in `@type signature_t`

## Testing
- `mix test`

------
https://chatgpt.com/codex/tasks/task_e_685076d933a08321a1689fe0b8686e09