### PR TITLE
Add spec for References Locator

### DIFF
--- a/lib/elixir_sense/providers/references/locator.ex
+++ b/lib/elixir_sense/providers/references/locator.ex
@@ -13,6 +13,13 @@ defmodule ElixirSense.Providers.References.Locator do
   alias ElixirSense.Core.SurroundContext
   alias ElixirSense.Core.Parser
 
+  @spec references(
+          String.t(),
+          pos_integer,
+          pos_integer,
+          ElixirSense.call_trace_t(),
+          keyword()
+        ) :: [reference_info()]
   def references(code, line, column, trace, options \\ []) do
     case NormalizedCode.Fragment.surround_context(code, {line, column}) do
       :none ->


### PR DESCRIPTION
## Summary
- add `@spec` for `ElixirSense.Providers.References.Locator.references/5`
- use local `reference_info()` type in spec

## Testing
- `mix format lib/elixir_sense/providers/references/locator.ex`
- `MIX_ENV=test mix test`


------
https://chatgpt.com/codex/tasks/task_e_68507724663c8321942e82dcfd9eb309