### PR TITLE
Find functions defined in `__using__` macros (gated, scoped variant)

### DIFF
--- a/lib/elixir_sense/core/compiler.ex
+++ b/lib/elixir_sense/core/compiler.ex
@@ -1001,6 +1001,27 @@ defmodule ElixirSense.Core.Compiler do
   defp expand_macro(
          meta,
          Kernel,
+         :use,
+         [target_module | _opts] = args,
+         callback,
+         state,
+         env
+       ) do
+    {expanded_module, state, env} = expand(target_module, state, env)
+
+    state =
+      if is_atom(expanded_module) do
+        State.add_use(expanded_module, state, env)
+      else
+        state
+      end
+
+    expand_macro_callback(meta, Kernel, :use, args, callback, state, env)
+  end
+
+  defp expand_macro(
+         meta,
+         Kernel,
          :defdelegate,
          [funs, opts],
          _callback,
@@ -2200,8 +2221,10 @@ defmodule ElixirSense.Core.Compiler do
       # If expanding the macro fails, we just give up.
       _kind, _payload ->
         # Logger.warning(Exception.format(kind, payload, __STACKTRACE__))
+        uses = state.uses
         # look for cursor in args
         {_ast, state, _env} = expand(args, state, env)
+        state = %{state | uses: uses}
 
         {{{:., meta, [module, fun]}, meta, args}, state, env}
     else

--- a/lib/elixir_sense/core/compiler/state.ex
+++ b/lib/elixir_sense/core/compiler/state.ex
@@ -47,6 +47,7 @@ defmodule ElixirSense.Core.Compiler.State do
           attributes: list(list(ElixirSense.Core.State.AttributeInfo.t())),
           scope_attributes: list(list(atom)),
           behaviours: %{optional(module) => [module]},
+          uses: %{optional(module) => [module]},
           specs: specs_t,
           types: types_t,
           mods_funs_to_positions: mods_funs_to_positions_t,
@@ -92,6 +93,7 @@ defmodule ElixirSense.Core.Compiler.State do
   defstruct attributes: [[]],
             scope_attributes: [[]],
             behaviours: %{},
+            uses: %{},
             specs: %{},
             types: %{},
             mods_funs_to_positions: %{},
@@ -1065,6 +1067,12 @@ defmodule ElixirSense.Core.Compiler.State do
   end
 
   def add_behaviour(_module, %__MODULE__{} = state, env), do: {nil, state, env}
+
+  def add_use(module, %__MODULE__{} = state, env) when is_atom(module) and not is_nil(module) do
+    update_in(state.uses[env.module], &Enum.uniq([module | &1 || []]))
+  end
+
+  def add_use(_module, %__MODULE__{} = state, _env), do: state
 
   def register_doc(%__MODULE__{} = state, env, :moduledoc, doc_arg) do
     current_module = env.module

--- a/lib/elixir_sense/core/metadata.ex
+++ b/lib/elixir_sense/core/metadata.ex
@@ -25,6 +25,7 @@ defmodule ElixirSense.Core.Metadata do
           specs: ElixirSense.Core.Compiler.State.specs_t(),
           structs: ElixirSense.Core.Compiler.State.structs_t(),
           records: ElixirSense.Core.Compiler.State.records_t(),
+          uses: %{optional(module) => [module]},
           error: nil | term,
           first_alias_positions: map(),
           moduledoc_positions: map()
@@ -41,6 +42,7 @@ defmodule ElixirSense.Core.Metadata do
             specs: %{},
             structs: %{},
             records: %{},
+            uses: %{},
             error: nil,
             first_alias_positions: %{},
             moduledoc_positions: %{}
@@ -62,6 +64,7 @@ defmodule ElixirSense.Core.Metadata do
       specs: acc.specs,
       structs: acc.structs,
       records: acc.records,
+      uses: acc.uses,
       mods_funs_to_positions: acc.mods_funs_to_positions,
       lines_to_env: acc.lines_to_env,
       vars_info_per_scope_id: acc.vars_info_per_scope_id,

--- a/lib/elixir_sense/core/parser.ex
+++ b/lib/elixir_sense/core/parser.ex
@@ -189,6 +189,7 @@ defmodule ElixirSense.Core.Parser do
       specs: acc.specs,
       structs: acc.structs,
       records: acc.records,
+      uses: acc.uses,
       mods_funs_to_positions: acc.mods_funs_to_positions,
       cursor_env: acc.cursor_env,
       closest_env: acc.closest_env,

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -249,19 +249,27 @@ defmodule ElixirSense.Providers.Definition.Locator do
 
         case fn_definition do
           nil ->
-            Location.find_mod_fun_source(mod, fun, call_arity)
+            location = Location.find_mod_fun_source(mod, fun, call_arity)
+            redirect_into_using_macro(location, mod, fun, metadata) || location
 
           %ModFunInfo{} = info ->
             {{line, column}, {end_line, end_column}} = Location.info_to_range(info)
+            category = ModFunInfo.get_category(info)
 
-            %Location{
+            location = %Location{
               file: nil,
-              type: ModFunInfo.get_category(info),
+              type: category,
               line: line,
               column: column,
               end_line: end_line,
               end_column: end_column
             }
+
+            if category in [:function, :macro] do
+              redirect_into_using_macro(location, mod, fun, metadata) || location
+            else
+              location
+            end
         end
 
       {mod, fun, true, :type} ->
@@ -309,6 +317,123 @@ defmodule ElixirSense.Providers.Definition.Locator do
     case {Phoenix.Router in env.requires, module} do
       {true, {:atom, module}} -> {true, module}
       {false, {:atom, module}} -> module
+      _ -> nil
+    end
+  end
+
+  # When a function's recorded definition sits on a `use SomeModule` line, the
+  # function was injected by `SomeModule.__using__/1`. In that case we try to
+  # locate the real `def`/`defmacro` inside that macro body and point there.
+  #
+  # Two guards keep this from misfiring:
+  #
+  #   * the `use`-site check (`use_site?/3`) — a genuine local or remote `def`
+  #     has its position on its own `def`/`defmacro` line, which is not a `use`
+  #     statement, so we leave it untouched (this is what makes a locally
+  #     overridden function resolve to the local definition, not the injected
+  #     one);
+  #   * the search is bounded to the `__using__/1` body, so an unrelated `def`
+  #     of the same name elsewhere in the used module's file is never matched.
+  #
+  # The set of used modules comes from the tracked `uses` (resolved at macro
+  # expansion time, so aliases and `Kernel.use/1` are handled correctly).
+  defp redirect_into_using_macro(%Location{line: line} = location, mod, fun, metadata) do
+    with true <- use_site?(location, metadata, line),
+         [_ | _] = used_modules <- used_modules(location, mod, metadata) do
+      Enum.find_value(used_modules, fn used_module ->
+        case Location.find_mod_fun_source(used_module, :__using__, :any) do
+          %Location{file: file, line: using_line, end_line: using_end_line}
+          when not is_nil(file) ->
+            find_def_in_using_body(file, using_line, using_end_line, fun)
+
+          _ ->
+            nil
+        end
+      end)
+    else
+      _ -> nil
+    end
+  end
+
+  defp redirect_into_using_macro(_location, _mod, _fun, _metadata), do: nil
+
+  # Does the recorded definition sit on a `use Foo` / `Kernel.use(Foo)` line?
+  defp use_site?(location, metadata, line) do
+    with source when is_binary(source) <- location_source(location, metadata),
+         text when is_binary(text) <- Enum.at(Source.split_lines(source), line - 1),
+         {:ok, ast} <- Code.string_to_quoted(text) do
+      case ast do
+        {:use, _, [_ | _]} -> true
+        {{:., _, [{:__aliases__, _, [:Kernel]}, :use]}, _, [_ | _]} -> true
+        {{:., _, [Kernel, :use]}, _, [_ | _]} -> true
+        _ -> false
+      end
+    else
+      _ -> false
+    end
+  end
+
+  # Modules `mod` uses, resolved at expansion time. For the current buffer they
+  # are in `metadata.uses`; for an external module we parse its source (only
+  # reached once we already know the position is a `use` site, so this is not
+  # on the hot path of ordinary remote lookups).
+  defp used_modules(%Location{file: nil}, mod, metadata) do
+    Map.get(metadata.uses, mod, [])
+  end
+
+  defp used_modules(%Location{file: file}, mod, _metadata) do
+    case File.read(file) do
+      {:ok, content} ->
+        external_metadata = Parser.parse_string(content, false, false, nil)
+        Map.get(external_metadata.uses, mod, [])
+
+      _ ->
+        []
+    end
+  end
+
+  # Source text backing the location: the in-memory buffer for the current
+  # module (file == nil), or the file contents for an external module.
+  defp location_source(%Location{file: nil}, metadata), do: metadata.source
+
+  defp location_source(%Location{file: file}, _metadata) do
+    case File.read(file) do
+      {:ok, content} -> content
+      _ -> nil
+    end
+  end
+
+  # Search only within the `__using__/1` macro body (between its def line and
+  # end line) for the injected definition. Bounding the search to the macro
+  # body avoids matching unrelated defs elsewhere in the same file.
+  defp find_def_in_using_body(file, using_line, using_end_line, fun) do
+    with {:ok, content} <- File.read(file) do
+      name = Atom.to_string(fun)
+      regex = ~r/\bdef(?:macro)?\s+(#{Regex.escape(name)})\b/
+
+      content
+      |> Source.split_lines()
+      |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
+      |> Enum.with_index()
+      |> Enum.find_value(fn {line_text, idx} ->
+        case Regex.run(regex, line_text, return: :index) do
+          [_whole, {name_offset, name_len}] ->
+            target_line = using_line + idx
+
+            %Location{
+              type: :function,
+              file: file,
+              line: target_line,
+              column: name_offset + 1,
+              end_line: target_line,
+              end_column: name_offset + 1 + name_len
+            }
+
+          _ ->
+            nil
+        end
+      end)
+    else
       _ -> nil
     end
   end

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -323,12 +323,13 @@ defmodule ElixirSense.Providers.Definition.Locator do
 
   # When a function's recorded definition sits on a `use SomeModule` line, the
   # function was injected by `SomeModule.__using__/1`. In that case we try to
-  # locate the real `def`/`defmacro` inside that macro body and point there.
+  # locate the real definition (def/defmacro/defdelegate/defguard) inside that
+  # macro body and point there.
   #
   # Two guards keep this from misfiring:
   #
   #   * the `use`-site check (`use_site?/3`) — a genuine local or remote `def`
-  #     has its position on its own `def`/`defmacro` line, which is not a `use`
+  #     has its position on its own definition line, which is not a `use`
   #     statement, so we leave it untouched (this is what makes a locally
   #     overridden function resolve to the local definition, not the injected
   #     one);
@@ -409,7 +410,10 @@ defmodule ElixirSense.Providers.Definition.Locator do
   defp find_def_in_using_body(file, using_line, using_end_line, fun) do
     case File.read(file) do
       {:ok, content} ->
-        regex = ~r/\bdef(?:macro)?\s+(#{Regex.escape(Atom.to_string(fun))})\b/
+        # Matches public definition forms: def, defmacro, defdelegate, defguard.
+        # The mandatory whitespace after the keyword excludes private variants
+        # (defp/defmacrop/defguardp) and defmodule.
+        regex = ~r/\bdef(?:macro|delegate|guard)?\s+(#{Regex.escape(Atom.to_string(fun))})\b/
 
         content
         |> Source.split_lines()

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -407,34 +407,35 @@ defmodule ElixirSense.Providers.Definition.Locator do
   # end line) for the injected definition. Bounding the search to the macro
   # body avoids matching unrelated defs elsewhere in the same file.
   defp find_def_in_using_body(file, using_line, using_end_line, fun) do
-    with {:ok, content} <- File.read(file) do
-      name = Atom.to_string(fun)
-      regex = ~r/\bdef(?:macro)?\s+(#{Regex.escape(name)})\b/
+    case File.read(file) do
+      {:ok, content} ->
+        regex = ~r/\bdef(?:macro)?\s+(#{Regex.escape(Atom.to_string(fun))})\b/
 
-      content
-      |> Source.split_lines()
-      |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
-      |> Enum.with_index()
-      |> Enum.find_value(fn {line_text, idx} ->
-        case Regex.run(regex, line_text, return: :index) do
-          [_whole, {name_offset, name_len}] ->
-            target_line = using_line + idx
+        content
+        |> Source.split_lines()
+        |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
+        |> Enum.with_index()
+        |> Enum.find_value(fn {line_text, idx} ->
+          case Regex.run(regex, line_text, return: :index) do
+            [_whole, {name_offset, name_len}] ->
+              target_line = using_line + idx
 
-            %Location{
-              type: :function,
-              file: file,
-              line: target_line,
-              column: name_offset + 1,
-              end_line: target_line,
-              end_column: name_offset + 1 + name_len
-            }
+              %Location{
+                type: :function,
+                file: file,
+                line: target_line,
+                column: name_offset + 1,
+                end_line: target_line,
+                end_column: name_offset + 1 + name_len
+              }
 
-          _ ->
-            nil
-        end
-      end)
-    else
-      _ -> nil
+            _ ->
+              nil
+          end
+        end)
+
+      _ ->
+        nil
     end
   end
 end

--- a/test/elixir_sense/providers/definition/locator_using_macro_test.exs
+++ b/test/elixir_sense/providers/definition/locator_using_macro_test.exs
@@ -129,6 +129,43 @@ defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest do
       assert location.line == 4
       assert location.column == 11
     end
+
+    test "finds definition injected via defdelegate" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingOtherForms.delegated_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 48)
+
+      assert location != nil
+      assert location.file =~ "using_macro_example.ex"
+      # `defdelegate delegated_function(), ...` inside __using__
+      assert location.line == 52
+      assert location.column == 19
+    end
+
+    test "finds definition injected via defguard" do
+      # A remote guard must be called from a guard context (and the module
+      # required) to resolve as a macro — unrelated to the using-macro search.
+      code = """
+      defmodule MyModule do
+        require ElixirSenseExample.ModuleUsingOtherForms
+        def test(x) when ElixirSenseExample.ModuleUsingOtherForms.is_even(x), do: x
+      end
+      """
+
+      location = Locator.definition(code, 3, 62)
+
+      assert location != nil
+      assert location.file =~ "using_macro_example.ex"
+      # `defguard is_even(value) when ...` inside __using__
+      assert location.line == 56
+      assert location.column == 16
+    end
   end
 
   describe "regression guards (must NOT misfire)" do

--- a/test/elixir_sense/providers/definition/locator_using_macro_test.exs
+++ b/test/elixir_sense/providers/definition/locator_using_macro_test.exs
@@ -1,0 +1,196 @@
+defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest.MyBehaviour do
+  defmacro __using__(_opts) do
+    quote do
+      def my_function(), do: :ok
+    end
+  end
+
+  # Unrelated regular function (outside __using__) sharing a name with a
+  # purely-local function in a consuming module.
+  def my_function_unrelated(), do: :unrelated
+end
+
+defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest.ModUsingBehaviour do
+  use ElixirSense.Providers.Definition.LocatorUsingMacroTest.MyBehaviour
+end
+
+defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest do
+  use ExUnit.Case, async: true
+  alias ElixirSense.Providers.Definition.Locator
+
+  @behaviour_mod ElixirSense.Providers.Definition.LocatorUsingMacroTest.MyBehaviour
+
+  describe "function injected via __using__ (the cases #330 targets)" do
+    test "finds definition of function defined in __using__ macro (current source)" do
+      code = """
+      defmodule MyModule do
+        use #{inspect(@behaviour_mod)}
+
+        def test do
+          my_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 5, 5)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "locator_using_macro_test.exs"
+      assert location.line == 4
+      assert location.column == 11
+    end
+
+    test "finds definition via another in-source module that uses the behaviour" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSense.Providers.Definition.LocatorUsingMacroTest.ModUsingBehaviour.my_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 78)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.line == 4
+      assert location.column == 11
+    end
+
+    test "finds definition of function defined in __using__ macro from external file" do
+      code = """
+      defmodule MyModule do
+        use ElixirSenseExample.UsingMacroExample
+
+        def test do
+          using_macro_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 5, 5)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 4
+      assert location.column == 11
+    end
+
+    test "finds definition via external module that uses the behaviour" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingMacroExample.using_macro_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 50)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 4
+      assert location.column == 11
+    end
+
+    test "resolves aliased use" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingAlias.using_macro_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 42)
+
+      assert location != nil
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 4
+      assert location.column == 11
+    end
+
+    test "resolves Kernel.use qualified call" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingKernelUse.using_macro_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 45)
+
+      assert location != nil
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 4
+      assert location.column == 11
+    end
+  end
+
+  describe "regression guards (must NOT misfire)" do
+    test "purely-local function is not redirected to an unrelated def in the used module's file" do
+      # MyModule uses a module whose file also contains an unrelated
+      # `def my_function_unrelated` (outside __using__). The local definition
+      # must win.
+      code = """
+      defmodule MyModule do
+        use #{inspect(@behaviour_mod)}
+
+        def my_function_unrelated(), do: :my_local
+
+        def test do
+          my_function_unrelated()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 7, 5)
+
+      assert location != nil
+      # local def is on line 4 of the in-memory buffer, file == nil
+      assert location.file == nil
+      assert location.line == 4
+    end
+
+    test "external local function is not redirected when it is a real def, not injected" do
+      # ModuleWithLocalUse defines `using_macro_function_unrelated` itself; the
+      # used module's file also has an unrelated def of the same name. The real
+      # local def in ModuleWithLocalUse must win.
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleWithLocalUse.using_macro_function_unrelated()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 45)
+
+      assert location != nil
+      assert location.file =~ "using_macro_example.ex"
+      # must land on the local def in ModuleWithLocalUse (`:local`), which is the
+      # last def in the file, NOT the unrelated def near the top
+      assert location.line > 30
+    end
+
+    test "ordinary remote function is unaffected" do
+      code = """
+      defmodule MyModule do
+        def test do
+          Enum.map([1], & &1)
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 10)
+
+      assert location != nil
+      assert location.file =~ "enum.ex"
+      assert location.type in [:function, :macro]
+    end
+  end
+end

--- a/test/elixir_sense/providers/definition/locator_using_macro_test.exs
+++ b/test/elixir_sense/providers/definition/locator_using_macro_test.exs
@@ -177,7 +177,26 @@ defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest do
       assert location.line > 30
     end
 
-    test "ordinary remote function is unaffected" do
+    test "ordinary remote function (module without use) is unaffected" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.PlainModuleExample.plain_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 45)
+
+      assert location != nil
+      assert location.file =~ "using_macro_example.ex"
+      assert location.type in [:function, :macro]
+      # resolves to the real def, not redirected anywhere
+      refute is_nil(location.line)
+    end
+
+    @tag requires_source: true
+    test "ordinary stdlib remote function is unaffected" do
       code = """
       defmodule MyModule do
         def test do

--- a/test/support/using_macro_example.ex
+++ b/test/support/using_macro_example.ex
@@ -15,6 +15,12 @@ defmodule ElixirSenseExample.ModuleUsingMacroExample do
   use ElixirSenseExample.UsingMacroExample
 end
 
+# A plain module that does not `use` anything, with an ordinary function.
+# Used to assert go-to-definition of a regular remote function is unaffected.
+defmodule ElixirSenseExample.PlainModuleExample do
+  def plain_function(), do: :ok
+end
+
 # Module using Kernel.use qualified call
 defmodule ElixirSenseExample.ModuleUsingKernelUse do
   Kernel.use(ElixirSenseExample.UsingMacroExample)

--- a/test/support/using_macro_example.ex
+++ b/test/support/using_macro_example.ex
@@ -1,0 +1,37 @@
+defmodule ElixirSenseExample.UsingMacroExample do
+  defmacro __using__(_opts) do
+    quote do
+      def using_macro_function(), do: :ok
+    end
+  end
+
+  # Unrelated regular function sharing a name with a purely-local function in
+  # a consuming module. It lives outside `__using__` and must never be the
+  # target of go-to-definition for that local function.
+  def using_macro_function_unrelated(), do: :unrelated
+end
+
+defmodule ElixirSenseExample.ModuleUsingMacroExample do
+  use ElixirSenseExample.UsingMacroExample
+end
+
+# Module using Kernel.use qualified call
+defmodule ElixirSenseExample.ModuleUsingKernelUse do
+  Kernel.use(ElixirSenseExample.UsingMacroExample)
+end
+
+# Module using aliased module
+defmodule ElixirSenseExample.ModuleUsingAlias do
+  alias ElixirSenseExample.UsingMacroExample, as: MyMacro
+
+  use MyMacro
+end
+
+# Module with a local function that shares a name with the unrelated function
+# in the used module's file. Go-to-definition for the local one must resolve to
+# the local def, not the unrelated def in using_macro_example.ex.
+defmodule ElixirSenseExample.ModuleWithLocalUse do
+  use ElixirSenseExample.UsingMacroExample
+
+  def using_macro_function_unrelated(), do: :local
+end

--- a/test/support/using_macro_example.ex
+++ b/test/support/using_macro_example.ex
@@ -41,3 +41,23 @@ defmodule ElixirSenseExample.ModuleWithLocalUse do
 
   def using_macro_function_unrelated(), do: :local
 end
+
+# Injects definitions via `defdelegate` and `defguard` (not just `def`) so the
+# go-to-definition search must recognise those forms too.
+defmodule ElixirSenseExample.UsingMacroOtherForms do
+  def delegated_target(), do: :ok
+
+  defmacro __using__(_opts) do
+    quote do
+      defdelegate delegated_function(),
+        to: ElixirSenseExample.UsingMacroOtherForms,
+        as: :delegated_target
+
+      defguard is_even(value) when is_integer(value) and rem(value, 2) == 0
+    end
+  end
+end
+
+defmodule ElixirSenseExample.ModuleUsingOtherForms do
+  use ElixirSenseExample.UsingMacroOtherForms
+end


### PR DESCRIPTION
Alternative to #330 (go-to-definition for functions injected via `__using__/1`, e.g. `MyApp.Repo.all` where `Repo` does `use Ecto.Repo`). Builds directly on @katafrakt's work and keeps the parts that are clearly right, while tightening when the source-scanning heuristic is allowed to fire. See the [detailed review on #330](https://github.com/elixir-lsp/elixir_sense/pull/330) for the regressions this addresses.

### Kept from #330
- The `uses` tracking in the compiler/state/metadata/parser (`State.add_use/3` + the `Kernel.use` `expand_macro` clause). Resolving the used module at macro-expansion time is what makes aliased `use` and `Kernel.use(...)` work — a line/regex parse of the `use` statement can't do that reliably.

### What's different
1. **Engage only on a real `use` site.** The redirect now fires only when the recorded definition position is itself a `use` statement. A genuine local/remote `def` has its position on its own `def` line, so a locally defined or overridden function resolves to *its own* definition instead of being pulled into `__using__`. (#330 ran the heuristic before trusting the recorded position, so a purely-local function whose name also appeared anywhere in a used module's file got mis-redirected.)
2. **Bound the search to the `__using__/1` body.** The `def`/`defmacro` scan is limited to the macro's line span (via the `__using__` location's `end_line`), instead of scanning the whole file suffix after `__using__`. An unrelated same-named `def` elsewhere in that file is no longer a false match. Also matches injected `defmacro`, not just `def`.
3. **Keep ordinary remote lookups off the parse path.** The used module's source is only read/parsed once we already know the position is a `use` site. #330 called the using-macro lookup first on *every* external function, doing a full `Parser.parse_string` over the defining module's source even when no `use` was involved (e.g. jumping to `Enum.map/2`).

### Tests
New `locator_using_macro_test.exs` covers the headline cases (current source, external file, via another module, aliased `use`, `Kernel.use(...)`) **plus regression guards**: local override, an unrelated same-named `def` in the used module's file, and an ordinary remote lookup. Full suite is green.

### Caveats (shared with #330)
Still ultimately a source heuristic: arity is not matched (first same-named `def` in the body wins), and `def name` inside strings/comments within the `__using__` body could match. Acceptable for go-to-definition, but worth noting.

cc @katafrakt — this isn't meant to replace your PR unilaterally; it's a concrete alternative for comparison and I'm happy to fold it back into #330 if you prefer. Co-authored you on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
