### PR TITLE
Add spec for docs/4 return

### DIFF
--- a/lib/elixir_sense/providers/hover/docs.ex
+++ b/lib/elixir_sense/providers/hover/docs.ex
@@ -59,10 +59,15 @@ defmodule ElixirSense.Providers.Hover.Docs do
 
   @type doc :: module_doc | function_doc | type_doc | variable_doc | attribute_doc | keyword_doc
 
+  @type position :: {pos_integer, pos_integer}
+  @type range :: %{begin: position, end: position}
+  @type docs_info :: %{docs: [doc], range: range}
+
   @builtin_functions BuiltinFunctions.all()
                      |> Enum.map(&elem(&1, 0))
                      |> Kernel.--([:exception, :message])
 
+  @spec docs(String.t(), pos_integer, pos_integer, keyword()) :: docs_info | nil
   def docs(code, line, column, options \\ []) do
     case NormalizedCode.Fragment.surround_context(code, {line, column}) do
       :none ->


### PR DESCRIPTION
## Summary
- specify `docs/4` return map with new types
- add `@spec` for `docs/4`

## Testing
- `mix test`

------
https://chatgpt.com/codex/tasks/task_e_685081771c2883219653a7e88d93188f