### PR TITLE
Add spec for field types retrieval

### DIFF
--- a/lib/elixir_sense/providers/utils/field.ex
+++ b/lib/elixir_sense/providers/utils/field.ex
@@ -4,6 +4,7 @@ defmodule ElixirSense.Providers.Utils.Field do
   alias ElixirSense.Core.Normalized.Typespec
   alias ElixirSense.Core.TypeInfo
 
+  @spec get_field_types(Metadata.t(), module, boolean) :: %{optional(atom) => Macro.t()}
   def get_field_types(%Metadata{} = metadata, mod, include_private) when is_atom(mod) do
     case get_field_types_from_metadata(metadata, mod, include_private) do
       nil -> get_field_types_from_introspection(mod, include_private)


### PR DESCRIPTION
## Summary
- specify `get_field_types/3` return type and arguments

## Testing
- `mix test`

------
https://chatgpt.com/codex/tasks/task_e_6850818438908321a78e8d61b2ed3909