### PR TITLE
Support finding function definition defined in `__using__` macro

### DIFF
--- a/lib/elixir_sense/core/compiler.ex
+++ b/lib/elixir_sense/core/compiler.ex
@@ -951,6 +951,27 @@ defmodule ElixirSense.Core.Compiler do
   defp expand_macro(
          meta,
          Kernel,
+         :use,
+         [target_module | _opts] = args,
+         callback,
+         state,
+         env
+       ) do
+    {expanded_module, state, env} = expand(target_module, state, env)
+
+    state =
+      if is_atom(expanded_module) do
+        State.add_use(expanded_module, state, env)
+      else
+        state
+      end
+
+    expand_macro_callback(meta, Kernel, :use, args, callback, state, env)
+  end
+
+  defp expand_macro(
+         meta,
+         Kernel,
          :defdelegate,
          [funs, opts],
          _callback,
@@ -2153,8 +2174,10 @@ defmodule ElixirSense.Core.Compiler do
       # If expanding the macro fails, we just give up.
       _kind, _payload ->
         # Logger.warning(Exception.format(kind, payload, __STACKTRACE__))
+        uses = state.uses
         # look for cursor in args
         {_ast, state, _env} = expand(args, state, env)
+        state = %{state | uses: uses}
 
         {{{:., meta, [module, fun]}, meta, args}, state, env}
     else

--- a/lib/elixir_sense/core/compiler/state.ex
+++ b/lib/elixir_sense/core/compiler/state.ex
@@ -48,6 +48,7 @@ defmodule ElixirSense.Core.Compiler.State do
           attributes: list(list(ElixirSense.Core.State.AttributeInfo.t())),
           scope_attributes: list(list(atom)),
           behaviours: %{optional(module) => [module]},
+          uses: %{optional(module) => [module]},
           specs: specs_t,
           types: types_t,
           mods_funs_to_positions: mods_funs_to_positions_t,
@@ -88,6 +89,7 @@ defmodule ElixirSense.Core.Compiler.State do
   defstruct attributes: [[]],
             scope_attributes: [[]],
             behaviours: %{},
+            uses: %{},
             specs: %{},
             types: %{},
             mods_funs_to_positions: %{},
@@ -1049,6 +1051,12 @@ defmodule ElixirSense.Core.Compiler.State do
   end
 
   def add_behaviour(_module, %__MODULE__{} = state, env), do: {nil, state, env}
+
+  def add_use(module, %__MODULE__{} = state, env) when is_atom(module) and not is_nil(module) do
+    update_in(state.uses[env.module], &Enum.uniq([module | &1 || []]))
+  end
+
+  def add_use(_module, %__MODULE__{} = state, _env), do: state
 
   def register_doc(%__MODULE__{} = state, env, :moduledoc, doc_arg) do
     current_module = env.module

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -25,6 +25,7 @@ defmodule ElixirSense.Core.Metadata do
           specs: ElixirSense.Core.Compiler.State.specs_t(),
           structs: ElixirSense.Core.Compiler.State.structs_t(),
           records: ElixirSense.Core.Compiler.State.records_t(),
+          uses: %{optional(module) => [module]},
           error: nil | term,
           first_alias_positions: map(),
           moduledoc_positions: map()
@@ -41,6 +42,7 @@ defmodule ElixirSense.Core.Metadata do
             specs: %{},
             structs: %{},
             records: %{},
+            uses: %{},
             error: nil,
             first_alias_positions: %{},
             moduledoc_positions: %{}
@@ -62,6 +64,7 @@ defmodule ElixirSense.Core.Metadata do
       specs: acc.specs,
       structs: acc.structs,
       records: acc.records,
+      uses: acc.uses,
       mods_funs_to_positions: acc.mods_funs_to_positions,
       lines_to_env: acc.lines_to_env,
       vars_info_per_scope_id: acc.vars_info_per_scope_id,

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -190,6 +190,7 @@ defmodule ElixirSense.Core.Parser do
       specs: acc.specs,
       structs: acc.structs,
       records: acc.records,
+      uses: acc.uses,
       mods_funs_to_positions: acc.mods_funs_to_positions,
       cursor_env: acc.cursor_env,
       closest_env: acc.closest_env,

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -250,19 +250,47 @@ defmodule ElixirSense.Providers.Definition.Locator do
 
         case fn_definition do
           nil ->
-            Location.find_mod_fun_source(mod, fun, call_arity)
+            # Try to find function in __using__ macro before giving up and pointing to the macro use
+            case find_function_in_module_using_macro(mod, fun, metadata) do
+              %Location{file: file} = location when not is_nil(file) ->
+                location
+
+              _ ->
+                Location.find_mod_fun_source(mod, fun, call_arity)
+            end
 
           %ModFunInfo{} = info ->
             {{line, column}, {end_line, end_column}} = Location.info_to_range(info)
 
-            %Location{
-              file: nil,
-              type: ModFunInfo.get_category(info),
-              line: line,
-              column: column,
-              end_line: end_line,
-              end_column: end_column
-            }
+            if ModFunInfo.get_category(info) in [:function, :macro] do
+              # First try to use find_function_in_module_using_macro for external modules
+              # This is needed when the function is defined in a different file via __using__
+              case find_function_in_module_using_macro(mod, fun, metadata) do
+                %Location{file: file} = location when not is_nil(file) ->
+                  location
+
+                _ ->
+                  find_function_in_using_macro(
+                    metadata,
+                    env,
+                    line,
+                    column,
+                    end_line,
+                    end_column,
+                    fun,
+                    info
+                  )
+              end
+            else
+              %Location{
+                file: nil,
+                type: ModFunInfo.get_category(info),
+                line: line,
+                column: column,
+                end_line: end_line,
+                end_column: end_column
+              }
+            end
         end
 
       {mod, fun, true, :type} ->
@@ -311,6 +339,264 @@ defmodule ElixirSense.Providers.Definition.Locator do
       {true, {:atom, module}} -> {true, module}
       {false, {:atom, module}} -> module
       _ -> nil
+    end
+  end
+
+  defp resolve_use_module({:__aliases__, _, parts}, env) do
+    [head | tail] = parts
+
+    case Keyword.fetch(env.aliases, Module.concat(Elixir, head)) do
+      {:ok, aliased_mod} ->
+        Module.concat([aliased_mod | tail])
+
+      :error ->
+        Module.concat(parts)
+    end
+  end
+
+  defp resolve_use_module(atom, _env) when is_atom(atom), do: atom
+  defp resolve_use_module(_, _), do: nil
+
+  defp find_function_in_module_using_macro(mod, fun, metadata) do
+    if Map.has_key?(metadata.mods_funs_to_positions, {mod, nil, nil}) do
+      # Module is in the current source - use metadata.source
+      find_used_modules_and_search_in_source(metadata.source, mod, fun)
+    else
+      # Module is external - try to get source file
+      with file when not is_nil(file) <- get_module_source_file(mod),
+           {:ok, content} <- File.read(file) do
+        find_used_modules_and_search_in_source(content, mod, fun)
+      else
+        _ -> nil
+      end
+    end
+  end
+
+  defp get_module_source_file(mod) do
+    try do
+      compile_info = mod.__info__(:compile)
+      source = Keyword.get(compile_info, :source)
+      if source, do: to_string(source)
+    catch
+      _, _ ->
+        case Code.fetch_docs(mod) do
+          {:docs_v1, _, _, _, _, _, docs} when is_list(docs) ->
+            docs
+            |> Enum.find_value(fn
+              {{_, _, _}, _, _, _, meta} when is_map(meta) ->
+                Map.get(meta, :source)
+
+              _ ->
+                nil
+            end)
+
+          _ ->
+            try do
+              case :code.get_object_code(mod) do
+                {^mod, bin, _} ->
+                  case :beam_lib.chunks(bin, [:debug_info]) do
+                    {:ok, {_, [{:debug_info, {:debug_info_v1, _, {_, %{file: file}, _}}}]}} ->
+                      to_string(file)
+
+                    _ ->
+                      nil
+                  end
+
+                _ ->
+                  nil
+              end
+            catch
+              _, _ -> nil
+            end
+        end
+    end
+  end
+
+  defp find_used_modules_and_search_in_source(source, mod, fun) do
+    with {:ok, ast} <- Code.string_to_quoted(source) do
+      collect_use_statements(ast, mod)
+      |> Enum.find_value(fn used_module ->
+        search_in_using_macro(used_module, fun)
+      end)
+    else
+      _ -> nil
+    end
+  end
+
+  defp collect_use_statements(ast, mod) do
+    target_parts = Module.split(mod)
+
+    {_, {_, modules}} =
+      Macro.traverse(
+        ast,
+        {[], []},
+        fn
+          {:defmodule, _meta, [module_ast | _]} = node, {stack, modules} ->
+            module_parts = module_ast_parts(module_ast)
+
+            full_parts =
+              case stack do
+                [parent_parts | _] when length(module_parts) == 1 ->
+                  parent_parts ++ module_parts
+
+                _ ->
+                  module_parts
+              end
+
+            {node, {[full_parts | stack], modules}}
+
+          {:use, _meta, [module_ast | _]} = node, {[current_parts | _] = stack, modules} ->
+            modules =
+              if current_parts == target_parts do
+                module = resolve_use_module(module_ast, %State.Env{aliases: []})
+                if module, do: [module | modules], else: modules
+              else
+                modules
+              end
+
+            {node, {stack, modules}}
+
+          node, acc ->
+            {node, acc}
+        end,
+        fn
+          {:defmodule, _meta, [_ | _]} = node, {[_ | rest], modules} ->
+            {node, {rest, modules}}
+
+          node, acc ->
+            {node, acc}
+        end
+      )
+
+    Enum.reverse(modules)
+  end
+
+  defp module_ast_parts({:__aliases__, _meta, parts}) do
+    parts
+    |> Module.concat()
+    |> Module.split()
+  end
+
+  defp module_ast_parts(atom) when is_atom(atom), do: Module.split(atom)
+  defp module_ast_parts(_), do: []
+
+  defp search_in_using_macro(module, fun) do
+    case Location.find_mod_fun_source(module, :__using__, :any) do
+      %Location{file: file, line: using_line, column: using_col} when not is_nil(file) ->
+        search_function_in_using_macro(file, using_line, using_col, fun)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp search_function_in_using_macro(file, using_line, using_col, fun) do
+    content = File.read!(file)
+    {_, suffix} = Source.split_at(content, using_line, using_col)
+    regex = ~r/def\s+(#{Regex.escape(Atom.to_string(fun))}\b)/
+
+    case Regex.run(regex, suffix, return: :index) do
+      [_entire_match, {fun_offset, _fun_len}] ->
+        {line_offset, col_offset} = calculate_offset(suffix, fun_offset)
+        target_line = using_line + line_offset
+        target_column = if line_offset == 0, do: using_col + col_offset, else: 1 + col_offset
+
+        %Location{
+          file: file,
+          type: :function,
+          line: target_line,
+          column: target_column,
+          end_line: target_line,
+          end_column: target_column
+        }
+
+      nil ->
+        nil
+    end
+  end
+
+  defp calculate_offset(suffix, fun_offset) do
+    suffix
+    |> String.slice(0, fun_offset)
+    |> Source.split_lines()
+    |> then(fn lines -> {length(lines) - 1, String.length(List.last(lines) || "")} end)
+  end
+
+  defp find_function_in_using_macro(metadata, env, line, column, end_line, end_column, fun, info) do
+    # This might be a function defined via `use`
+    # We need to find the `use` statement and the module being used
+    source_line = Source.split_lines(metadata.source) |> Enum.at(line - 1)
+
+    used_module =
+      case Code.string_to_quoted(source_line) do
+        {:ok, {:use, _, [module_ast | _]}} ->
+          resolve_use_module(module_ast, env)
+
+        _ ->
+          nil
+      end
+
+    case used_module do
+      nil ->
+        %Location{
+          file: nil,
+          type: if(info, do: ModFunInfo.get_category(info), else: :function),
+          line: line,
+          column: column,
+          end_line: end_line,
+          end_column: end_column
+        }
+
+      used_module ->
+        # Find __using__ macro in the used module
+        case Location.find_mod_fun_source(used_module, :__using__, :any) do
+          %Location{file: file, line: using_line, column: using_col} = using_location
+          when not is_nil(file) ->
+            # Function is defined inside quote block, not as actual module function.
+            # Use regex to find def within __using__ source text.
+            content = File.read!(file)
+            {_, suffix} = Source.split_at(content, using_line, using_col)
+
+            regex = ~r/def\s+(#{Regex.escape(Atom.to_string(fun))}\b)/
+
+            case Regex.run(regex, suffix, return: :index) do
+              [_entire_match, {fun_offset, _fun_len}] ->
+                {line_offset, col_offset} =
+                  suffix
+                  |> String.slice(0, fun_offset)
+                  |> Source.split_lines()
+                  |> then(fn lines ->
+                    {length(lines) - 1, String.length(List.last(lines) || "")}
+                  end)
+
+                target_line = using_line + line_offset
+
+                target_column =
+                  if line_offset == 0, do: using_col + col_offset, else: 1 + col_offset
+
+                %Location{
+                  file: file,
+                  type: :function,
+                  line: target_line,
+                  column: target_column,
+                  end_line: target_line,
+                  end_column: target_column
+                }
+
+              nil ->
+                using_location
+            end
+
+          _ ->
+            %Location{
+              file: nil,
+              type: if(info, do: ModFunInfo.get_category(info), else: :function),
+              line: line,
+              column: column,
+              end_line: end_line,
+              end_column: end_column
+            }
+        end
     end
   end
 end

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -373,43 +373,11 @@ defmodule ElixirSense.Providers.Definition.Locator do
   end
 
   defp get_module_source_file(mod) do
-    try do
-      compile_info = mod.__info__(:compile)
-      source = Keyword.get(compile_info, :source)
-      if source, do: to_string(source)
-    catch
-      _, _ ->
-        case Code.fetch_docs(mod) do
-          {:docs_v1, _, _, _, _, _, docs} when is_list(docs) ->
-            docs
-            |> Enum.find_value(fn
-              {{_, _, _}, _, _, _, meta} when is_map(meta) ->
-                Map.get(meta, :source)
-
-              _ ->
-                nil
-            end)
-
-          _ ->
-            try do
-              case :code.get_object_code(mod) do
-                {^mod, bin, _} ->
-                  case :beam_lib.chunks(bin, [:debug_info]) do
-                    {:ok, {_, [{:debug_info, {:debug_info_v1, _, {_, %{file: file}, _}}}]}} ->
-                      to_string(file)
-
-                    _ ->
-                      nil
-                  end
-
-                _ ->
-                  nil
-              end
-            catch
-              _, _ -> nil
-            end
-        end
-    end
+    compile_info = mod.__info__(:compile)
+    source = Keyword.get(compile_info, :source)
+    if source, do: to_string(source)
+  catch
+    _, _ -> nil
   end
 
   defp find_used_modules_and_search_in_source(source, mod, fun) do

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -483,14 +483,14 @@ defmodule ElixirSense.Providers.Definition.Locator do
   defp search_in_using_macro(module, fun) do
     case Location.find_mod_fun_source(module, :__using__, :any) do
       %Location{file: file, line: using_line, column: using_col} when not is_nil(file) ->
-        search_function_in_using_macro(file, using_line, using_col, fun)
+        find_function_def_in_using_macro_source(file, using_line, using_col, fun)
 
       _ ->
         nil
     end
   end
 
-  defp search_function_in_using_macro(file, using_line, using_col, fun) do
+  defp find_function_def_in_using_macro_source(file, using_line, using_col, fun) do
     content = File.read!(file)
     {_, suffix} = Source.split_at(content, using_line, using_col)
     regex = ~r/def\s+(#{Regex.escape(Atom.to_string(fun))}\b)/
@@ -522,6 +522,17 @@ defmodule ElixirSense.Providers.Definition.Locator do
     |> then(fn lines -> {length(lines) - 1, String.length(List.last(lines) || "")} end)
   end
 
+  defp fallback_location(line, column, end_line, end_column, info) do
+    %Location{
+      file: nil,
+      type: if(info, do: ModFunInfo.get_category(info), else: :function),
+      line: line,
+      column: column,
+      end_line: end_line,
+      end_column: end_column
+    }
+  end
+
   defp find_function_in_using_macro(metadata, env, line, column, end_line, end_column, fun, info) do
     # This might be a function defined via `use`
     # We need to find the `use` statement and the module being used
@@ -536,67 +547,14 @@ defmodule ElixirSense.Providers.Definition.Locator do
           nil
       end
 
-    case used_module do
-      nil ->
-        %Location{
-          file: nil,
-          type: if(info, do: ModFunInfo.get_category(info), else: :function),
-          line: line,
-          column: column,
-          end_line: end_line,
-          end_column: end_column
-        }
+    case used_module && Location.find_mod_fun_source(used_module, :__using__, :any) do
+      %Location{file: file, line: using_line, column: using_col} = using_location
+      when not is_nil(file) ->
+        find_function_def_in_using_macro_source(file, using_line, using_col, fun) ||
+          using_location
 
-      used_module ->
-        # Find __using__ macro in the used module
-        case Location.find_mod_fun_source(used_module, :__using__, :any) do
-          %Location{file: file, line: using_line, column: using_col} = using_location
-          when not is_nil(file) ->
-            # Function is defined inside quote block, not as actual module function.
-            # Use regex to find def within __using__ source text.
-            content = File.read!(file)
-            {_, suffix} = Source.split_at(content, using_line, using_col)
-
-            regex = ~r/def\s+(#{Regex.escape(Atom.to_string(fun))}\b)/
-
-            case Regex.run(regex, suffix, return: :index) do
-              [_entire_match, {fun_offset, _fun_len}] ->
-                {line_offset, col_offset} =
-                  suffix
-                  |> String.slice(0, fun_offset)
-                  |> Source.split_lines()
-                  |> then(fn lines ->
-                    {length(lines) - 1, String.length(List.last(lines) || "")}
-                  end)
-
-                target_line = using_line + line_offset
-
-                target_column =
-                  if line_offset == 0, do: using_col + col_offset, else: 1 + col_offset
-
-                %Location{
-                  file: file,
-                  type: :function,
-                  line: target_line,
-                  column: target_column,
-                  end_line: target_line,
-                  end_column: target_column
-                }
-
-              nil ->
-                using_location
-            end
-
-          _ ->
-            %Location{
-              file: nil,
-              type: if(info, do: ModFunInfo.get_category(info), else: :function),
-              line: line,
-              column: column,
-              end_line: end_line,
-              end_column: end_column
-            }
-        end
+      _ ->
+        fallback_location(line, column, end_line, end_column, info)
     end
   end
 end

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -359,13 +359,22 @@ defmodule ElixirSense.Providers.Definition.Locator do
 
   defp find_function_in_module_using_macro(mod, fun, metadata) do
     if Map.has_key?(metadata.mods_funs_to_positions, {mod, nil, nil}) do
-      # Module is in the current source - use metadata.source
-      find_used_modules_and_search_in_source(metadata.source, mod, fun)
+      # Module is in the current source - use metadata.uses
+      used_modules = Map.get(metadata.uses, mod, [])
+
+      Enum.find_value(used_modules, fn used_module ->
+        search_in_using_macro(used_module, fun)
+      end)
     else
-      # Module is external - try to get source file
+      # Module is external - read the file contents and parse it
       with file when not is_nil(file) <- get_module_source_file(mod),
            {:ok, content} <- File.read(file) do
-        find_used_modules_and_search_in_source(content, mod, fun)
+        external_metadata = Parser.parse_string(content, false, false, nil)
+        used_modules = Map.get(external_metadata.uses, mod, [])
+
+        Enum.find_value(used_modules, fn used_module ->
+          search_in_using_macro(used_module, fun)
+        end)
       else
         _ -> nil
       end
@@ -379,74 +388,6 @@ defmodule ElixirSense.Providers.Definition.Locator do
   catch
     _, _ -> nil
   end
-
-  defp find_used_modules_and_search_in_source(source, mod, fun) do
-    with {:ok, ast} <- Code.string_to_quoted(source) do
-      collect_use_statements(ast, mod)
-      |> Enum.find_value(fn used_module ->
-        search_in_using_macro(used_module, fun)
-      end)
-    else
-      _ -> nil
-    end
-  end
-
-  defp collect_use_statements(ast, mod) do
-    target_parts = Module.split(mod)
-
-    {_, {_, modules}} =
-      Macro.traverse(
-        ast,
-        {[], []},
-        fn
-          {:defmodule, _meta, [module_ast | _]} = node, {stack, modules} ->
-            module_parts = module_ast_parts(module_ast)
-
-            full_parts =
-              case stack do
-                [parent_parts | _] when length(module_parts) == 1 ->
-                  parent_parts ++ module_parts
-
-                _ ->
-                  module_parts
-              end
-
-            {node, {[full_parts | stack], modules}}
-
-          {:use, _meta, [module_ast | _]} = node, {[current_parts | _] = stack, modules} ->
-            modules =
-              if current_parts == target_parts do
-                module = resolve_use_module(module_ast, %State.Env{aliases: []})
-                if module, do: [module | modules], else: modules
-              else
-                modules
-              end
-
-            {node, {stack, modules}}
-
-          node, acc ->
-            {node, acc}
-        end,
-        fn
-          {:defmodule, _meta, [_ | _]} = node, {[_ | rest], modules} ->
-            {node, {rest, modules}}
-
-          node, acc ->
-            {node, acc}
-        end
-      )
-
-    Enum.reverse(modules)
-  end
-
-  defp module_ast_parts({:__aliases__, _meta, parts}) do
-    parts
-    |> Module.concat()
-    |> Module.split()
-  end
-
-  defp module_ast_parts(atom) when is_atom(atom), do: Module.split(atom)
-  defp module_ast_parts(_), do: []
 
   defp search_in_using_macro(module, fun) do
     case Location.find_mod_fun_source(module, :__using__, :any) do

--- a/test/elixir_sense/providers/definition/locator_test.exs
+++ b/test/elixir_sense/providers/definition/locator_test.exs
@@ -53,4 +53,46 @@ defmodule ElixirSense.Providers.Definition.LocatorTest do
     assert location.line == 4
     assert location.column == 11
   end
+
+  test "finds definition of function defined in __using__ macro from external file" do
+    code = """
+    defmodule MyModule do
+      use ElixirSenseExample.UsingMacroExample
+
+      def test do
+        using_macro_function()
+      end
+    end
+    """
+
+    {line, column} = {5, 5}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    assert location.file =~ "using_macro_example.ex"
+    assert location.line == 4
+    assert location.column == 11
+  end
+
+  test "finds definition of function defined in __using__ macro via module from external file" do
+    code = """
+    defmodule MyModule do
+      def test do
+        ElixirSenseExample.ModuleUsingMacroExample.using_macro_function()
+      end
+    end
+    """
+
+    {line, column} = {3, 49}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    assert location.file =~ "using_macro_example.ex"
+    assert location.line == 4
+    assert location.column == 11
+  end
 end

--- a/test/elixir_sense/providers/definition/locator_test.exs
+++ b/test/elixir_sense/providers/definition/locator_test.exs
@@ -95,4 +95,158 @@ defmodule ElixirSense.Providers.Definition.LocatorTest do
     assert location.line == 4
     assert location.column == 11
   end
+
+  test "finds definition when using Kernel.use qualified call" do
+    code = """
+    defmodule MyModule do
+      Kernel.use(ElixirSense.Providers.Definition.LocatorTest.MyBehaviour)
+
+      def test do
+        my_function()
+      end
+    end
+    """
+
+    {line, column} = {5, 5}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    assert location.line == 4
+    assert location.column == 11
+  end
+
+  test "finds definition when using module alias" do
+    code = """
+    defmodule MyModule do
+      alias ElixirSense.Providers.Definition.LocatorTest.MyBehaviour
+
+      use MyBehaviour
+
+      def test do
+        my_function()
+      end
+    end
+    """
+
+    {line, column} = {7, 5}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    assert location.line == 4
+    assert location.column == 11
+  end
+
+  test "finds definition when using module with custom alias" do
+    code = """
+    defmodule MyModule do
+      alias ElixirSense.Providers.Definition.LocatorTest.MyBehaviour, as: MyB
+
+      use MyB
+
+      def test do
+        my_function()
+      end
+    end
+    """
+
+    {line, column} = {7, 5}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    assert location.line == 4
+    assert location.column == 11
+  end
+
+  test "no false positive when local function named use exists" do
+    code = """
+    defmodule MyModule do
+      defp use(_module), do: nil
+
+      use ElixirSense.Providers.Definition.LocatorTest.MyBehaviour
+
+      def test do
+        use(SomeModule)
+        my_function()
+      end
+    end
+    """
+
+    {line, column} = {8, 5}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    # should find the function from __using__ macro, not be confused by local use/1
+    assert location.line == 4
+    assert location.column == 11
+  end
+
+  describe "modules in external file" do
+    test "finds definition via external module using Kernel.use qualified call" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingKernelUse.using_macro_function()
+        end
+      end
+      """
+
+      {line, column} = {3, 45}
+
+      location = Locator.definition(code, line, column)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 4
+      assert location.column == 11
+    end
+
+    test "finds definition via external module using aliased module" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingAlias.using_macro_function()
+        end
+      end
+      """
+
+      {line, column} = {3, 42}
+
+      location = Locator.definition(code, line, column)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 4
+      assert location.column == 11
+    end
+
+    test "finds definition via external module that has other local functions" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleWithLocalUse.using_macro_function()
+        end
+      end
+      """
+
+      {line, column} = {3, 44}
+
+      location = Locator.definition(code, line, column)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 4
+      assert location.column == 11
+    end
+  end
 end

--- a/test/elixir_sense/providers/definition/locator_test.exs
+++ b/test/elixir_sense/providers/definition/locator_test.exs
@@ -1,0 +1,56 @@
+defmodule ElixirSense.Providers.Definition.LocatorTest.MyBehaviour do
+  defmacro __using__(_opts) do
+    quote do
+      def my_function(), do: :ok
+    end
+  end
+end
+
+defmodule ElixirSense.Providers.Definition.LocatorTest.ModUsingBehaviour do
+  use ElixirSense.Providers.Definition.LocatorTest.MyBehaviour
+end
+
+defmodule ElixirSense.Providers.Definition.LocatorTest do
+  use ExUnit.Case, async: true
+  alias ElixirSense.Providers.Definition.Locator
+
+  test "finds definition of function defined in __using__ macro" do
+    code = """
+    defmodule MyModule do
+      use ElixirSense.Providers.Definition.LocatorTest.MyBehaviour
+
+      def test do
+        my_function()
+      end
+    end
+    """
+
+    {line, column} = {5, 5}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    assert location.line == 4
+    assert location.column == 11
+  end
+
+  test "finds definition of function defined in __using__ macro via another module" do
+    code = """
+    defmodule MyModule do
+      def test do
+        ElixirSense.Providers.Definition.LocatorTest.ModUsingBehaviour.my_function()
+      end
+    end
+    """
+
+    {line, column} = {3, 70}
+
+    location = Locator.definition(code, line, column)
+
+    assert location != nil
+    assert location.type == :function
+    assert location.line == 4
+    assert location.column == 11
+  end
+end

--- a/test/support/using_macro_example.ex
+++ b/test/support/using_macro_example.ex
@@ -9,3 +9,29 @@ end
 defmodule ElixirSenseExample.ModuleUsingMacroExample do
   use ElixirSenseExample.UsingMacroExample
 end
+
+# Module using Kernel.use qualified call (tests reviewer concern #1)
+defmodule ElixirSenseExample.ModuleUsingKernelUse do
+  Kernel.use(ElixirSenseExample.UsingMacroExample)
+end
+
+# Module using aliased module (tests reviewer concern #2)
+defmodule ElixirSenseExample.ModuleUsingAlias do
+  alias ElixirSenseExample.UsingMacroExample, as: MyMacro
+
+  use MyMacro
+end
+
+# Module with local function named use (tests reviewer concern #3)
+# This tests that a local function named `use` doesn't confuse use tracking
+defmodule ElixirSenseExample.ModuleWithLocalUse do
+  # This local function exists but won't shadow the Kernel.use macro
+  # The test verifies that proper AST expansion correctly identifies Kernel.use
+  defp my_use(_module), do: nil
+
+  use ElixirSenseExample.UsingMacroExample
+
+  def call_local_use do
+    my_use(SomeModule)
+  end
+end

--- a/test/support/using_macro_example.ex
+++ b/test/support/using_macro_example.ex
@@ -1,0 +1,11 @@
+defmodule ElixirSenseExample.UsingMacroExample do
+  defmacro __using__(_opts) do
+    quote do
+      def using_macro_function(), do: :ok
+    end
+  end
+end
+
+defmodule ElixirSenseExample.ModuleUsingMacroExample do
+  use ElixirSenseExample.UsingMacroExample
+end


### PR DESCRIPTION
This adds heuristic to find the function source location, even if it's defined insige the `__using__` macro. It supports the following cases:

1. When current module has `use OtherMod` and the function is defined in `OtherMod`'s `__using__` - it correctly points to a relevant line in `OtherMod`.

2. When `MyMod` has `use OtherMod` (as above) and `YetAnotherMod` calls `MyMod.function_defined_in_using`. This basically covers things like `MyApp.Repo.all`, where `Repo` has `use Ecto.Repo` - now ElixirSense correctly finds the definition of `all` inside `Ecto.Repo`.

This is not a perfect solution, as it uses regular expressions and heuristic for find the definition and it might something be wrong. However, this would enable Expert to have working go-to-definition in quite (in my opinion) important route. See https://github.com/katafrakt/expert/pull/1 where I test these changes in Expert.

---
Note: I tried to make the code relatively readable, sometime cutting out unlikely cases (a153d8992d4eb2c95caa3e6c8f4d18d91f921ace), but there is still this huge `Macro.traverse`, which is kind of intimidating. Maybe I'm missing something obvious here to make it better.