### PR TITLE
Fix for multi-line `use` calls

### DIFF
--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -338,97 +338,21 @@ defmodule ElixirSense.Providers.Definition.Locator do
   #
   # The set of used modules comes from the tracked `uses` (resolved at macro
   # expansion time, so aliases and `Kernel.use/1` are handled correctly).
-  #
-  # The injected function may live several `use` hops away: `MyApp.Repo` does
-  # `use AshPostgres.Repo`, whose `__using__/1` does `use Ecto.Repo`, whose
-  # `__using__/1` actually defines `aggregate`. We therefore walk the `use`
-  # chain (see `search_using_chain/4`) rather than only the directly-used
-  # modules.
-  #
-  # `@using_chain_max_depth` caps the number of `use` hops to follow: a safety
-  # net for pathologically deep (or, together with the visited set, cyclic)
-  # chains; real chains are only a few levels deep.
-  @using_chain_max_depth 5
-
   defp redirect_into_using_macro(%Location{line: line} = location, mod, fun, metadata) do
     with true <- use_site?(location, metadata, line),
          [_ | _] = used_modules <- used_modules(location, mod, metadata) do
-      search_using_chain(used_modules, fun, MapSet.new(), @using_chain_max_depth)
+      Enum.find_value(used_modules, fn mod ->
+        with %Location{file: file, line: l, end_line: el} when not is_nil(file) <-
+               Location.find_mod_fun_source(mod, :__using__, :any) do
+          search_using_body(file, l, el, fun)
+        end
+      end)
     else
       _ -> nil
     end
   end
 
   defp redirect_into_using_macro(_location, _mod, _fun, _metadata), do: nil
