### PR TITLE
[perf] Remove ensure_compiled when building the module store

### DIFF
--- a/lib/elixir_sense/providers/plugins/module_store.ex
+++ b/lib/elixir_sense/providers/plugins/module_store.ex
@@ -69,7 +69,6 @@ defmodule ElixirSense.Providers.Plugins.ModuleStore do
     Applications.get_modules_from_applications()
     |> Enum.filter(fn module ->
       try do
-        _ = Code.ensure_compiled(module)
         function_exported?(module, :module_info, 0)
       rescue
         _ ->


### PR DESCRIPTION
Calling ensure compiled on every module in the system takes a very long time on most projects, and it's not clear why this is necessary unconditionally on startup.

Removing this dramatically improves expert's time from boot to usability (by over 30 seconds in my work project)