### PR TITLE
completion: restore bitstring modifier suggestions

### DIFF
--- a/lib/elixir_sense/core/source.ex
+++ b/lib/elixir_sense/core/source.ex
@@ -735,7 +735,7 @@ defmodule ElixirSense.Core.Source do
   def concat_module_parts([], _, _), do: :error
 
   def bitstring_options(prefix) do
-    case Code.Fragment.container_cursor_to_quoted(prefix, columns: true) do
+    case bitstring_quoted(prefix) do
       {:ok, quoted} ->
         path = Macro.path(quoted, &match?({:__cursor__, _, []}, &1))
 
@@ -761,6 +761,17 @@ defmodule ElixirSense.Core.Source do
 
       {:error, _} ->
         nil
+    end
+  end
+
+  # A modifier prefix can be an Elixir reserved word (for example, `in`). In
+  # that case Code.Fragment fails before it has a chance to insert its cursor.
+  # Retrying with an identifier suffix makes the fragment parseable without
+  # changing the original text returned to the completion engine.
+  defp bitstring_quoted(prefix) do
+    case Code.Fragment.container_cursor_to_quoted(prefix, columns: true) do
+      {:error, _} -> Code.Fragment.container_cursor_to_quoted(prefix <> "_", columns: true)
+      result -> result
     end
   end
 

--- a/lib/elixir_sense/providers/completion/completion_engine.ex
+++ b/lib/elixir_sense/providers/completion/completion_engine.ex
@@ -998,7 +998,7 @@ defmodule ElixirSense.Providers.Completion.CompletionEngine do
   end
 
   defp container_context(code, env, metadata, cursor_position) do
-    case Code.Fragment.container_cursor_to_quoted(code) do
+    case container_cursor_to_quoted(code) do
       {:ok, quoted} ->
         case Macro.path(quoted, &match?({:__cursor__, _, []}, &1)) do
           [cursor, {:%{}, _, pairs}, {:%, _, [struct_module_ast, _map]} | _] ->
@@ -1053,6 +1053,17 @@ defmodule ElixirSense.Providers.Completion.CompletionEngine do
 
       {:error, _} ->
         nil
+    end
+  end
+
+  # A modifier prefix can be an Elixir reserved word (for example, `in`). In
+  # that case Code.Fragment fails before it has a chance to insert its cursor.
+  # Retrying with an identifier suffix makes the fragment parseable without
+  # affecting the original completion hint.
+  defp container_cursor_to_quoted(code) do
+    case Code.Fragment.container_cursor_to_quoted(code) do
+      {:error, _} -> Code.Fragment.container_cursor_to_quoted(code ++ ~c"_")
+      result -> result
     end
   end
 

--- a/test/elixir_sense/core/source_test.exs
+++ b/test/elixir_sense/core/source_test.exs
@@ -1229,6 +1229,10 @@ defmodule ElixirSense.Core.SourceTest do
       assert "int" == bitstring_options(text)
     end
 
+    test "single line reserved word prefix" do
+      assert "in" == bitstring_options("<<ident::in")
+    end
+
     test "single line multiple" do
       text = "<<ident::integer, some::"
       assert "" == bitstring_options(text)

--- a/test/elixir_sense/providers/completion/suggestions_test.exs
+++ b/test/elixir_sense/providers/completion/suggestions_test.exs
@@ -4710,6 +4710,10 @@ defmodule ElixirSense.Providers.Completion.SuggestionTest do
   end
 
   test "bitstring options" do
+    assert [%{name: "integer", type: :bitstring_option}] =
+             ElixirSense.suggestions("<<x::in", 1, 8)
+             |> Enum.filter(&(&1.type == :bitstring_option))
+
     buffer = """
     defmodule ElixirSenseExample.OtherModule do
       alias ElixirSenseExample.SameModule


### PR DESCRIPTION
## Summary

Restores bitstring modifier completion when the typed modifier prefix is the reserved word `in`.

`Code.Fragment.container_cursor_to_quoted/2` rejected the incomplete `<<x::in` fragment before placing its cursor, so bitstring context was not detected. The completion and source AST paths now retry failed fragments with a harmless identifier suffix while preserving the original hint.

## Validation

- `mix test test/elixir_sense/core/source_test.exs:1232 test/elixir_sense/providers/completion/suggestions_test.exs:4712`
- `mix format --check-formatted` for changed files

Fixes #342.