-
-  # Walk the `use` chain looking for the injected definition. For each module we
-  # search its `__using__/1` body for the `def`; on a miss we recurse into the
-  # modules that body itself `use`s. The visited set prevents cycles and the
-  # depth cap bounds the search.
-  defp search_using_chain(_modules, _fun, _visited, depth) when depth <= 0, do: nil
-
-  defp search_using_chain(modules, fun, visited, depth) do
-    Enum.find_value(modules, &search_one_module(&1, fun, visited, depth))
-  end
-
-  defp search_one_module(mod, _fun, visited, _depth) when is_map_key(visited, mod), do: nil
-
-  defp search_one_module(mod, fun, visited, depth) do
-    with %Location{file: file, line: l, end_line: el} when not is_nil(file) <-
-           Location.find_mod_fun_source(mod, :__using__, :any) do
-      search_using_body(file, l, el, fun) ||
-        search_using_chain(
-          nested_used_modules(file, l, el),
-          fun,
-          MapSet.put(visited, mod),
-          depth - 1
-        )
-    end
-  end
-
-  # Read the `__using__/1` body once and scan it for both the target definition
-  # and nested `use` modules. `search_using_body` looks for the def;
-  # `nested_used_modules` extracts `use`d modules for the next chain hop.
-  # Both share `body_lines/3` to avoid duplicate `File.read` + slice work.
-
-  defp body_lines(file, using_line, using_end_line) do
-    case File.read(file) do
-      {:ok, content} ->
-        content
-        |> Source.split_lines()
-        |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
-
-      _ ->
-        []
-    end
-  end
-
-  # Modules `use`d *within* a `__using__/1` body. These nested uses live inside
-  # the macro's quote block, so they are not part of the using module's own
-  # `metadata.uses`; we scan the body text directly.
-  defp nested_used_modules(file, using_line, using_end_line) do
-    file
-    |> body_lines(using_line, using_end_line)
-    |> Enum.flat_map(&extract_used_modules/1)
-    |> Enum.uniq()
-  end
-
-  # Extracts module names from `use` statements on a single line. Uses
-  # `Regex.scan/3` to capture all matches (e.g. `use Foo; use Bar`).
-  # Skips comment lines to avoid false positives like `# use Phoenix.Router`.
-  @nested_use_extractor ~r/\buse\s+([A-Z][A-Za-z0-9_.]*)/
-
-  defp extract_used_modules(line_text) do
-    if comment_line?(line_text) do
-      []
-    else
-      @nested_use_extractor
-      |> Regex.scan(line_text, capture: :all_but_first)
-      |> Enum.map(fn [name] -> Module.concat(String.split(name, ".")) end)
-    end
-  end
-
-  defp comment_line?(line_text), do: String.match?(String.trim_leading(line_text), ~r/^#/)
 
   # Matches the start of a `use Foo` / `use Foo, opts` / `Kernel.use(Foo)` /
   # `Kernel.use Foo` statement. The trailing `[\s(]` ensures we match the `use`
@@ -478,6 +402,20 @@ defmodule ElixirSense.Providers.Definition.Locator do
       _ -> nil
     end
   end
+
+  defp body_lines(file, using_line, using_end_line) do
+    case File.read(file) do
+      {:ok, content} ->
+        content
+        |> Source.split_lines()
+        |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
+
+      _ ->
+        []
+    end
+  end
+
+  defp comment_line?(line_text), do: String.match?(String.trim_leading(line_text), ~r/^#/)
 
   # Search only within the `__using__/1` macro body (between its def line and
   # end line) for the injected definition. Bounding the search to the macro

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -321,24 +321,34 @@ defmodule ElixirSense.Providers.Definition.Locator do
     end
   end
 
-  # When a function was injected by a `__using__/1` macro, try to locate the
-  # real definition (def/defmacro/defdelegate/defguard) inside that macro body.
+  # When a function's recorded definition sits on a `use SomeModule` line, the
+  # function was injected by `SomeModule.__using__/1`. In that case we try to
+  # locate the real definition (def/defmacro/defdelegate/defguard) inside that
+  # macro body and point there.
   #
-  # The search is bounded to `__using__/1` bodies, so an unrelated `def` of
-  # the same name elsewhere in the used module's file is never matched — and a
-  # locally overridden function won't be found inside `__using__` either, so
-  # the fallback `|| location` in the caller preserves the local definition.
+  # Two guards keep this from misfiring:
   #
-  # `use_site?/3` is a cheap regex gate that rejects the vast majority of
-  # ordinary definitions (whose recorded line is a `def`, not a `use`),
-  # keeping the expensive source parse in `used_modules/3` off the hot path.
-  defp redirect_into_using_macro(location, mod, fun, metadata) do
-    with true <- use_site?(location, metadata),
+  #   * the `use`-site check (`use_site?/3`) — a genuine local or remote `def`
+  #     has its position on its own definition line, which is not a `use`
+  #     statement, so we leave it untouched (this is what makes a locally
+  #     overridden function resolve to the local definition, not the injected
+  #     one);
+  #   * the search is bounded to the `__using__/1` body, so an unrelated `def`
+  #     of the same name elsewhere in the used module's file is never matched.
+  #
+  # The set of used modules comes from the tracked `uses` (resolved at macro
+  # expansion time, so aliases and `Kernel.use/1` are handled correctly).
+  defp redirect_into_using_macro(%Location{line: line} = location, mod, fun, metadata) do
+    with true <- use_site?(location, metadata, line),
          [_ | _] = used_modules <- used_modules(location, mod, metadata) do
-      Enum.find_value(used_modules, fn mod ->
-        with %Location{file: file, line: l, end_line: el} when not is_nil(file) <-
-               Location.find_mod_fun_source(mod, :__using__, :any) do
-          search_using_body(file, l, el, fun)
+      Enum.find_value(used_modules, fn used_module ->
+        case Location.find_mod_fun_source(used_module, :__using__, :any) do
+          %Location{file: file, line: using_line, end_line: using_end_line}
+          when not is_nil(file) ->
+            find_def_in_using_body(file, using_line, using_end_line, fun)
+
+          _ ->
+            nil
         end
       end)
     else
@@ -346,23 +356,16 @@ defmodule ElixirSense.Providers.Definition.Locator do
     end
   end
 
-  # Does the function's recorded definition line look like a `use` statement?
+  defp redirect_into_using_macro(_location, _mod, _fun, _metadata), do: nil
+
+  # Does the recorded definition sit on a `use Foo` / `Kernel.use(Foo)` line?
+  # We match with a regex rather than `Code.string_to_quoted` because a `use`
+  # may span multiple lines (`use Foo,\n  opt: 1`), making the first line
+  # unparseable on its own.
   @use_line_detector ~r/^\s*(?:Kernel\s*\.\s*)?use[\s(]/
-
-  defp use_site?(%Location{line: line} = location, metadata) do
-    source =
-      case location.file do
-        nil ->
-          metadata.source
-
-        file ->
-          case File.read(file) do
-            {:ok, content} -> content
-            _ -> nil
-          end
-      end
-
-    with text when is_binary(text) <- source && Enum.at(Source.split_lines(source), line - 1) do
+  defp use_site?(location, metadata, line) do
+    with source when is_binary(source) <- location_source(location, metadata),
+         text when is_binary(text) <- Enum.at(Source.split_lines(source), line - 1) do
       Regex.match?(@use_line_detector, text)
     else
       _ -> false
@@ -370,8 +373,9 @@ defmodule ElixirSense.Providers.Definition.Locator do
   end
 
   # Modules `mod` uses, resolved at expansion time. For the current buffer they
-  # are in `metadata.uses` (cheap map lookup); for an external module we must
-  # parse its source (expensive — guarded by `use_site?` in the caller).
+  # are in `metadata.uses`; for an external module we parse its source (only
+  # reached once we already know the position is a `use` site, so this is not
+  # on the hot path of ordinary remote lookups).
   defp used_modules(%Location{file: nil}, mod, metadata) do
     Map.get(metadata.uses, mod, [])
   end
@@ -387,54 +391,53 @@ defmodule ElixirSense.Providers.Definition.Locator do
     end
   end
 
-  defp body_lines(file, using_line, using_end_line) do
-    case File.read(file) do
-      {:ok, content} ->
-        content
-        |> Source.split_lines()
-        |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
+  # Source text backing the location: the in-memory buffer for the current
+  # module (file == nil), or the file contents for an external module.
+  defp location_source(%Location{file: nil}, metadata), do: metadata.source
 
-      _ ->
-        []
+  defp location_source(%Location{file: file}, _metadata) do
+    case File.read(file) do
+      {:ok, content} -> content
+      _ -> nil
     end
   end
-
-  defp comment_line?(line_text), do: String.match?(String.trim_leading(line_text), ~r/^#/)
 
   # Search only within the `__using__/1` macro body (between its def line and
   # end line) for the injected definition. Bounding the search to the macro
   # body avoids matching unrelated defs elsewhere in the same file.
-  defp search_using_body(file, using_line, using_end_line, fun) do
-    # Matches public definition forms: def, defmacro, defdelegate, defguard.
-    # The mandatory whitespace after the keyword excludes private variants
-    # (defp/defmacrop/defguardp) and defmodule.
-    regex = ~r/\bdef(?:macro|delegate|guard)?\s+(#{Regex.escape(Atom.to_string(fun))})\b/
+  defp find_def_in_using_body(file, using_line, using_end_line, fun) do
+    case File.read(file) do
+      {:ok, content} ->
+        # Matches public definition forms: def, defmacro, defdelegate, defguard.
+        # The mandatory whitespace after the keyword excludes private variants
+        # (defp/defmacrop/defguardp) and defmodule.
+        regex = ~r/\bdef(?:macro|delegate|guard)?\s+(#{Regex.escape(Atom.to_string(fun))})\b/
 
-    lines = body_lines(file, using_line, using_end_line)
+        content
+        |> Source.split_lines()
+        |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
+        |> Enum.with_index()
+        |> Enum.find_value(fn {line_text, idx} ->
+          case Regex.run(regex, line_text, return: :index) do
+            [_whole, {name_offset, name_len}] ->
+              target_line = using_line + idx
 
-    lines
-    |> Enum.with_index()
-    |> Enum.find_value(fn {line_text, idx} ->
-      if comment_line?(line_text) do
+              %Location{
+                type: :function,
+                file: file,
+                line: target_line,
+                column: name_offset + 1,
+                end_line: target_line,
+                end_column: name_offset + 1 + name_len
+              }
+
+            _ ->
+              nil
+          end
+        end)
+
+      _ ->
         nil
-      else
-        case Regex.run(regex, line_text, return: :index) do
-          [_whole, {name_offset, name_len}] ->
-            target_line = using_line + idx
-
-            %Location{
-              type: :function,
-              file: file,
-              line: target_line,
-              column: name_offset + 1,
-              end_line: target_line,
-              end_column: name_offset + 1 + name_len
-            }
-
-          _ ->
-            nil
-        end
-      end
-    end)
+    end
   end
 end

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -367,7 +367,7 @@ defmodule ElixirSense.Providers.Definition.Locator do
   defp use_site?(location, metadata, line) do
     with source when is_binary(source) <- location_source(location, metadata),
          text when is_binary(text) <- Enum.at(Source.split_lines(source), line - 1) do
-      Regex.match?(@use_line_detector, text)
+      not comment_line?(text) and Regex.match?(@use_line_detector, text)
     else
       _ -> false
     end

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -338,9 +338,8 @@ defmodule ElixirSense.Providers.Definition.Locator do
   #
   # The set of used modules comes from the tracked `uses` (resolved at macro
   # expansion time, so aliases and `Kernel.use/1` are handled correctly).
-  defp redirect_into_using_macro(%Location{line: line} = location, mod, fun, metadata) do
-    with true <- use_site?(location, metadata, line),
-         [_ | _] = used_modules <- used_modules(location, mod, metadata) do
+  defp redirect_into_using_macro(location, mod, fun, metadata) do
+    with [_ | _] = used_modules <- used_modules(location, mod, metadata) do
       Enum.find_value(used_modules, fn mod ->
         with %Location{file: file, line: l, end_line: el} when not is_nil(file) <-
                Location.find_mod_fun_source(mod, :__using__, :any) do
@@ -352,31 +351,8 @@ defmodule ElixirSense.Providers.Definition.Locator do
     end
   end
 
-  defp redirect_into_using_macro(_location, _mod, _fun, _metadata), do: nil
-
-  # Matches the start of a `use Foo` / `use Foo, opts` / `Kernel.use(Foo)` /
-  # `Kernel.use Foo` statement. The trailing `[\s(]` ensures we match the `use`
-  # keyword and not an identifier like `use_foo`.
-  @use_line_detector ~r/^\s*(?:Kernel\s*\.\s*)?use[\s(]/
-
-  # Does the recorded definition sit on a `use Foo` / `Kernel.use(Foo)` line?
-  #
-  # We match the line textually rather than parsing it: a `use` may span
-  # several lines (`use Foo,\n  opt: 1`), in which case the recorded line on its
-  # own (`use Foo,`) is not valid Elixir and would fail to parse.
-  defp use_site?(location, metadata, line) do
-    with source when is_binary(source) <- location_source(location, metadata),
-         text when is_binary(text) <- Enum.at(Source.split_lines(source), line - 1) do
-      not comment_line?(text) and Regex.match?(@use_line_detector, text)
-    else
-      _ -> false
-    end
-  end
-
   # Modules `mod` uses, resolved at expansion time. For the current buffer they
-  # are in `metadata.uses`; for an external module we parse its source (only
-  # reached once we already know the position is a `use` site, so this is not
-  # on the hot path of ordinary remote lookups).
+  # are in `metadata.uses`; for an external module we parse its source.
   defp used_modules(%Location{file: nil}, mod, metadata) do
     Map.get(metadata.uses, mod, [])
   end
@@ -389,17 +365,6 @@ defmodule ElixirSense.Providers.Definition.Locator do
 
       _ ->
         []
-    end
-  end
-
-  # Source text backing the location: the in-memory buffer for the current
-  # module (file == nil), or the file contents for an external module.
-  defp location_source(%Location{file: nil}, metadata), do: metadata.source
-
-  defp location_source(%Location{file: file}, _metadata) do
-    case File.read(file) do
-      {:ok, content} -> content
-      _ -> nil
     end
   end
 

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -321,25 +321,20 @@ defmodule ElixirSense.Providers.Definition.Locator do
     end
   end
 
-  # When a function's recorded definition sits on a `use SomeModule` line, the
-  # function was injected by `SomeModule.__using__/1`. In that case we try to
-  # locate the real definition (def/defmacro/defdelegate/defguard) inside that
-  # macro body and point there.
+  # When a function was injected by a `__using__/1` macro, try to locate the
+  # real definition (def/defmacro/defdelegate/defguard) inside that macro body.
   #
-  # Two guards keep this from misfiring:
+  # The search is bounded to `__using__/1` bodies, so an unrelated `def` of
+  # the same name elsewhere in the used module's file is never matched — and a
+  # locally overridden function won't be found inside `__using__` either, so
+  # the fallback `|| location` in the caller preserves the local definition.
   #
-  #   * the `use`-site check (`use_site?/3`) — a genuine local or remote `def`
-  #     has its position on its own definition line, which is not a `use`
-  #     statement, so we leave it untouched (this is what makes a locally
-  #     overridden function resolve to the local definition, not the injected
-  #     one);
-  #   * the search is bounded to the `__using__/1` body, so an unrelated `def`
-  #     of the same name elsewhere in the used module's file is never matched.
-  #
-  # The set of used modules comes from the tracked `uses` (resolved at macro
-  # expansion time, so aliases and `Kernel.use/1` are handled correctly).
+  # `use_site?/3` is a cheap regex gate that rejects the vast majority of
+  # ordinary definitions (whose recorded line is a `def`, not a `use`),
+  # keeping the expensive source parse in `used_modules/3` off the hot path.
   defp redirect_into_using_macro(location, mod, fun, metadata) do
-    with [_ | _] = used_modules <- used_modules(location, mod, metadata) do
+    with true <- use_site?(location, metadata),
+         [_ | _] = used_modules <- used_modules(location, mod, metadata) do
       Enum.find_value(used_modules, fn mod ->
         with %Location{file: file, line: l, end_line: el} when not is_nil(file) <-
                Location.find_mod_fun_source(mod, :__using__, :any) do
@@ -351,8 +346,32 @@ defmodule ElixirSense.Providers.Definition.Locator do
     end
   end
 
+  # Does the function's recorded definition line look like a `use` statement?
+  @use_line_detector ~r/^\s*(?:Kernel\s*\.\s*)?use[\s(]/
+
+  defp use_site?(%Location{line: line} = location, metadata) do
+    source =
+      case location.file do
+        nil ->
+          metadata.source
+
+        file ->
+          case File.read(file) do
+            {:ok, content} -> content
+            _ -> nil
+          end
+      end
+
+    with text when is_binary(text) <- source && Enum.at(Source.split_lines(source), line - 1) do
+      Regex.match?(@use_line_detector, text)
+    else
+      _ -> false
+    end
+  end
+
   # Modules `mod` uses, resolved at expansion time. For the current buffer they
-  # are in `metadata.uses`; for an external module we parse its source.
+  # are in `metadata.uses` (cheap map lookup); for an external module we must
+  # parse its source (expensive — guarded by `use_site?` in the caller).
   defp used_modules(%Location{file: nil}, mod, metadata) do
     Map.get(metadata.uses, mod, [])
   end

--- a/lib/elixir_sense/providers/definition/locator.ex
+++ b/lib/elixir_sense/providers/definition/locator.ex
@@ -338,19 +338,22 @@ defmodule ElixirSense.Providers.Definition.Locator do
   #
   # The set of used modules comes from the tracked `uses` (resolved at macro
   # expansion time, so aliases and `Kernel.use/1` are handled correctly).
+  #
+  # The injected function may live several `use` hops away: `MyApp.Repo` does
+  # `use AshPostgres.Repo`, whose `__using__/1` does `use Ecto.Repo`, whose
+  # `__using__/1` actually defines `aggregate`. We therefore walk the `use`
+  # chain (see `search_using_chain/4`) rather than only the directly-used
+  # modules.
+  #
+  # `@using_chain_max_depth` caps the number of `use` hops to follow: a safety
+  # net for pathologically deep (or, together with the visited set, cyclic)
+  # chains; real chains are only a few levels deep.
+  @using_chain_max_depth 5
+
   defp redirect_into_using_macro(%Location{line: line} = location, mod, fun, metadata) do
     with true <- use_site?(location, metadata, line),
          [_ | _] = used_modules <- used_modules(location, mod, metadata) do
-      Enum.find_value(used_modules, fn used_module ->
-        case Location.find_mod_fun_source(used_module, :__using__, :any) do
-          %Location{file: file, line: using_line, end_line: using_end_line}
-          when not is_nil(file) ->
-            find_def_in_using_body(file, using_line, using_end_line, fun)
-
-          _ ->
-            nil
-        end
-      end)
+      search_using_chain(used_modules, fun, MapSet.new(), @using_chain_max_depth)
     else
       _ -> nil
     end
@@ -358,17 +361,89 @@ defmodule ElixirSense.Providers.Definition.Locator do
 
   defp redirect_into_using_macro(_location, _mod, _fun, _metadata), do: nil
 
+  # Walk the `use` chain looking for the injected definition. For each module we
+  # search its `__using__/1` body for the `def`; on a miss we recurse into the
+  # modules that body itself `use`s. The visited set prevents cycles and the
+  # depth cap bounds the search.
+  defp search_using_chain(_modules, _fun, _visited, depth) when depth <= 0, do: nil
+
+  defp search_using_chain(modules, fun, visited, depth) do
+    Enum.find_value(modules, &search_one_module(&1, fun, visited, depth))
+  end
+
+  defp search_one_module(mod, _fun, visited, _depth) when is_map_key(visited, mod), do: nil
+
+  defp search_one_module(mod, fun, visited, depth) do
+    with %Location{file: file, line: l, end_line: el} when not is_nil(file) <-
+           Location.find_mod_fun_source(mod, :__using__, :any) do
+      search_using_body(file, l, el, fun) ||
+        search_using_chain(
+          nested_used_modules(file, l, el),
+          fun,
+          MapSet.put(visited, mod),
+          depth - 1
+        )
+    end
+  end
+
+  # Read the `__using__/1` body once and scan it for both the target definition
+  # and nested `use` modules. `search_using_body` looks for the def;
+  # `nested_used_modules` extracts `use`d modules for the next chain hop.
+  # Both share `body_lines/3` to avoid duplicate `File.read` + slice work.
+
+  defp body_lines(file, using_line, using_end_line) do
+    case File.read(file) do
+      {:ok, content} ->
+        content
+        |> Source.split_lines()
+        |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
+
+      _ ->
+        []
+    end
+  end
+
+  # Modules `use`d *within* a `__using__/1` body. These nested uses live inside
+  # the macro's quote block, so they are not part of the using module's own
+  # `metadata.uses`; we scan the body text directly.
+  defp nested_used_modules(file, using_line, using_end_line) do
+    file
+    |> body_lines(using_line, using_end_line)
+    |> Enum.flat_map(&extract_used_modules/1)
+    |> Enum.uniq()
+  end
+
+  # Extracts module names from `use` statements on a single line. Uses
+  # `Regex.scan/3` to capture all matches (e.g. `use Foo; use Bar`).
+  # Skips comment lines to avoid false positives like `# use Phoenix.Router`.
+  @nested_use_extractor ~r/\buse\s+([A-Z][A-Za-z0-9_.]*)/
+
+  defp extract_used_modules(line_text) do
+    if comment_line?(line_text) do
+      []
+    else
+      @nested_use_extractor
+      |> Regex.scan(line_text, capture: :all_but_first)
+      |> Enum.map(fn [name] -> Module.concat(String.split(name, ".")) end)
+    end
+  end
+
+  defp comment_line?(line_text), do: String.match?(String.trim_leading(line_text), ~r/^#/)
+
+  # Matches the start of a `use Foo` / `use Foo, opts` / `Kernel.use(Foo)` /
+  # `Kernel.use Foo` statement. The trailing `[\s(]` ensures we match the `use`
+  # keyword and not an identifier like `use_foo`.
+  @use_line_detector ~r/^\s*(?:Kernel\s*\.\s*)?use[\s(]/
+
   # Does the recorded definition sit on a `use Foo` / `Kernel.use(Foo)` line?
+  #
+  # We match the line textually rather than parsing it: a `use` may span
+  # several lines (`use Foo,\n  opt: 1`), in which case the recorded line on its
+  # own (`use Foo,`) is not valid Elixir and would fail to parse.
   defp use_site?(location, metadata, line) do
     with source when is_binary(source) <- location_source(location, metadata),
-         text when is_binary(text) <- Enum.at(Source.split_lines(source), line - 1),
-         {:ok, ast} <- Code.string_to_quoted(text) do
-      case ast do
-        {:use, _, [_ | _]} -> true
-        {{:., _, [{:__aliases__, _, [:Kernel]}, :use]}, _, [_ | _]} -> true
-        {{:., _, [Kernel, :use]}, _, [_ | _]} -> true
-        _ -> false
-      end
+         text when is_binary(text) <- Enum.at(Source.split_lines(source), line - 1) do
+      Regex.match?(@use_line_detector, text)
     else
       _ -> false
     end
@@ -407,39 +482,37 @@ defmodule ElixirSense.Providers.Definition.Locator do
   # Search only within the `__using__/1` macro body (between its def line and
   # end line) for the injected definition. Bounding the search to the macro
   # body avoids matching unrelated defs elsewhere in the same file.
-  defp find_def_in_using_body(file, using_line, using_end_line, fun) do
-    case File.read(file) do
-      {:ok, content} ->
-        # Matches public definition forms: def, defmacro, defdelegate, defguard.
-        # The mandatory whitespace after the keyword excludes private variants
-        # (defp/defmacrop/defguardp) and defmodule.
-        regex = ~r/\bdef(?:macro|delegate|guard)?\s+(#{Regex.escape(Atom.to_string(fun))})\b/
+  defp search_using_body(file, using_line, using_end_line, fun) do
+    # Matches public definition forms: def, defmacro, defdelegate, defguard.
+    # The mandatory whitespace after the keyword excludes private variants
+    # (defp/defmacrop/defguardp) and defmodule.
+    regex = ~r/\bdef(?:macro|delegate|guard)?\s+(#{Regex.escape(Atom.to_string(fun))})\b/
 
-        content
-        |> Source.split_lines()
-        |> Enum.slice((using_line - 1)..(using_end_line - 1)//1)
-        |> Enum.with_index()
-        |> Enum.find_value(fn {line_text, idx} ->
-          case Regex.run(regex, line_text, return: :index) do
-            [_whole, {name_offset, name_len}] ->
-              target_line = using_line + idx
+    lines = body_lines(file, using_line, using_end_line)
 
-              %Location{
-                type: :function,
-                file: file,
-                line: target_line,
-                column: name_offset + 1,
-                end_line: target_line,
-                end_column: name_offset + 1 + name_len
-              }
-
-            _ ->
-              nil
-          end
-        end)
-
-      _ ->
+    lines
+    |> Enum.with_index()
+    |> Enum.find_value(fn {line_text, idx} ->
+      if comment_line?(line_text) do
         nil
-    end
+      else
+        case Regex.run(regex, line_text, return: :index) do
+          [_whole, {name_offset, name_len}] ->
+            target_line = using_line + idx
+
+            %Location{
+              type: :function,
+              file: file,
+              line: target_line,
+              column: name_offset + 1,
+              end_line: target_line,
+              end_column: name_offset + 1 + name_len
+            }
+
+          _ ->
+            nil
+        end
+      end
+    end)
   end
 end

--- a/test/elixir_sense/providers/definition/locator_using_macro_test.exs
+++ b/test/elixir_sense/providers/definition/locator_using_macro_test.exs
@@ -148,6 +148,67 @@ defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest do
       assert location.column == 19
     end
 
+    test "finds definition injected through a transitive use chain (current source)" do
+      code = """
+      defmodule MyModule do
+        use ElixirSenseExample.UsingMacroOuter
+
+        def test do
+          nested_using_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 5, 5)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      # `def nested_using_function` lives in UsingMacroInner.__using__, two hops
+      # away (MyModule -> UsingMacroOuter -> UsingMacroInner)
+      assert location.line == 72
+      assert location.column == 11
+    end
+
+    test "finds definition through a transitive use chain via external module" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingNested.nested_using_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 48)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 72
+      assert location.column == 11
+    end
+
+    test "finds definition when the use spans multiple lines (use Foo, opts)" do
+      code = """
+      defmodule MyModule do
+        use ElixirSenseExample.UsingMacroWithOpts,
+          some: :opt
+
+        def test do
+          opted_using_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 6, 5)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 95
+      assert location.column == 11
+    end
+
     test "finds definition injected via defguard" do
       # A remote guard must be called from a guard context (and the module
       # required) to resolve as a macro — unrelated to the using-macro search.

--- a/test/elixir_sense/providers/definition/locator_using_macro_test.exs
+++ b/test/elixir_sense/providers/definition/locator_using_macro_test.exs
@@ -188,7 +188,7 @@ defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest do
       assert location.column == 11
     end
 
-    test "finds definition when the use spans multiple lines (use Foo, opts)" do
+    test "finds definition when the use spans multiple lines (current source)" do
       code = """
       defmodule MyModule do
         use ElixirSenseExample.UsingMacroWithOpts,
@@ -201,6 +201,24 @@ defmodule ElixirSense.Providers.Definition.LocatorUsingMacroTest do
       """
 
       location = Locator.definition(code, 6, 5)
+
+      assert location != nil
+      assert location.type == :function
+      assert location.file =~ "using_macro_example.ex"
+      assert location.line == 95
+      assert location.column == 11
+    end
+
+    test "finds definition when the use spans multiple lines (external module)" do
+      code = """
+      defmodule MyModule do
+        def test do
+          ElixirSenseExample.ModuleUsingWithOpts.opted_using_function()
+        end
+      end
+      """
+
+      location = Locator.definition(code, 3, 45)
 
       assert location != nil
       assert location.type == :function

--- a/test/support/using_macro_example.ex
+++ b/test/support/using_macro_example.ex
@@ -61,3 +61,43 @@ end
 defmodule ElixirSenseExample.ModuleUsingOtherForms do
   use ElixirSenseExample.UsingMacroOtherForms
 end
+
+# Transitive `use` chain: the injected function is defined several `use` hops
+# away. `UsingMacroOuter.__using__` itself does `use UsingMacroInner`, which is
+# where `nested_using_function` actually lives (mirrors MyApp.Repo ->
+# AshPostgres.Repo -> Ecto.Repo). Go-to-definition must follow the chain.
+defmodule ElixirSenseExample.UsingMacroInner do
+  defmacro __using__(_opts) do
+    quote do
+      def nested_using_function(), do: :nested
+    end
+  end
+end
+
+defmodule ElixirSenseExample.UsingMacroOuter do
+  defmacro __using__(_opts) do
+    quote do
+      use ElixirSenseExample.UsingMacroInner
+    end
+  end
+end
+
+defmodule ElixirSenseExample.ModuleUsingNested do
+  use ElixirSenseExample.UsingMacroOuter
+end
+
+# Multi-line `use` with options. The recorded definition line is the `use`
+# keyword line (`use ...,`), which is not valid Elixir on its own, so the
+# use-site detection must not rely on parsing that line in isolation.
+defmodule ElixirSenseExample.UsingMacroWithOpts do
+  defmacro __using__(_opts) do
+    quote do
+      def opted_using_function(), do: :ok
+    end
+  end
+end
+
+defmodule ElixirSenseExample.ModuleUsingWithOpts do
+  use ElixirSenseExample.UsingMacroWithOpts,
+    some: :opt
+end


### PR DESCRIPTION
When I tried to plug #333 into Expert, I found it not working for some Ecto definitions. At first I thought this is due to transitive use of `use` (like `use AshPostgres.Repo` which calls `use Ecto.Repo` inside its `__using__`), but ultimately I found this is because of multi-line `use`s, like [AshPostgres does](https://github.com/ash-project/ash_postgres/blob/main/lib/repo.ex#L137-L139):

```elixir
        use Ecto.Repo,
          adapter: opts[:adapter] || Ecto.Adapters.Postgres,
          otp_app: otp_app
```

When we were calling `use_site?/3` on the first line, it tried to do `Code.string_to_quoted` on a line ending with a comma, returning `{:error, _}` and not finding it as a use site. This PR replaces the check with a regex-based. I was trying to find some false positives it can generate, but I don't think there are some. The obvious one is about comments, but I don't think a line with a comment can be a param to `use_site?` currently.

The commit history is a mess here of all my previous attempt, so it needs squashing.