### PR TITLE
Add spec for Options.get_param_options

### DIFF
--- a/lib/elixir_sense/core/options.ex
+++ b/lib/elixir_sense/core/options.ex
@@ -70,6 +70,13 @@ defmodule ElixirSense.Core.Options do
     end
   end
 
+  @spec get_param_options(
+          module,
+          atom,
+          non_neg_integer,
+          ElixirSense.Core.State.Env.t(),
+          ElixirSense.Core.Metadata.t()
+        ) :: [atom | {atom, Macro.t()}]
   def get_param_options(module, function, arity, env, metadata) do
     behaviours = env.behaviours
 


### PR DESCRIPTION
## Summary
- document parameters and return type for `get_param_options/5`

## Testing
- `mix test`

------
https://chatgpt.com/codex/tasks/task_e_68508168ee548321a4bbedd8257f9499